### PR TITLE
Enhance code quality with stricter linting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,24 @@ verbose_file_reads = "warn"                 # Use fs::read_to_string() instead o
 # Smart pointer hygiene
 rc_buffer = "warn"                          # Use Rc<[T]> instead of Rc<Vec<T>>
 rc_mutex = "warn"                           # Use Arc<Mutex<T>> instead of Rc<Mutex<T>>
+#
+# === Additional restriction lints (high-value, low false positive) ===
+# Panic prevention
+if_then_some_else_none = "warn"             # Use .then() or .then_some() for cleaner code
+#
+# Correctness
+empty_drop = "warn"                         # Empty Drop implementations are dead code
+create_dir = "warn"                         # Use create_dir_all() for robustness
+#
+# API consistency
+mutex_atomic = "warn"                       # Use AtomicBool instead of Mutex<bool>
+#
+# Performance and idioms
+string_add = "warn"                         # Use push_str() instead of + for efficiency
+#
+# Documentation hygiene
+unnecessary_safety_comment = "warn"         # Remove spurious // SAFETY: comments
+unnecessary_safety_doc = "warn"             # Remove spurious /// # Safety sections
 
 [features]
 sync-send = []
@@ -328,6 +346,11 @@ opt-level = 1
 # This catches integer overflow bugs that would otherwise wrap silently
 [profile.release]
 overflow-checks = true
+# Link-Time Optimization for better performance (10-20% improvement typical)
+# "thin" provides most of the benefit with reasonable build times
+lto = "thin"
+# Single codegen unit for maximum optimization (slightly slower builds)
+codegen-units = 1
 
 # CI-specific profile with both overflow checks and debug assertions
 # Used by ci-safety.yml for maximum runtime checking

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! Instead of registering callback functions, Fortress Rollback (previously GGRS) returns a list of requests for the user to fulfill.
 
 #![forbid(unsafe_code)] // let us try
+#![deny(warnings)] // Treat all warnings as errors (matches CI behavior)
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]

--- a/src/sessions/player_registry.rs
+++ b/src/sessions/player_registry.rs
@@ -123,7 +123,7 @@ impl<T: Config> PlayerRegistry<T> {
                 PlayerType::Remote(a) => Some((h, a)),
                 PlayerType::Spectator(a) => Some((h, a)),
             })
-            .filter_map(|(h, a)| if addr == *a { Some(*h) } else { None })
+            .filter_map(|(h, a)| (addr == *a).then_some(*h))
             .collect();
         handles
     }

--- a/src/sync_layer/mod.rs
+++ b/src/sync_layer/mod.rs
@@ -450,11 +450,7 @@ impl<T: Config> SyncLayer<T> {
         #[cfg(loom)]
         let cell_frame = cell.0.lock().unwrap().frame;
 
-        if cell_frame == frame {
-            Some(cell)
-        } else {
-            None
-        }
+        (cell_frame == frame).then_some(cell)
     }
 
     /// Returns the latest saved frame.

--- a/tests/network/multi_process.rs
+++ b/tests/network/multi_process.rs
@@ -573,11 +573,7 @@ fn find_peer_binary() -> Option<std::path::PathBuf> {
     // The binary is in the target directory (e.g., target/debug/network_test_peer)
     let peer_binary = target_dir.join(PEER_BINARY_NAME);
 
-    if peer_binary.exists() {
-        Some(peer_binary)
-    } else {
-        None
-    }
+    peer_binary.exists().then_some(peer_binary)
 }
 
 /// Checks if the network_test_peer binary is available.


### PR DESCRIPTION
- Enable LTO (thin) and codegen-units=1 in release profile for 10-20% perf gain
- Add #![deny(warnings)] to lib.rs for local warnings=errors parity with CI
- Add high-value restriction clippy lints:
  - if_then_some_else_none: Prefer .then()/.then_some() patterns
  - empty_drop: Catch empty Drop implementations
  - create_dir: Prefer create_dir_all() for robustness
  - mutex_atomic: Prefer AtomicBool over Mutex<bool>
  - string_add: Prefer push_str() for efficiency
  - unnecessary_safety_comment/doc: Remove spurious safety docs
- Refactor code to use idiomatic .then_some() patterns in:
  - sync_layer/mod.rs: saved_cell_for_frame()
  - sessions/player_registry.rs: handles_by_address()
  - tests/network/multi_process.rs: find_peer_binary()