### PR TITLE
ci: harden workflow permissions to job scope + add fork guard to dependabot auto-merge

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -23,21 +23,23 @@ on:
       - '.github/workflows/ci-benchmarks.yml'
   workflow_dispatch:  # Allow manual runs
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
-
-permissions:
-  # Required for github-pages deployment
-  contents: write
-  # Required for posting benchmark comments on commits
-  deployments: write
-  # Required for posting PR comments (benchmark alerts)
-  pull-requests: write
 
 jobs:
   benchmark:
     name: Run Benchmarks
     runs-on: ubuntu-latest
+    permissions:
+      # Required for github-pages deployment
+      contents: write
+      # Required for posting benchmark comments on commits
+      deployments: write
+      # Required for posting PR comments (benchmark alerts)
+      pull-requests: write
     # Skip for Dependabot PRs - it doesn't have write permissions for PR comments
     if: github.actor != 'dependabot[bot]'
     # Use a consistent runner for reproducible results
@@ -183,6 +185,8 @@ jobs:
   benchmark-quick:
     name: Quick Benchmark Smoke Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Quick benchmarks run even if full benchmark fails
     # Skip for Dependabot PRs - benchmark results aren't useful for dependency updates
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/ci-changelog.yml
+++ b/.github/workflows/ci-changelog.yml
@@ -10,13 +10,15 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   changelog-check:
     name: Changelog Reminder
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
 
     # Skip for dependabot PRs
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,13 +5,16 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   dependabot:
     name: Enable auto-merge for Dependabot PRs
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.draft
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    name: Enable auto-merge for Dependabot PRs
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -26,7 +26,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -36,6 +35,9 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -8,8 +8,6 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -63,6 +61,9 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
 
     environment:
       name: github-pages

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -62,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     permissions:
+      contents: read
       pages: write
       id-token: write
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,12 +6,14 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   label-areas:
     name: Label PR by area
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Apply area labels
         uses: actions/labeler@v6
@@ -22,6 +24,9 @@ jobs:
   label-size:
     name: Label PR by size
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Apply size label
         continue-on-error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,6 +19,8 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/sync-issue-template.yml
+++ b/.github/workflows/sync-issue-template.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: sync-issue-template
@@ -17,6 +17,8 @@ jobs:
   sync-versions:
     name: Sync Release Versions Into Issue Template
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 # Prevent concurrent wiki syncs to avoid git conflicts
 concurrency:
@@ -50,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-wiki
     if: needs.check-wiki.outputs.wiki_exists == 'true'
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Write permissions were declared at the workflow level across multiple workflows, granting every job wider access than needed. `dependabot-auto-merge.yml` additionally lacked a fork-origin guard on its `pull_request_target` trigger, allowing the write-permissioned job to run for PRs from forks.

### `dependabot-auto-merge.yml`
- Downgrade workflow-level to `contents: read` / `pull-requests: read`
- Move `contents: write` / `pull-requests: write` to the `dependabot` job
- Add fork guard: `github.event.pull_request.head.repo.full_name == github.repository`

```yaml
permissions:
  contents: read
  pull-requests: read

jobs:
  dependabot:
    if: >-
      github.event.pull_request.user.login == 'dependabot[bot]' &&
      !github.event.pull_request.draft &&
      github.event.pull_request.head.repo.full_name == github.repository
    permissions:
      contents: write
      pull-requests: write
```

### Sweep of all other workflows
Same over-permissioned pattern found and fixed in 8 additional workflows — write permissions moved from workflow scope to the specific jobs that require them:

- `ci-benchmarks` — `contents/deployments/pull-requests: write` → `benchmark` job only; explicit `contents: read` added to `benchmark-quick`
- `ci-changelog` — `pull-requests: write` → `changelog-check` job only
- `devcontainer-build` — `packages: write` → `build-and-push` job only
- `docs-deploy` — `pages: write` / `id-token: write` → `deploy` job only
- `labeler` — `pull-requests: write` → both label jobs
- `publish` — `contents: write` → `publish` job only
- `sync-issue-template` — `contents: write` → `sync-versions` job only
- `wiki-sync` — `contents: write` → `sync-wiki` job only

`actionlint` is already enforced in `ci-lint.yml` and will catch permission misconfigurations in future workflow changes.