### PR TITLE
chore(deps): group Dependabot updates into larger weekly batches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,67 +8,88 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     assignees:
       - "wallstop"
     reviewers:
       - "wallstop"
     commit-message:
       prefix: "chore(deps)"
-    open-pull-requests-limit: 10
+    # Favor larger, area-grouped PRs over many single-package PRs.
+    groups:
+      cargo-workspace:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 2
 
   # Rust dependencies for fuzz directory (separate workspace)
   - package-ecosystem: "cargo"
     directory: "/fuzz"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     assignees:
       - "wallstop"
     reviewers:
       - "wallstop"
     commit-message:
       prefix: "chore(deps)"
-    open-pull-requests-limit: 5
+    groups:
+      cargo-fuzz:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
 
   # Rust dependencies for loom-tests directory (separate workspace,
   # requires special --cfg loom flags that conflict with normal builds)
   - package-ecosystem: "cargo"
     directory: "/loom-tests"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     assignees:
       - "wallstop"
     reviewers:
       - "wallstop"
     commit-message:
       prefix: "chore(deps)"
-    open-pull-requests-limit: 5
+    groups:
+      cargo-loom-tests:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
 
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     assignees:
       - "wallstop"
     reviewers:
       - "wallstop"
     commit-message:
       prefix: "chore(ci)"
-    open-pull-requests-limit: 5
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
 
   # Docker dependencies
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     assignees:
       - "wallstop"
     reviewers:
       - "wallstop"
     commit-message:
       prefix: "chore(docker)"
-    open-pull-requests-limit: 3
+    groups:
+      docker-all:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
     ignore:
       # Rust base image is intentionally pinned to MSRV (Minimum Supported Rust Version)
       # defined in Cargo.toml. The Dockerfile uses MSRV to ensure network tests validate


### PR DESCRIPTION
### Motivation
- Reduce Dependabot noise by preferring fewer, larger PRs that group many version updates by area instead of many single-package PRs. 
- Align update cadence and grouping with a batched strategy (weekly, area groups) to let PRs accumulate more updates before opening.

### Description
- Switched all Dependabot schedules from `daily` to `weekly` for the configured ecosystems. 
- Added `groups` blocks (wildcard `"*"` patterns) to each update block to batch updates by area (root cargo workspace, `/fuzz`, `/loom-tests`, `github-actions`, and `/docker`).
- Reduced `open-pull-requests-limit` values to focus Dependabot on a small number of larger PRs (root cargo → 2, others → 1). 
- Preserved existing assignees/reviewers, commit-message prefixes, and the Docker `rust` ignore rule.

### Testing
- Successfully parsed the updated YAML with Ruby using `YAML.load_file` and confirmed the `updates` entries. 
- Ran a Python-based structural check that validated presence of `groups`, wildcard patterns, reduced PR limits, and weekly schedules, and it passed. 
- Attempted to parse with Python `PyYAML` but that run failed due to `PyYAML` not being installed in the environment. 
- Verified the file diff with `git diff` and committed the change (`chore(deps): group dependabot updates into larger weekly PRs`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6d5ff00883319e08b228bc0e2b88)