### PR TITLE
Attempt to fix CI (Windows Failures)

### DIFF
--- a/.github/actions/install-cargo-tool/action.yml
+++ b/.github/actions/install-cargo-tool/action.yml
@@ -68,8 +68,18 @@ runs:
           exit 1
         fi
 
-        CARGO_HOME_RESOLVED="$(resolve_cargo_home)"
-        TOOL_GLOB="$(cargo_tool_cache_glob "$TOOL_NAME" "$CARGO_HOME_RESOLVED")"
+        if ! CARGO_HOME_RESOLVED="$(resolve_cargo_home)"; then
+          echo "❌ ERROR: failed to resolve cargo home"
+          exit 1
+        fi
+        if ! cargo_home_is_safe "$CARGO_HOME_RESOLVED"; then
+          echo "❌ ERROR: resolved cargo home must be an absolute, non-root path (got '$CARGO_HOME_RESOLVED')"
+          exit 1
+        fi
+        if ! TOOL_GLOB="$(cargo_tool_cache_glob "$TOOL_NAME" "$CARGO_HOME_RESOLVED")"; then
+          echo "❌ ERROR: failed to build cargo tool cache glob for '$TOOL_NAME'"
+          exit 1
+        fi
         BIN_DIR="${CARGO_HOME_RESOLVED%/}/bin"
 
         echo "cargo_home=$CARGO_HOME_RESOLVED" >> "$GITHUB_OUTPUT"
@@ -151,7 +161,7 @@ runs:
             echo "installed=false" >> "$GITHUB_OUTPUT"
             echo "⚠️ Cached $TOOL_NAME version does not match requested version $REQUIRED_VERSION"
             printf '%s\n' "$VERSION_OUTPUT"
-            if [ -z "$CARGO_HOME_RESOLVED" ] || [ "$CARGO_HOME_RESOLVED" = "/" ]; then
+            if ! cargo_home_is_safe "$CARGO_HOME_RESOLVED"; then
               echo "❌ ERROR: refusing to clean cache with unsafe cargo home path '$CARGO_HOME_RESOLVED'"
               exit 1
             fi

--- a/.github/actions/install-cargo-tool/action.yml
+++ b/.github/actions/install-cargo-tool/action.yml
@@ -8,61 +8,140 @@
 # It uses taiki-e/install-action with retry logic and falls back to
 # cargo install if the binary download consistently fails.
 
-name: 'Install Cargo Tool'
-description: 'Installs a cargo tool with retry logic and fallback to cargo install'
+name: "Install Cargo Tool"
+description: "Installs a cargo tool with retry logic and fallback to cargo install"
 
 inputs:
   tool:
-    description: 'Tool name (e.g., cargo-nextest, cargo-tarpaulin, cargo-hack)'
+    description: "Tool name (e.g., cargo-nextest, cargo-tarpaulin, cargo-hack)"
     required: true
   version:
-    description: 'Tool version (optional, defaults to latest stable)'
+    description: "Tool version (optional, defaults to latest stable)"
     required: false
-    default: ''
+    default: ""
   max-retries:
-    description: 'Maximum number of retry attempts for taiki-e/install-action'
+    description: "Maximum number of retry attempts for taiki-e/install-action"
     required: false
-    default: '3'
+    default: "3"
   retry-delay:
-    description: 'Delay in seconds between retry attempts'
+    description: "Delay in seconds between retry attempts"
     required: false
-    default: '10'
+    default: "10"
   fallback-to-cargo-install:
-    description: 'Whether to fall back to cargo install if binary download fails'
+    description: "Whether to fall back to cargo install if binary download fails"
     required: false
-    default: 'true'
+    default: "true"
 
 outputs:
   install-method:
-    description: 'How the tool was installed (binary, cargo-install, or cache)'
+    description: "How the tool was installed (binary, cargo-install, or cache)"
     value: ${{ steps.final-status.outputs.method }}
 
 runs:
   using: composite
   steps:
+    - name: Resolve cargo cache path
+      id: resolve-cache-path
+      shell: bash
+      run: |
+        set -euo pipefail
+        TOOL_NAME="${{ inputs.tool }}"
+        MAX_RETRIES="${{ inputs.max-retries }}"
+        RETRY_DELAY="${{ inputs.retry-delay }}"
+        if [[ ! "$TOOL_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+          echo "❌ ERROR: invalid tool name '$TOOL_NAME' (allowed: A-Z, a-z, 0-9, ., _, -)"
+          exit 1
+        fi
+        if [[ ! "$MAX_RETRIES" =~ ^[1-3]$ ]]; then
+          echo "❌ ERROR: max-retries must be an integer between 1 and 3 (got '$MAX_RETRIES')"
+          exit 1
+        fi
+        if [[ ! "$RETRY_DELAY" =~ ^[0-9]+$ ]]; then
+          echo "❌ ERROR: retry-delay must be a non-negative integer (got '$RETRY_DELAY')"
+          exit 1
+        fi
+        VERSION_HELPER_PATH="${GITHUB_ACTION_PATH//\\//}/version-check.sh"
+
+        # shellcheck source=.github/actions/install-cargo-tool/version-check.sh
+        if ! source "$VERSION_HELPER_PATH"; then
+          echo "❌ ERROR: failed to source helper script at $VERSION_HELPER_PATH"
+          exit 1
+        fi
+
+        CARGO_HOME_RESOLVED="$(resolve_cargo_home)"
+        TOOL_GLOB="$(cargo_tool_cache_glob "$TOOL_NAME" "$CARGO_HOME_RESOLVED")"
+        BIN_DIR="${CARGO_HOME_RESOLVED%/}/bin"
+
+        echo "cargo_home=$CARGO_HOME_RESOLVED" >> "$GITHUB_OUTPUT"
+        echo "bin_dir=$BIN_DIR" >> "$GITHUB_OUTPUT"
+        echo "tool_glob=$TOOL_GLOB" >> "$GITHUB_OUTPUT"
+
     # Check cache first - significantly faster than downloading
     - name: Cache cargo binaries
       id: cargo-bin-cache
       uses: actions/cache@v5
+      continue-on-error: true
       with:
-        path: |
-          ~/.cargo/bin/${{ inputs.tool }}*
+        path: ${{ steps.resolve-cache-path.outputs.tool_glob }}
         key: cargo-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.tool }}-${{ inputs.version || 'latest' }}-v1
         restore-keys: |
           cargo-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.tool }}-
+
+    - name: Report cache diagnostics
+      shell: bash
+      run: |
+        set -euo pipefail
+        TOOL_NAME="${{ inputs.tool }}"
+        CARGO_CMD="${TOOL_NAME#cargo-}"
+        CACHE_HIT_VALUE="${{ steps.cargo-bin-cache.outputs.cache-hit }}"
+
+        echo "=== install-cargo-tool diagnostics ==="
+        echo "runner.os=${{ runner.os }}"
+        echo "runner.arch=${{ runner.arch }}"
+        echo "GITHUB_ACTION_PATH(raw)=${GITHUB_ACTION_PATH:-<unset>}"
+        echo "CARGO_HOME(raw)=${CARGO_HOME:-<unset>}"
+        echo "resolved cargo_home=${{ steps.resolve-cache-path.outputs.cargo_home }}"
+        echo "resolved bin_dir=${{ steps.resolve-cache-path.outputs.bin_dir }}"
+        echo "resolved tool_glob=${{ steps.resolve-cache-path.outputs.tool_glob }}"
+        echo "cache outcome=${{ steps.cargo-bin-cache.outcome }}"
+        if [ -n "$CACHE_HIT_VALUE" ]; then
+          echo "cache-hit output=$CACHE_HIT_VALUE"
+        else
+          echo "cache-hit output=<empty>"
+        fi
+
+        if command -v "$TOOL_NAME" &> /dev/null; then
+          echo "tool detected on PATH at: $(command -v "$TOOL_NAME")"
+        elif cargo "$CARGO_CMD" --version &> /dev/null 2>&1; then
+          echo "tool detected as cargo subcommand: cargo $CARGO_CMD"
+        else
+          echo "tool is not yet installed; continuing with install attempts"
+        fi
+
+        VERSION_HELPER_PATH="${GITHUB_ACTION_PATH//\\//}/version-check.sh"
+        if [ ! -f "$VERSION_HELPER_PATH" ]; then
+          echo "❌ ERROR: helper script missing at $VERSION_HELPER_PATH"
+          exit 1
+        fi
 
     - name: Check if tool is already installed
       id: check-installed
       shell: bash
       run: |
+        set -euo pipefail
         TOOL_NAME="${{ inputs.tool }}"
         REQUIRED_VERSION="${{ inputs.version }}"
         # Convert cargo-foo to cargo foo for version check
         CARGO_CMD="${TOOL_NAME#cargo-}"
+        VERSION_HELPER_PATH="${GITHUB_ACTION_PATH//\\//}/version-check.sh"
+        CARGO_HOME_RESOLVED="${{ steps.resolve-cache-path.outputs.cargo_home }}"
         # shellcheck source=.github/actions/install-cargo-tool/version-check.sh
-        source "$GITHUB_ACTION_PATH/version-check.sh"
+        if ! source "$VERSION_HELPER_PATH"; then
+          echo "❌ ERROR: failed to source helper script at $VERSION_HELPER_PATH"
+          exit 1
+        fi
 
-        if command -v "$TOOL_NAME" &> /dev/null || cargo "$CARGO_CMD" --version &> /dev/null 2>&1; then
+        if command -v "$TOOL_NAME" &> /dev/null || cargo "$CARGO_CMD" --version &> /dev/null; then
           VERSION_OUTPUT="$(cargo "$CARGO_CMD" --version 2>/dev/null || "$TOOL_NAME" --version 2>/dev/null || true)"
           if installed_version_matches "$TOOL_NAME" "$VERSION_OUTPUT" "$REQUIRED_VERSION"; then
             echo "installed=true" >> "$GITHUB_OUTPUT"
@@ -72,7 +151,11 @@ runs:
             echo "installed=false" >> "$GITHUB_OUTPUT"
             echo "⚠️ Cached $TOOL_NAME version does not match requested version $REQUIRED_VERSION"
             printf '%s\n' "$VERSION_OUTPUT"
-            rm -f "$HOME/.cargo/bin/$TOOL_NAME" "$HOME/.cargo/bin/$TOOL_NAME.exe"
+            if [ -z "$CARGO_HOME_RESOLVED" ] || [ "$CARGO_HOME_RESOLVED" = "/" ]; then
+              echo "❌ ERROR: refusing to clean cache with unsafe cargo home path '$CARGO_HOME_RESOLVED'"
+              exit 1
+            fi
+            rm -f "$CARGO_HOME_RESOLVED/bin/$TOOL_NAME" "$CARGO_HOME_RESOLVED/bin/$TOOL_NAME.exe"
             echo "📦 $TOOL_NAME needs to be installed"
           fi
         else
@@ -91,7 +174,7 @@ runs:
 
     # Brief delay before retry
     - name: Delay before retry 1
-      if: steps.check-installed.outputs.installed != 'true' && steps.install-attempt-1.outcome == 'failure'
+      if: steps.check-installed.outputs.installed != 'true' && fromJSON(inputs.max-retries) >= 2 && steps.install-attempt-1.outcome == 'failure'
       shell: bash
       run: |
         echo "⏳ First attempt failed, waiting ${{ inputs.retry-delay }}s before retry..."
@@ -100,7 +183,7 @@ runs:
     # Attempt 2
     - name: Install ${{ inputs.tool }} (attempt 2)
       id: install-attempt-2
-      if: steps.check-installed.outputs.installed != 'true' && steps.install-attempt-1.outcome == 'failure'
+      if: steps.check-installed.outputs.installed != 'true' && fromJSON(inputs.max-retries) >= 2 && steps.install-attempt-1.outcome == 'failure'
       uses: taiki-e/install-action@v2
       with:
         tool: ${{ inputs.tool }}${{ inputs.version && format('@{0}', inputs.version) || '' }}
@@ -108,7 +191,7 @@ runs:
 
     # Brief delay before retry
     - name: Delay before retry 2
-      if: steps.check-installed.outputs.installed != 'true' && steps.install-attempt-1.outcome == 'failure' && steps.install-attempt-2.outcome == 'failure'
+      if: steps.check-installed.outputs.installed != 'true' && fromJSON(inputs.max-retries) >= 3 && steps.install-attempt-1.outcome == 'failure' && steps.install-attempt-2.outcome == 'failure'
       shell: bash
       run: |
         echo "⏳ Second attempt failed, waiting ${{ inputs.retry-delay }}s before retry..."
@@ -117,24 +200,45 @@ runs:
     # Attempt 3
     - name: Install ${{ inputs.tool }} (attempt 3)
       id: install-attempt-3
-      if: steps.check-installed.outputs.installed != 'true' && steps.install-attempt-1.outcome == 'failure' && steps.install-attempt-2.outcome == 'failure'
+      if: steps.check-installed.outputs.installed != 'true' && fromJSON(inputs.max-retries) >= 3 && steps.install-attempt-1.outcome == 'failure' && steps.install-attempt-2.outcome == 'failure'
       uses: taiki-e/install-action@v2
       with:
         tool: ${{ inputs.tool }}${{ inputs.version && format('@{0}', inputs.version) || '' }}
       continue-on-error: true
+
+    - name: Determine retry exhaustion
+      id: retry-exhausted
+      if: steps.check-installed.outputs.installed != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        MAX_RETRIES="${{ inputs.max-retries }}"
+        ATTEMPT_1="${{ steps.install-attempt-1.outcome }}"
+        ATTEMPT_2="${{ steps.install-attempt-2.outcome }}"
+        ATTEMPT_3="${{ steps.install-attempt-3.outcome }}"
+
+        ALL_FAILED=false
+        if [ "$MAX_RETRIES" = "1" ] && [ "$ATTEMPT_1" = "failure" ]; then
+          ALL_FAILED=true
+        elif [ "$MAX_RETRIES" = "2" ] && [ "$ATTEMPT_2" = "failure" ]; then
+          ALL_FAILED=true
+        elif [ "$MAX_RETRIES" = "3" ] && [ "$ATTEMPT_3" = "failure" ]; then
+          ALL_FAILED=true
+        fi
+
+        echo "all_failed=$ALL_FAILED" >> "$GITHUB_OUTPUT"
 
     # Fallback: cargo install (slower but more reliable)
     - name: Fallback to cargo install
       id: cargo-install-fallback
       if: |
         steps.check-installed.outputs.installed != 'true' &&
-        steps.install-attempt-1.outcome == 'failure' &&
-        steps.install-attempt-2.outcome == 'failure' &&
-        steps.install-attempt-3.outcome == 'failure' &&
+        steps.retry-exhausted.outputs.all_failed == 'true' &&
         inputs.fallback-to-cargo-install == 'true'
       shell: bash
       run: |
-        echo "⚠️ Binary download failed after 3 attempts, falling back to cargo install..."
+        set -euo pipefail
+        echo "⚠️ Binary download failed after ${{ inputs.max-retries }} attempt(s), falling back to cargo install..."
         TOOL="${{ inputs.tool }}"
         VERSION="${{ inputs.version }}"
 
@@ -151,14 +255,19 @@ runs:
       id: final-status
       shell: bash
       run: |
+        set -euo pipefail
         TOOL_NAME="${{ inputs.tool }}"
         REQUIRED_VERSION="${{ inputs.version }}"
         CARGO_CMD="${TOOL_NAME#cargo-}"
+        VERSION_HELPER_PATH="${GITHUB_ACTION_PATH//\\//}/version-check.sh"
         # shellcheck source=.github/actions/install-cargo-tool/version-check.sh
-        source "$GITHUB_ACTION_PATH/version-check.sh"
+        if ! source "$VERSION_HELPER_PATH"; then
+          echo "❌ ERROR: failed to source helper script at $VERSION_HELPER_PATH"
+          exit 1
+        fi
 
         # Check if tool is now available
-        if command -v "$TOOL_NAME" &> /dev/null || cargo "$CARGO_CMD" --version &> /dev/null 2>&1; then
+        if command -v "$TOOL_NAME" &> /dev/null || cargo "$CARGO_CMD" --version &> /dev/null; then
           # Determine how it was installed
           if [ "${{ steps.check-installed.outputs.installed }}" == "true" ]; then
             echo "method=cache" >> "$GITHUB_OUTPUT"

--- a/.github/actions/install-cargo-tool/version-check.sh
+++ b/.github/actions/install-cargo-tool/version-check.sh
@@ -16,6 +16,31 @@ resolve_cargo_home() {
   return 1
 }
 
+cargo_home_is_safe() {
+  local cargo_home="${1:-}"
+  cargo_home="${cargo_home//\\//}"
+
+  if [ -z "$cargo_home" ]; then
+    return 1
+  fi
+
+  case "$cargo_home" in
+    /*|[A-Za-z]:/*)
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  case "$cargo_home" in
+    "/"|[A-Za-z]:/)
+      return 1
+      ;;
+  esac
+
+  return 0
+}
+
 cargo_tool_cache_glob() {
   local tool_name="$1"
   local cargo_home_value="${2:-}"
@@ -26,7 +51,9 @@ cargo_tool_cache_glob() {
   fi
 
   if [ -z "$cargo_home_value" ]; then
-    cargo_home_value="$(resolve_cargo_home)"
+    if ! cargo_home_value="$(resolve_cargo_home)"; then
+      return 1
+    fi
   fi
 
   cargo_home_value="${cargo_home_value//\\//}"

--- a/.github/actions/install-cargo-tool/version-check.sh
+++ b/.github/actions/install-cargo-tool/version-check.sh
@@ -1,6 +1,39 @@
 #!/usr/bin/env bash
 # Shared version checks for the install-cargo-tool composite action.
 
+resolve_cargo_home() {
+  if [ -n "${CARGO_HOME:-}" ]; then
+    printf '%s\n' "${CARGO_HOME//\\//}"
+    return 0
+  fi
+
+  if [ -n "${HOME:-}" ]; then
+    printf '%s\n' "${HOME//\\//}/.cargo"
+    return 0
+  fi
+
+  echo "ERROR: neither CARGO_HOME nor HOME is set" >&2
+  return 1
+}
+
+cargo_tool_cache_glob() {
+  local tool_name="$1"
+  local cargo_home_value="${2:-}"
+
+  if [ -z "$tool_name" ]; then
+    echo "ERROR: tool name is required" >&2
+    return 1
+  fi
+
+  if [ -z "$cargo_home_value" ]; then
+    cargo_home_value="$(resolve_cargo_home)"
+  fi
+
+  cargo_home_value="${cargo_home_value//\\//}"
+  cargo_home_value="${cargo_home_value%/}"
+  printf '%s/bin/%s*\n' "$cargo_home_value" "$tool_name"
+}
+
 primary_version_output_matches_required() {
   local output="$1"
   local tool_name="$2"
@@ -8,6 +41,9 @@ primary_version_output_matches_required() {
   [ -z "$required" ] && return 0
 
   awk -v tool="$tool_name" -v required="$required" '
+    BEGIN {
+      saw_nonempty = 0
+    }
     function normalize(version) {
       sub(/^v/, "", version)
       sub(/:$/, "", version)
@@ -19,12 +55,13 @@ primary_version_output_matches_required() {
       next
     }
     {
+      saw_nonempty = 1
       first = $1
       version = normalize($2)
       exit ((first == tool || first == "cargo-" tool || first == tool ".exe") && version == required) ? 0 : 1
     }
     END {
-      if (NR == 0) {
+      if (saw_nonempty == 0) {
         exit 1
       }
     }

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ pre-push.log
 pr-description.md
 text_tt*
 proposed_fix
+ci-log*.txt
+ci-log*.log

--- a/scripts/tests/test_install_cargo_tool_action.py
+++ b/scripts/tests/test_install_cargo_tool_action.py
@@ -7,6 +7,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 VERSION_HELPER = REPO_ROOT / ".github" / "actions" / "install-cargo-tool" / "version-check.sh"
 
@@ -29,10 +31,17 @@ def _write_cargo_stub(tmp_path: Path, install_list: str) -> Path:
     return bin_dir
 
 
-def _run_helper(tmp_path: Path, command: str, install_list: str) -> subprocess.CompletedProcess[str]:
+def _run_helper(
+    tmp_path: Path,
+    command: str,
+    install_list: str,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     bin_dir = _write_cargo_stub(tmp_path, install_list)
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    if env_overrides:
+        env.update(env_overrides)
     return subprocess.run(
         ["bash", "-c", f"source {VERSION_HELPER}; {command}"],
         cwd=REPO_ROOT,
@@ -43,66 +52,178 @@ def _run_helper(tmp_path: Path, command: str, install_list: str) -> subprocess.C
     )
 
 
-def test_installed_version_rejects_unrelated_cargo_install_version(
-    tmp_path: Path,
-) -> None:
-    """A stale target binary must not pass because another package has the version."""
-    result = _run_helper(
-        tmp_path,
-        "installed_version_matches cargo-nextest 'cargo-nextest 0.9.99' 0.9.100",
-        "cargo-llvm-cov v0.9.100:\n    cargo-llvm-cov",
-    )
-
-    assert result.returncode == 1
+def _bash_single_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
 
 
-def test_installed_version_rejects_matching_dependency_version_in_tool_output(
-    tmp_path: Path,
-) -> None:
-    """Only the target tool's primary version token may satisfy the requirement."""
-    result = _run_helper(
-        tmp_path,
-        "installed_version_matches cargo-nextest 'cargo-nextest 0.9.99 nextest-runner 0.9.100,' 0.9.100",
-        "",
-    )
-
-    assert result.returncode == 1
-
-
-def test_installed_version_accepts_primary_tool_version_output(
-    tmp_path: Path,
-) -> None:
-    """The target tool's own version remains the preferred successful path."""
-    result = _run_helper(
-        tmp_path,
-        "installed_version_matches cargo-nextest 'cargo-nextest 0.9.100 nextest-runner 0.9.99' 0.9.100",
-        "",
-    )
-
+@pytest.mark.parametrize("value", ["it's", "a'b'c", "''"])
+def test_bash_single_quote_round_trip(tmp_path: Path, value: str) -> None:
+    """Shell-quoted helper output should round-trip through bash unchanged."""
+    result = _run_helper(tmp_path, f"printf %s {_bash_single_quote(value)}", "")
     assert result.returncode == 0
+    assert result.stdout == value
 
 
-def test_installed_version_accepts_target_cargo_install_entry_when_output_missing(
+@pytest.mark.parametrize(
+    ("command", "install_list", "expected_returncode"),
+    [
+        (
+            "installed_version_matches cargo-nextest 'cargo-nextest 0.9.99' 0.9.100",
+            "cargo-llvm-cov v0.9.100:\n    cargo-llvm-cov",
+            1,
+        ),
+        (
+            "installed_version_matches cargo-nextest 'cargo-nextest 0.9.99 nextest-runner 0.9.100,' 0.9.100",
+            "",
+            1,
+        ),
+        (
+            "installed_version_matches cargo-nextest 'cargo-nextest 0.9.100 nextest-runner 0.9.99' 0.9.100",
+            "",
+            0,
+        ),
+        (
+            "installed_version_matches cargo-nextest '' 0.9.100",
+            "cargo-nextest v0.9.100:\n    cargo-nextest",
+            0,
+        ),
+        (
+            "installed_version_matches cargo-nextest '' 0.9.100",
+            "cargo-llvm-cov v0.9.100:\n    cargo-llvm-cov",
+            1,
+        ),
+    ],
+    ids=[
+        "reject_unrelated_cargo_install_version",
+        "reject_dependency_version_token",
+        "accept_primary_tool_version",
+        "accept_matching_cargo_install_entry",
+        "reject_unrelated_cargo_install_entry",
+    ],
+)
+def test_installed_version_matches_matrix(
     tmp_path: Path,
+    command: str,
+    install_list: str,
+    expected_returncode: int,
 ) -> None:
-    """The cargo-install fallback is allowed only for the requested tool entry."""
-    result = _run_helper(
-        tmp_path,
-        "installed_version_matches cargo-nextest '' 0.9.100",
-        "cargo-nextest v0.9.100:\n    cargo-nextest",
+    """Version checks remain strict across stale and valid version-reporting patterns."""
+    result = _run_helper(tmp_path, command, install_list)
+    assert result.returncode == expected_returncode
+
+
+@pytest.mark.parametrize(
+    ("output", "tool_name", "required", "expected_returncode"),
+    [
+        ("cargo-nextest 0.9.100", "cargo-nextest", "0.9.100", 0),
+        ("cargo-nextest.exe v0.9.100:", "cargo-nextest", "0.9.100", 0),
+        (
+            "cargo-nextest 0.9.99 nextest-runner 0.9.100,",
+            "cargo-nextest",
+            "0.9.100",
+            1,
+        ),
+        ("", "cargo-nextest", "0.9.100", 1),
+        ("nextest version 0.9.100", "cargo-nextest", "0.9.100", 1),
+    ],
+    ids=[
+        "exact_match",
+        "windows_exe_prefix_and_v",
+        "dependency_token_must_not_match",
+        "empty_output_fails",
+        "unexpected_format_fails",
+    ],
+)
+def test_primary_version_output_matches_required_matrix(
+    tmp_path: Path,
+    output: str,
+    tool_name: str,
+    required: str,
+    expected_returncode: int,
+) -> None:
+    """Primary parser should only accept the requested tool's own version token."""
+    command = (
+        "primary_version_output_matches_required "
+        f"{_bash_single_quote(output)} "
+        f"{_bash_single_quote(tool_name)} "
+        f"{_bash_single_quote(required)}"
     )
+    result = _run_helper(tmp_path, command, "")
+    assert result.returncode == expected_returncode
 
-    assert result.returncode == 0
 
-
-def test_installed_version_rejects_unrelated_entry_when_output_missing(
+@pytest.mark.parametrize(
+    ("env_overrides", "expected_cargo_home"),
+    [
+        ({"CARGO_HOME": "/tmp/custom-cargo", "HOME": "/tmp/home"}, "/tmp/custom-cargo"),
+        ({"CARGO_HOME": "", "HOME": "/tmp/home"}, "/tmp/home/.cargo"),
+        (
+            {"CARGO_HOME": "C:\\Users\\runneradmin\\.cargo", "HOME": "/tmp/home"},
+            "C:/Users/runneradmin/.cargo",
+        ),
+    ],
+    ids=[
+        "prefer_cargo_home",
+        "fallback_to_home",
+        "normalize_windows_backslashes",
+    ],
+)
+def test_resolve_cargo_home_matrix(
     tmp_path: Path,
+    env_overrides: dict[str, str],
+    expected_cargo_home: str,
 ) -> None:
-    """The fallback must stay scoped even when the target has no --version output."""
+    """Cargo home resolution must be deterministic across OS-specific path formats."""
+    result = _run_helper(tmp_path, "resolve_cargo_home", "", env_overrides)
+    assert result.returncode == 0
+    assert result.stdout.strip() == expected_cargo_home
+
+
+def test_resolve_cargo_home_requires_environment(tmp_path: Path) -> None:
+    """A missing HOME and CARGO_HOME should fail with a precise diagnostic."""
     result = _run_helper(
         tmp_path,
-        "installed_version_matches cargo-nextest '' 0.9.100",
-        "cargo-llvm-cov v0.9.100:\n    cargo-llvm-cov",
+        "resolve_cargo_home",
+        "",
+        {"CARGO_HOME": "", "HOME": ""},
     )
 
     assert result.returncode == 1
+    assert "neither CARGO_HOME nor HOME is set" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "cargo_home", "expected_glob"),
+    [
+        ("cargo-nextest", "/tmp/.cargo", "/tmp/.cargo/bin/cargo-nextest*"),
+        ("cargo-hack", "/tmp/.cargo/", "/tmp/.cargo/bin/cargo-hack*"),
+        (
+            "cargo-nextest",
+            "C:\\Users\\runneradmin\\.cargo",
+            "C:/Users/runneradmin/.cargo/bin/cargo-nextest*",
+        ),
+    ],
+    ids=[
+        "unix_path",
+        "trailing_slash",
+        "windows_path_normalized",
+    ],
+)
+def test_cargo_tool_cache_glob_matrix(
+    tmp_path: Path,
+    tool_name: str,
+    cargo_home: str,
+    expected_glob: str,
+) -> None:
+    """Cache glob generation should be stable for both Unix and Windows path styles."""
+    command = f"cargo_tool_cache_glob {tool_name} '{cargo_home}'"
+    result = _run_helper(tmp_path, command, "")
+    assert result.returncode == 0
+    assert result.stdout.strip() == expected_glob
+
+
+def test_cargo_tool_cache_glob_requires_tool_name(tmp_path: Path) -> None:
+    """An empty tool name should fail fast with a useful error."""
+    result = _run_helper(tmp_path, "cargo_tool_cache_glob '' '/tmp/.cargo'", "")
+    assert result.returncode == 1
+    assert "tool name is required" in result.stderr

--- a/scripts/tests/test_install_cargo_tool_action.py
+++ b/scripts/tests/test_install_cargo_tool_action.py
@@ -36,16 +36,18 @@ def _run_helper(
     command: str,
     install_list: str,
     env_overrides: dict[str, str] | None = None,
+    helper_path: Path = VERSION_HELPER,
 ) -> subprocess.CompletedProcess[str]:
     bin_dir = _write_cargo_stub(tmp_path, install_list)
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["VERSION_HELPER_PATH"] = str(helper_path)
     if env_overrides:
         env.update(env_overrides)
     return subprocess.run(
-        ["bash", "-c", f"source {VERSION_HELPER}; {command}"],
+        ["bash", "-c", 'source "$VERSION_HELPER_PATH"; eval "$TEST_COMMAND"'],
         cwd=REPO_ROOT,
-        env=env,
+        env={**env, "TEST_COMMAND": command},
         capture_output=True,
         text=True,
         check=False,
@@ -190,6 +192,75 @@ def test_resolve_cargo_home_requires_environment(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert "neither CARGO_HOME nor HOME is set" in result.stderr
+
+
+def test_run_helper_supports_shell_metacharacters_in_helper_path(tmp_path: Path) -> None:
+    """Helper sourcing should work when the helper path contains shell metacharacters."""
+    helper_dir = tmp_path / "helper path's"
+    helper_dir.mkdir()
+    helper_copy = helper_dir / "version-check.sh"
+    helper_copy.write_text(VERSION_HELPER.read_text(encoding="utf-8"), encoding="utf-8")
+    helper_copy.chmod(0o755)
+
+    result = _run_helper(
+        tmp_path,
+        "resolve_cargo_home",
+        "",
+        {"CARGO_HOME": "", "HOME": "/tmp/home"},
+        helper_path=helper_copy,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "/tmp/home/.cargo"
+
+
+@pytest.mark.parametrize(
+    ("cargo_home", "expected_returncode"),
+    [
+        ("/tmp/.cargo", 0),
+        ("//server/share/.cargo", 0),
+        ("/c/Users/runneradmin/.cargo", 0),
+        ("C:/Users/runneradmin/.cargo", 0),
+        ("C:\\Users\\runneradmin\\.cargo", 0),
+        ("", 1),
+        ("/", 1),
+        ("C:/", 1),
+        ("C:\\", 1),
+        (".", 1),
+        ("..", 1),
+        ("cargo", 1),
+        ("./cargo", 1),
+        ("../cargo", 1),
+        ("~/.cargo", 1),
+        ("C:relative", 1),
+    ],
+    ids=[
+        "accept_unix_absolute",
+        "accept_unc_absolute",
+        "accept_msys_absolute",
+        "accept_windows_absolute",
+        "accept_windows_backslashes",
+        "reject_empty",
+        "reject_unix_root",
+        "reject_windows_root",
+        "reject_windows_root_backslashes",
+        "reject_relative_current",
+        "reject_relative_parent",
+        "reject_relative_bare",
+        "reject_relative_dot_prefix",
+        "reject_relative_parent_prefix",
+        "reject_tilde",
+        "reject_windows_drive_relative",
+    ],
+)
+def test_cargo_home_is_safe_matrix(
+    tmp_path: Path,
+    cargo_home: str,
+    expected_returncode: int,
+) -> None:
+    """Cargo home safety checks must reject unsafe paths before destructive actions."""
+    command = f"cargo_home_is_safe {_bash_single_quote(cargo_home)}"
+    result = _run_helper(tmp_path, command, "")
+    assert result.returncode == expected_returncode
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Hardens the `install-cargo-tool` CI action to reduce flaky installs (especially on Windows) and make failures easier to diagnose.

This PR:
- normalizes `CARGO_HOME`/path handling and cache glob generation across Unix/Windows,
- validates action inputs early (`tool`, `max-retries`, `retry-delay`),
- treats cache restore failures as non-blocking while emitting clearer diagnostics,
- makes retry behavior respect configured retry count before fallback,
- strengthens version parsing so only the target tool version satisfies checks,
- expands automated tests for helper/path/version logic,
- removes an accidentally committed local binary and ignores local CI log artifacts.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation (changes to documentation only)
- [x] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [x] 🔧 CI/Build (changes to CI configuration or build process)

## Checklist

### Required

- [ ] I have read the [CONTRIBUTING guide](../docs/contributing.md)
- [ ] I have followed the **zero-panic policy**:
  - No `unwrap()` in production code
  - No `expect()` in production code
  - No `panic!()` or `todo!()`
  - All fallible operations return `Result`
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] I have run `cargo fmt && cargo clippy --all-targets --features tokio,json` with no warnings
- [ ] I have run `cargo nextest run` and all tests pass

### If Applicable

- [ ] I have updated the documentation accordingly
- [ ] I have added an entry to `CHANGELOG.md` for user-facing changes
- [ ] I have updated relevant examples in the `examples/` directory
- [ ] My changes generate no new compiler warnings

## Testing

**Tests added/modified:**

- `scripts/tests/test_install_cargo_tool_action.py` (expanded coverage for version parsing, cache path resolution, and glob generation)

**Manual testing performed:**

- Validated branch diff from merge-base (`origin/main`) includes only CI action hardening, test updates, ignore cleanup, and binary cleanup.

## Related Issues

- N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the composite action used across CI, including cache paths, retry gating, and conditional cleanup of cached binaries; mistakes could break tool installation or delete the wrong files on runners. Changes are scoped to CI infrastructure and include expanded regression tests to reduce risk.
> 
> **Overview**
> **Hardens the `install-cargo-tool` composite action** to be more reliable across Unix/Windows by resolving and validating `CARGO_HOME`, generating a normalized cache glob, and refusing to delete cached binaries unless the resolved cargo home path is deemed safe.
> 
> **Improves CI robustness and debuggability** by making cache restore non-blocking (`continue-on-error`), emitting detailed cache/install diagnostics, and making retries/fallback respect `max-retries` (with explicit retry-exhaustion detection) before running `cargo install`.
> 
> **Tightens version matching semantics and test coverage**: `installed_version_matches` now only accepts the target tool’s own version token (no dependency-version false positives), adds helper functions for cargo-home/path normalization, and significantly expands Python/pytest regression tests for parsing and path edge cases. Also updates `.gitignore` to ignore local CI log artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd84d91563548cff142983986c7170041bd92f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->