### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.1]
+## [0.8.1] - 2026-05-16
 
 ### Added
 
@@ -474,7 +474,8 @@ fn handle_inputs(inputs: &[(MyInput, InputStatus)]) { ... }
 
 For detailed migration instructions, see [docs/migration.md](docs/migration.md).
 
-[Unreleased]: https://github.com/wallstop/fortress-rollback/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/wallstop/fortress-rollback/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/wallstop/fortress-rollback/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/wallstop/fortress-rollback/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/wallstop/fortress-rollback/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/wallstop/fortress-rollback/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1]
+
 ### Added
 
 - `P2PSession::set_input_delay()` and `P2PSession::input_delay()` for runtime input-delay adjustment, enabling hybrid delay+rollback in response to changing network conditions. Mid-session **increases** are supported on peers with a single local player: the input queue replicates the most recently added input across the new gap, and the same replicated frames are pushed onto every remote endpoint's pending-output buffer so the remote peer's input sequence remains strictly monotonic. Mid-session **decreases** return an `InputDelayDecreaseUnsupported` error and leave the queue unchanged; mid-session increases on peers with multiple local players return `InputDelayMidSessionMultiLocalUnsupported`. If mid-session increase gap-fill fails an internal queue invariant, the input queue restores its prior state and delay before returning `InputQueueGapFillFailed`. The mid-session gap-fill mirror step now surfaces `InternalErrorStructured(ConnectionStatusIndexOutOfBounds { player_handle })` if the matching `local_connect_status` entry is missing rather than silently skipping the update; if this error is returned through the public API, it indicates an internal-invariant violation and should be treated as a library bug. On a **frozen** input queue (a dropped peer under `ContinueWithout`), `set_input_delay` is unconditionally a silent no-op — including when the requested delay would exceed `max_frame_delay()`, which no longer leaks a `FrameDelayTooLarge` error for an already-gone peer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "fortress-rollback"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "tests/network-peer"]
 
 [package]
 name = "fortress-rollback"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["wallstop <wallstop@wallstopstudios.com>"]
 edition = "2021"
 rust-version = "1.86"  # Minimum Supported Rust Version (MSRV) - required by criterion 0.8.1


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes. -->
<!-- What problem does this solve? Why is this change needed? -->

## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation (changes to documentation only)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] 🔧 CI/Build (changes to CI configuration or build process)

## Checklist

<!-- Please review and check all applicable items -->

### Required

- [x] I have read the [CONTRIBUTING guide](../docs/contributing.md)
- [x] I have followed the **zero-panic policy**:
  - No `unwrap()` in production code
  - No `expect()` in production code
  - No `panic!()` or `todo!()`
  - All fallible operations return `Result`
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] I have run `cargo fmt && cargo clippy --all-targets --features tokio,json` with no warnings
- [x] I have run `cargo nextest run` and all tests pass

### If Applicable

- [ ] I have updated the documentation accordingly
- [x] I have added an entry to `CHANGELOG.md` for user-facing changes
- [ ] I have updated relevant examples in the `examples/` directory
- [x] My changes generate no new compiler warnings

## Testing

<!-- Describe how you tested your changes -->
<!-- Include any relevant details about your testing environment -->

**Tests added/modified:**

- (None)

**Manual testing performed:**

- (None)

## Related Issues

<!-- Link any related issues using GitHub keywords -->
<!-- Examples: Fixes #123, Closes #456, Relates to #789 -->

---

<!-- Thank you for contributing to Fortress Rollback! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates crate version metadata and adds a `0.8.1` changelog entry; no functional code changes are included in this diff.
> 
> **Overview**
> Bumps the crate version from `0.8.0` to `0.8.1` in `Cargo.toml`/`Cargo.lock` and updates `CHANGELOG.md` to publish the `0.8.1` release notes.
> 
> Updates the changelog compare links so `[Unreleased]` now tracks from `v0.8.1` and adds a `[0.8.1]` comparison reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b63c194e38d9c8d31266ce86ededc683be40addc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->