### PR TITLE
feat: Peer-Mesh Hardening

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -85,7 +85,9 @@ jobs:
 
       # Run all criterion benchmarks
       - name: Run benchmarks
-        run: cargo bench --bench input_queue --bench p2p_session --bench sync_layer -- --output-format bencher | tee benchmark-results.txt
+        run: |
+          set -o pipefail
+          cargo bench --bench input_queue --bench p2p_session --bench sync_layer -- --output-format bencher | tee benchmark-results.txt
         env:
           RUSTC_WRAPPER: ${{ steps.sccache-check.outputs.working == 'true' && 'sccache' || '' }}
           SCCACHE_GHA_ENABLED: ${{ steps.sccache-check.outputs.working == 'true' && 'true' || 'false' }}

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/docs/**"
       - "scripts/tests/**"
       - "scripts/ci/check-doc-claims.sh"
+      - "scripts/hooks/check-rust-semantic-claims.py"
       - "scripts/ci/check-derive-bounds.sh"
       - ".markdownlint.json"
       - ".markdown-link-check.json"
@@ -33,6 +34,7 @@ on:
       - "scripts/docs/**"
       - "scripts/tests/**"
       - "scripts/ci/check-doc-claims.sh"
+      - "scripts/hooks/check-rust-semantic-claims.py"
       - "scripts/ci/check-derive-bounds.sh"
       - ".markdownlint.json"
       - ".markdown-link-check.json"
@@ -84,6 +86,8 @@ jobs:
       - name: Run Vale prose linter
         id: vale
         run: |
+          set -o pipefail
+
           {
             echo "## Vale Prose Lint Results"
             echo ""
@@ -270,6 +274,8 @@ jobs:
 
       - name: Check for rustdoc-style code fence attributes
         run: |
+          set -o pipefail
+
           {
             echo "## Code Fence Syntax Check"
             echo ""
@@ -580,6 +586,8 @@ jobs:
 
       - name: Run documentation tests
         run: |
+          set -o pipefail
+
           {
             echo "## Documentation Example Tests"
             echo ""
@@ -626,6 +634,8 @@ jobs:
 
       - name: Measure documentation coverage
         run: |
+          set -o pipefail
+
           {
             echo "## Documentation Coverage Report"
             echo ""
@@ -693,6 +703,8 @@ jobs:
 
       - name: Verify markdown code samples
         run: |
+          set -o pipefail
+
           {
             echo "## Markdown Code Sample Verification"
             echo ""

--- a/.github/workflows/ci-mutation.yml
+++ b/.github/workflows/ci-mutation.yml
@@ -127,6 +127,8 @@ jobs:
       - name: Run mutation testing
         id: mutants
         run: |
+          set -o pipefail
+
           {
             echo ""
             echo "## Mutation Testing Results (${{ matrix.os }})"

--- a/.github/workflows/ci-safety.yml
+++ b/.github/workflows/ci-safety.yml
@@ -167,6 +167,7 @@ jobs:
 
       - name: Run tests with ${{ matrix.check }}
         run: |
+          set -o pipefail
           RUSTFLAGS="${{ matrix.rustflags }}" cargo test --release --lib 2>&1 | tee test-${{ matrix.check }}.txt
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
@@ -212,6 +213,8 @@ jobs:
       - name: Run strict clippy lints (nursery)
         shell: bash
         run: |
+          set -o pipefail
+
           {
             echo "## Strict Clippy Lints (Nursery)"
             echo ""
@@ -391,6 +394,8 @@ jobs:
 
       - name: Build documentation with warnings as errors
         run: |
+          set -o pipefail
+
           {
             echo "## Documentation Build"
             echo ""
@@ -406,6 +411,8 @@ jobs:
 
       - name: Run documentation tests
         run: |
+          set -o pipefail
+
           if cargo test --doc 2>&1 | tee doc-tests.txt; then
             echo "✅ All doc tests passed" >> "$GITHUB_STEP_SUMMARY"
           else
@@ -452,6 +459,8 @@ jobs:
 
       - name: Check for panic-prone patterns (library only)
         run: |
+          set -o pipefail
+
           {
             echo "## No-Panics Check"
             echo ""

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -233,6 +233,8 @@ jobs:
       - name: Check for outdated dependencies
         id: outdated
         run: |
+          set -o pipefail
+
           {
             echo "## Dependency Freshness Check"
             echo ""

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -51,6 +51,7 @@ Rules: always `bat --paging=never` (bare `bat` blocks); never redirect to `/dev/
 - **ZERO-PANIC POLICY** -- Production code must NEVER panic; all errors as `Result`
 - **All clippy lints pass** -- `clippy::all`, `clippy::pedantic`, `clippy::nursery`
 - **No broken doc links** -- All intra-doc links must resolve
+- **Accurate panic docs** -- Rustdoc `# Panics` lists all reachable panic conditions; boundary panic docs should have matching tests when practical
 - **Public items documented** -- Rustdoc with examples
 - **Overflow checks in release** -- Integer overflow caught at runtime
 - **Deterministic behavior** -- Same inputs must always produce same outputs

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -242,7 +242,7 @@ Validate locally: `python3 scripts/hooks/check-changelog-unreleased.py`. Also ru
 - **After shell-script changes:** `bash scripts/ci/check-shell-portability.sh`
 - **Hook policy:** `pre-commit`/`pre-push` target <10s; slow full-repo checks belong in manual hooks, agent preflight, or CI.
 - **After `.llm/` changes:** All `.md` files under `.llm/` must be **300 lines or fewer** (enforced by pre-commit hook `llm-line-limit`)
-- **Link validation:** `python3 scripts/docs/check-links.py` (also flags rustdoc intra-doc links whose backticked text names an item the `crate::`/`super::`/`self::` target's last segment does not -- they resolve but land on the wrong page; see [doc-code-sync.md](skills/ci-cd-tooling/doc-code-sync.md#intra-doc-link-text-vs-target)). Runs in agent preflight when `.rs`/`.md` files change.
+- **Doc/link validation:** `python3 scripts/docs/check-links.py` plus `bash scripts/ci/check-doc-claims.sh` for Rust semantic claim drift (also flags rustdoc intra-doc links whose backticked text names an item the `crate::`/`super::`/`self::` target's last segment does not -- they resolve but land on the wrong page; see [doc-code-sync.md](skills/ci-cd-tooling/doc-code-sync.md#intra-doc-link-text-vs-target)). Runs in agent preflight when `.rs`/`.md` files change.
 - **Spell check:** `typos`
 - **Vale (advisory):** `vale docs/` -- checks prose quality, non-blocking in CI. Cheat-sheet of recurring swaps and weasel words: [`.llm/skills/workflows/user-facing-docs.md`](skills/workflows/user-facing-docs.md#prose-conventions). Agent preflight surfaces per-file counts via the `vale-advisory` check.
 - **Full local validation:** `cargo fmt && cargo clippy --workspace --all-targets --features tokio,json && cargo nextest run --no-capture`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`P2PSession::peer_checksum_mismatch_count(handle)` and an advisory per-peer checksum trust-downgrade
+  signal (Byzantine-peer hardening).** With desync detection enabled, the session now tracks, per remote
+  peer, how many confirmed-frame checksums failed to match the local history, exposes that count via the
+  new method, and logs **one** advisory `WARNING` once a peer's count crosses an internal threshold. This
+  is deliberately advisory: the library **never auto-ejects** a peer on checksum mismatch (with two
+  endpoints it cannot tell which side is wrong, so dropping a peer risks removing the honest one) — apps
+  apply their own policy from the raw count. The `SyncHealth::DesyncDetected` docs are clarified
+  accordingly: handle it gracefully (it is a recoverable event), do not hard-panic; a single mismatch is a
+  genuine divergence in the trusted-peer model but may be a one-off bad checksum from a malicious/buggy
+  peer in an untrusted deployment, where *persistence* is what distinguishes the two.
 - **Hot Join (reserved-slot model), behind the new opt-in `hot-join` feature flag.** A peer can join a
   running session by filling a *reserved* (or previously gracefully-dropped) player slot: it synchronizes
   with the host, receives a full game-state snapshot, loads it, and resumes normal rollback play — all
@@ -32,8 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `FortressEvent::PeerJoined { handle, addr }`; `InvalidRequestKind::PlayerCountMismatch { expected, actual }`.
   - Under `hot-join`, `Config::State` additionally requires `Serialize + DeserializeOwned` (for snapshot
     transfer). This bound only applies when the feature is enabled, so it is **not** a breaking change for
-    existing builds. Snapshot deserialization is allocation-bounded (a hostile length prefix yields an
-    error, never an OOM); keep `Config::State` non-recursive.
+    existing builds. Snapshot deserialization is **both allocation-bounded and recursion-depth-bounded**:
+    a hostile length prefix yields an error (never an OOM), and a deeply-nested recursive snapshot yields a
+    recoverable decode error (never a stack-overflow abort), so a recursive `Config::State` is safe up to a
+    generous nesting limit. (`Config::Input` is bound `Copy`, hence provably non-recursive, so the input
+    decode path keeps its direct fast path.)
   - The join handshake is ack-gated and loss/latency tolerant within a bounded envelope: the host
     re-serves the snapshot until acknowledged and only reactivates the slot on the ack, an abandoned join
     can never stall or fail-close the host (it resumes solo with the slot still reserved), and a joiner

--- a/scripts/ci/agent-preflight.py
+++ b/scripts/ci/agent-preflight.py
@@ -114,6 +114,14 @@ def is_link_check_surface_file(path: str) -> bool:
     return is_markdown_file(path) or is_rust_file(path)
 
 
+def is_doc_claims_surface_file(path: str) -> bool:
+    """Return True for files that can affect check-doc-claims output."""
+    return is_rust_file(path) or path in {
+        "scripts/ci/check-doc-claims.sh",
+        "scripts/hooks/check-rust-semantic-claims.py",
+    }
+
+
 def git_output_lines(repo_root: Path, args: list[str]) -> set[str]:
     """Run git and return non-empty output lines.
 
@@ -163,6 +171,9 @@ def plan_checks(changed_files: set[str], run_all: bool = False) -> list[PlannedC
     )
     link_check_changed = any(
         is_link_check_surface_file(path) for path in changed_files
+    )
+    doc_claims_changed = any(
+        is_doc_claims_surface_file(path) for path in changed_files
     )
     changelog_changed = any(is_changelog_file(path) for path in changed_files)
 
@@ -291,6 +302,22 @@ def plan_checks(changed_files: set[str], run_all: bool = False) -> list[PlannedC
                 # Detection + reporting only -- the correct fix depends on item
                 # visibility, so there is no safe blind auto-fix.
                 fix_command=None,
+            )
+        )
+
+    if run_all or doc_claims_changed:
+        checks.append(
+            PlannedCheck(
+                check_id="doc-claims",
+                description=(
+                    "validate Rust doc comments and test names against "
+                    "implementation clues"
+                ),
+                command=["bash", "scripts/ci/check-doc-claims.sh"],
+                fix_hint=(
+                    "Update stale rustdoc/test names, or adjust the implementation "
+                    "if the documented contract is the intended behavior."
+                ),
             )
         )
 

--- a/scripts/ci/check-doc-claims.sh
+++ b/scripts/ci/check-doc-claims.sh
@@ -5,6 +5,7 @@
 # - "downcast" docs must be backed by actual downcasting infrastructure
 # - bounded decode docs must not point callers at unbounded decode helpers
 # - `codec::decode_*` references in docs/allocation comments must name real helpers
+# - Rustdoc range contracts and test names must match implementation clues
 #
 # Usage: ./scripts/ci/check-doc-claims.sh [options]
 #   ./scripts/ci/check-doc-claims.sh            # Check all Rust files
@@ -38,7 +39,7 @@ print_usage() {
     echo "  --verbose  Show all files checked"
     echo "  --help     Show this help message"
     echo ""
-    echo "Checks doc comments for misleading downcast and bounded-decode claims."
+    echo "Checks doc comments and test names for misleading semantic claims."
 }
 
 main() {
@@ -223,6 +224,20 @@ main() {
     done < <(find "$PROJECT_ROOT/src" "$PROJECT_ROOT/tests" "$PROJECT_ROOT/examples" "$PROJECT_ROOT/benches" \
         -name '*.rs' -print 2>/dev/null \
         | sort)
+
+    echo ""
+
+    local semantic_claim_checker="$PROJECT_ROOT/scripts/hooks/check-rust-semantic-claims.py"
+    if [[ -f "$semantic_claim_checker" ]]; then
+        if ! python3 "$semantic_claim_checker"; then
+            issues=$((issues + 1))
+        fi
+    else
+        issues=$((issues + 1))
+        echo ""
+        echo -e "${RED}ERROR${NC}: missing semantic claim checker: $semantic_claim_checker"
+        echo -e "  ${BLUE}Fix:${NC} Restore scripts/hooks/check-rust-semantic-claims.py."
+    fi
 
     echo ""
 

--- a/scripts/hooks/check-rust-semantic-claims.py
+++ b/scripts/hooks/check-rust-semantic-claims.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+"""Check Rust doc and test names for semantic claims that drift from code."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SCAN_DIRS = ("src", "tests", "examples", "benches")
+
+FN_RE = re.compile(r"\bfn\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:<[^({;]*>)?\s*\(")
+INCLUSIVE_RANGE_ASSERT_RE = re.compile(
+    r"assert!\s*\(\s*"
+    r"\(\s*(?P<lower>[0-9]+)\s*\.\.=\s*(?P<upper>[0-9]+)\s*\)"
+    r"\s*\.contains\s*\(\s*&\s*(?P<param>[A-Za-z_][A-Za-z0-9_]*)\s*\)",
+    re.DOTALL,
+)
+CREATE_CHANNEL_MESH_CALL_RE = re.compile(r"\bcreate_channel_mesh\s*\(")
+DIVERGENCE_EXPR = r"(?P<var>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)"
+NO_DIVERGENCE_ASSERT_RES = (
+    re.compile(
+        rf"assert!\s*\(\s*{DIVERGENCE_EXPR}\.is_empty\s*\(",
+        re.DOTALL,
+    ),
+    re.compile(
+        rf"assert!\s*\(\s*{DIVERGENCE_EXPR}\.is_none\s*\(",
+        re.DOTALL,
+    ),
+    re.compile(
+        rf"assert_eq!\s*\(\s*{DIVERGENCE_EXPR}\s*,\s*None\b",
+        re.DOTALL,
+    ),
+    re.compile(
+        rf"assert_eq!\s*\(\s*None\s*,\s*{DIVERGENCE_EXPR}\b",
+        re.DOTALL,
+    ),
+)
+POSITIVE_DIVERGENCE_ASSERT_RES = (
+    re.compile(
+        rf"assert!\s*\(\s*!\s*{DIVERGENCE_EXPR}\.is_empty\s*\(",
+        re.DOTALL,
+    ),
+    re.compile(
+        rf"assert!\s*\(\s*{DIVERGENCE_EXPR}\.is_some\s*\(",
+        re.DOTALL,
+    ),
+    re.compile(
+        rf"assert_ne!\s*\(\s*{DIVERGENCE_EXPR}\s*,\s*None\b",
+        re.DOTALL,
+    ),
+    re.compile(
+        rf"assert_eq!\s*\(\s*{DIVERGENCE_EXPR}\s*,\s*Some\s*\(",
+        re.DOTALL,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class RustFunction:
+    """A Rust function with the source context needed by this checker."""
+
+    name: str
+    line: int
+    body: str
+    masked_body: str
+    doc_text: str
+    attrs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One semantic-claim mismatch."""
+
+    path: Path
+    line: int
+    message: str
+    fix: str
+
+
+def repo_root_from_script() -> Path:
+    """Return the repository root based on this script location."""
+    return Path(__file__).resolve().parents[2]
+
+
+def blank_range(chars: list[str], start: int, end: int) -> None:
+    """Replace a source range with spaces while preserving newlines."""
+    for index in range(start, min(end, len(chars))):
+        if chars[index] != "\n":
+            chars[index] = " "
+
+
+def raw_string_end(text: str, index: int) -> int | None:
+    """Return the exclusive end of a raw string that starts at index, if any."""
+    if text.startswith("br", index):
+        raw_index = index + 1
+    elif text.startswith("r", index):
+        raw_index = index
+    else:
+        return None
+
+    cursor = raw_index + 1
+    while cursor < len(text) and text[cursor] == "#":
+        cursor += 1
+
+    if cursor >= len(text) or text[cursor] != '"':
+        return None
+
+    hashes = cursor - raw_index - 1
+    terminator = '"' + ("#" * hashes)
+    end = text.find(terminator, cursor + 1)
+    if end == -1:
+        return len(text)
+    return end + len(terminator)
+
+
+def quoted_string_end(text: str, index: int) -> int:
+    """Return the exclusive end of a normal quoted string."""
+    cursor = index + 1
+    while cursor < len(text):
+        if text[cursor] == "\\":
+            cursor += 2
+            continue
+        if text[cursor] == '"':
+            return cursor + 1
+        cursor += 1
+    return len(text)
+
+
+def char_literal_end(text: str, index: int) -> int | None:
+    """Return the exclusive end of a char literal, avoiding lifetimes."""
+    if index + 1 >= len(text):
+        return None
+    next_char = text[index + 1]
+    if next_char.isalpha() or next_char == "_":
+        return None
+
+    cursor = index + 1
+    while cursor < len(text):
+        if text[cursor] == "\\":
+            cursor += 2
+            continue
+        if text[cursor] == "'":
+            return cursor + 1
+        cursor += 1
+    return None
+
+
+def mask_non_code(text: str) -> str:
+    """Mask comments and string literals so simple Rust scans avoid false hits."""
+    chars = list(text)
+    cursor = 0
+    while cursor < len(text):
+        raw_end = raw_string_end(text, cursor)
+        if raw_end is not None:
+            blank_range(chars, cursor, raw_end)
+            cursor = raw_end
+            continue
+
+        if text.startswith("//", cursor):
+            end = text.find("\n", cursor)
+            if end == -1:
+                end = len(text)
+            blank_range(chars, cursor, end)
+            cursor = end
+            continue
+
+        if text.startswith("/*", cursor):
+            depth = 1
+            inner = cursor + 2
+            while inner < len(text) and depth > 0:
+                if text.startswith("/*", inner):
+                    depth += 1
+                    inner += 2
+                elif text.startswith("*/", inner):
+                    depth -= 1
+                    inner += 2
+                else:
+                    inner += 1
+            blank_range(chars, cursor, inner)
+            cursor = inner
+            continue
+
+        if text.startswith('b"', cursor):
+            end = quoted_string_end(text, cursor + 1)
+            blank_range(chars, cursor, end)
+            cursor = end
+            continue
+
+        if text[cursor] == '"':
+            end = quoted_string_end(text, cursor)
+            blank_range(chars, cursor, end)
+            cursor = end
+            continue
+
+        if text[cursor] == "'":
+            end = char_literal_end(text, cursor)
+            if end is not None:
+                blank_range(chars, cursor, end)
+                cursor = end
+                continue
+
+        cursor += 1
+
+    return "".join(chars)
+
+
+def find_matching_brace(masked: str, open_brace: int) -> int | None:
+    """Return the matching closing brace in already-masked Rust source."""
+    depth = 0
+    for cursor in range(open_brace, len(masked)):
+        if masked[cursor] == "{":
+            depth += 1
+        elif masked[cursor] == "}":
+            depth -= 1
+            if depth == 0:
+                return cursor
+    return None
+
+
+def line_number(text: str, offset: int) -> int:
+    """Return the 1-based line number for a byte offset."""
+    return text.count("\n", 0, offset) + 1
+
+
+def line_start_offsets(text: str) -> list[int]:
+    """Return byte offsets for the start of each source line."""
+    offsets = [0]
+    for match in re.finditer("\n", text):
+        offsets.append(match.end())
+    return offsets
+
+
+def line_index_for_offset(offsets: list[int], offset: int) -> int:
+    """Return the 0-based source line index containing offset."""
+    low = 0
+    high = len(offsets)
+    while low + 1 < high:
+        mid = (low + high) // 2
+        if offsets[mid] <= offset:
+            low = mid
+        else:
+            high = mid
+    return low
+
+
+def strip_doc_marker(line: str) -> str:
+    """Remove a Rust outer-doc marker from one source line."""
+    return re.sub(r"^[ \t]*/// ?", "", line.rstrip("\n"))
+
+
+def function_metadata(lines: list[str], fn_line_index: int) -> tuple[str, tuple[str, ...]]:
+    """Return attached rustdoc text and attributes for a function line."""
+    cursor = fn_line_index - 1
+    attrs: list[str] = []
+    while cursor >= 0 and lines[cursor].strip().startswith("#["):
+        attrs.insert(0, lines[cursor].strip())
+        cursor -= 1
+
+    doc_lines: list[str] = []
+    while cursor >= 0 and lines[cursor].lstrip().startswith("///"):
+        doc_lines.insert(0, strip_doc_marker(lines[cursor]))
+        cursor -= 1
+
+    return "\n".join(doc_lines), tuple(attrs)
+
+
+def iter_functions(text: str) -> list[RustFunction]:
+    """Extract Rust functions from source text."""
+    masked = mask_non_code(text)
+    offsets = line_start_offsets(text)
+    lines = text.splitlines(keepends=True)
+    functions: list[RustFunction] = []
+
+    for match in FN_RE.finditer(masked):
+        open_brace = masked.find("{", match.end())
+        semicolon = masked.find(";", match.end())
+        if open_brace == -1 or (semicolon != -1 and semicolon < open_brace):
+            continue
+
+        close_brace = find_matching_brace(masked, open_brace)
+        if close_brace is None:
+            continue
+
+        fn_line_index = line_index_for_offset(offsets, match.start())
+        doc_text, attrs = function_metadata(lines, fn_line_index)
+        functions.append(
+            RustFunction(
+                name=match.group(1),
+                line=line_number(text, match.start()),
+                body=text[open_brace : close_brace + 1],
+                masked_body=masked[open_brace : close_brace + 1],
+                doc_text=doc_text,
+                attrs=attrs,
+            )
+        )
+
+    return functions
+
+
+def is_test_function(function: RustFunction) -> bool:
+    """Return true when a function is marked as a Rust test."""
+    return any("test" in attr for attr in function.attrs)
+
+
+def name_claims_positive_divergence(name: str) -> bool:
+    """Return true when a test name says divergence is the expected outcome."""
+    tokens = name.lower().split("_")
+    if any(token in tokens for token in ("without", "no", "not", "prevents", "avoids")):
+        return False
+    return any(token in tokens for token in ("diverges", "divergent", "divergence"))
+
+
+def body_has_divergence_var_assertion(
+    body: str,
+    regexes: tuple[re.Pattern[str], ...],
+) -> bool:
+    """Return true when any regex assertion targets a divergence-named value."""
+    for regex in regexes:
+        for match in regex.finditer(body):
+            if "diverg" in match.group("var").lower():
+                return True
+    return False
+
+
+def body_asserts_no_divergence(body: str) -> bool:
+    """Return true when a body has a direct no-divergence assertion."""
+    return body_has_divergence_var_assertion(body, NO_DIVERGENCE_ASSERT_RES)
+
+
+def body_asserts_positive_divergence(body: str) -> bool:
+    """Return true when a body directly asserts a divergence exists."""
+    return body_has_divergence_var_assertion(body, POSITIVE_DIVERGENCE_ASSERT_RES)
+
+
+def number_token_present(text: str, number: str) -> bool:
+    """Return true when number appears as a standalone numeric token."""
+    return re.search(rf"(?<![0-9]){re.escape(number)}(?![0-9])", text) is not None
+
+
+def panics_section(doc_text: str) -> str:
+    """Extract a rustdoc # Panics section, if present."""
+    lines = doc_text.splitlines()
+    section: list[str] = []
+    in_section = False
+    for line in lines:
+        if re.match(r"^[ \t]*#+[ \t]+Panics\b", line, flags=re.IGNORECASE):
+            in_section = True
+            section.append(line)
+            continue
+        if in_section and re.match(r"^[ \t]*#+[ \t]+[A-Za-z]", line):
+            break
+        if in_section:
+            section.append(line)
+    return "\n".join(section)
+
+
+def check_test_name_claims(path: Path, function: RustFunction) -> list[Finding]:
+    """Check test names whose positive divergence claim disagrees with assertions."""
+    if not is_test_function(function):
+        return []
+    if not name_claims_positive_divergence(function.name):
+        return []
+    if body_asserts_positive_divergence(function.masked_body):
+        return []
+    if not body_asserts_no_divergence(function.masked_body):
+        return []
+
+    return [
+        Finding(
+            path=path,
+            line=function.line,
+            message=(
+                f"test `{function.name}` says divergence is expected, but its body "
+                "asserts a divergence collection/option is empty or absent"
+            ),
+            fix=(
+                "Rename the test to describe the no-divergence/convergence oracle, "
+                "or change the assertion if the intended oracle is positive divergence."
+            ),
+        )
+    ]
+
+
+def check_range_contracts(path: Path, function: RustFunction) -> list[Finding]:
+    """Check inclusive-range assertions against attached rustdoc contracts."""
+    if not function.doc_text:
+        return []
+
+    findings: list[Finding] = []
+    for match in INCLUSIVE_RANGE_ASSERT_RE.finditer(function.masked_body):
+        lower = match.group("lower")
+        upper = match.group("upper")
+        param = match.group("param")
+
+        missing_doc_bounds = [
+            bound
+            for bound in (lower, upper)
+            if not number_token_present(function.doc_text, bound)
+        ]
+        if missing_doc_bounds:
+            findings.append(
+                Finding(
+                    path=path,
+                    line=function.line,
+                    message=(
+                        f"`{function.name}` asserts `{param}` is in `{lower}..={upper}`, "
+                        f"but its rustdoc omits bound(s): {', '.join(missing_doc_bounds)}"
+                    ),
+                    fix=(
+                        "Document the full accepted range in the argument contract so "
+                        "callers see the same bounds the implementation enforces."
+                    ),
+                )
+            )
+
+        panic_text = panics_section(function.doc_text)
+        if panic_text:
+            missing_panic_bounds = [
+                bound
+                for bound in (lower, upper)
+                if not number_token_present(panic_text, bound)
+            ]
+            if missing_panic_bounds:
+                findings.append(
+                    Finding(
+                        path=path,
+                        line=function.line,
+                        message=(
+                            f"`{function.name}` panics outside `{lower}..={upper}`, "
+                            "but its # Panics section omits bound(s): "
+                            f"{', '.join(missing_panic_bounds)}"
+                        ),
+                        fix=(
+                            "Document every panic condition from the range assertion "
+                            "inside # Panics."
+                        ),
+                    )
+                )
+
+    return findings
+
+
+def check_delegated_mesh_contracts(path: Path, function: RustFunction) -> list[Finding]:
+    """Check helpers that inherit `create_channel_mesh`'s panic contract."""
+    if function.name == "create_channel_mesh":
+        return []
+    if not function.doc_text:
+        return []
+    if not CREATE_CHANNEL_MESH_CALL_RE.search(function.masked_body):
+        return []
+
+    panic_text = panics_section(function.doc_text)
+    if not panic_text:
+        return [
+            Finding(
+                path=path,
+                line=function.line,
+                message=(
+                    f"`{function.name}` delegates to `create_channel_mesh`, whose "
+                    "accepted range is `2..=1000`, but its rustdoc has no # Panics "
+                    "section"
+                ),
+                fix=(
+                    "Add a # Panics section that documents the delegated mesh-size "
+                    "panic contract, including the `n > 1000` upper-bound case."
+                ),
+            )
+        ]
+
+    missing_panic_bounds = [
+        bound for bound in ("2", "1000") if not number_token_present(panic_text, bound)
+    ]
+    if not missing_panic_bounds:
+        return []
+
+    return [
+        Finding(
+            path=path,
+            line=function.line,
+            message=(
+                f"`{function.name}` delegates to `create_channel_mesh`, whose accepted "
+                "range is `2..=1000`, but its # Panics section omits bound(s): "
+                f"{', '.join(missing_panic_bounds)}"
+            ),
+            fix=(
+                "Document the delegated mesh-size panic contract, including the "
+                "`n > 1000` upper-bound case."
+            ),
+        )
+    ]
+
+
+def collect_rust_files(repo_root: Path, explicit_files: list[str]) -> list[Path]:
+    """Collect Rust files to scan."""
+    if explicit_files:
+        files = []
+        for raw_path in explicit_files:
+            path = Path(raw_path)
+            if not path.is_absolute():
+                path = repo_root / path
+            if path.suffix == ".rs" and path.exists():
+                files.append(path)
+        return sorted(set(files))
+
+    files: list[Path] = []
+    for dirname in SCAN_DIRS:
+        root = repo_root / dirname
+        if root.exists():
+            files.extend(root.rglob("*.rs"))
+    return sorted(files)
+
+
+def check_file(path: Path) -> list[Finding]:
+    """Check one Rust file."""
+    text = path.read_text(encoding="utf-8")
+    findings: list[Finding] = []
+    for function in iter_functions(text):
+        findings.extend(check_test_name_claims(path, function))
+        findings.extend(check_range_contracts(path, function))
+        findings.extend(check_delegated_mesh_contracts(path, function))
+    return findings
+
+
+def print_findings(repo_root: Path, findings: list[Finding]) -> None:
+    """Print findings with stable, repo-relative paths."""
+    for finding in findings:
+        rel_path = finding.path.relative_to(repo_root)
+        print("")
+        print(f"ERROR: {rel_path}:{finding.line}")
+        print(f"  {finding.message}.")
+        print(f"  Fix: {finding.fix}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Check Rust doc/test semantic claims against implementation clues."
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Optional Rust files to scan; defaults to src/, tests/, examples/, benches/.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the checker."""
+    args = build_parser().parse_args(argv)
+    repo_root = repo_root_from_script()
+    rust_files = collect_rust_files(repo_root, args.files)
+
+    findings: list[Finding] = []
+    for path in rust_files:
+        findings.extend(check_file(path))
+
+    if not findings:
+        print("SUCCESS: Rust semantic claims match checked implementation clues.")
+        return 0
+
+    print_findings(repo_root, findings)
+    print("")
+    print(f"FAILED: {len(findings)} Rust semantic claim mismatch(es) detected.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_agent_preflight.py
+++ b/scripts/tests/test_agent_preflight.py
@@ -38,6 +38,7 @@ CHECK_TRIGGER_CASES: list[tuple[str, str]] = [
     ("changelog-unreleased-rule", "CHANGELOG.md"),
     ("vale-advisory", "docs/index.md"),
     ("link-check", "README.md"),
+    ("doc-claims", "tests/common/channel_socket.rs"),
     ("advance-frame-error-handling", "tests/sessions/spectator.rs"),
     ("kani-violation-cost", "src/lib.rs"),
 ]
@@ -223,6 +224,31 @@ def test_plan_checks_runs_link_check_for_rust_files() -> None:
     """A .rs change triggers the link check (rustdoc intra-doc links)."""
     checks = plan_checks({"src/lib.rs"})
     assert "link-check" in _ids(checks)
+
+
+def test_plan_checks_runs_doc_claims_for_rust_files() -> None:
+    """A .rs change triggers Rust semantic-claim checks."""
+    checks = plan_checks({"src/lib.rs"})
+    doc_claims_check = next(c for c in checks if c.check_id == "doc-claims")
+    assert doc_claims_check.command == ["bash", "scripts/ci/check-doc-claims.sh"]
+
+
+@pytest.mark.parametrize(
+    "changed_file",
+    [
+        "scripts/ci/check-doc-claims.sh",
+        "scripts/hooks/check-rust-semantic-claims.py",
+    ],
+)
+def test_plan_checks_runs_doc_claims_for_doc_claims_tooling(
+    changed_file: str,
+) -> None:
+    """Semantic-claim tooling changes trigger the check they affect."""
+    checks = plan_checks({changed_file})
+    check_ids = _ids(checks)
+    doc_claims_check = next(c for c in checks if c.check_id == "doc-claims")
+    assert doc_claims_check.command == ["bash", "scripts/ci/check-doc-claims.sh"]
+    assert "advance-frame-error-handling" not in check_ids
 
 
 def test_plan_checks_skips_link_check_for_unrelated_files() -> None:

--- a/scripts/tests/test_check_rust_semantic_claims.py
+++ b/scripts/tests/test_check_rust_semantic_claims.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Tests for scripts/hooks/check-rust-semantic-claims.py."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECK_SOURCE = REPO_ROOT / "scripts" / "hooks" / "check-rust-semantic-claims.py"
+
+
+def _setup_repo(tmp_path: Path) -> Path:
+    """Create a temporary repo with the semantic-claim checker copied in."""
+    repo = tmp_path / "repo"
+    script_path = repo / "scripts" / "hooks" / CHECK_SOURCE.name
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(CHECK_SOURCE, script_path)
+    return repo
+
+
+def _write_rust(repo: Path, rel_path: str, content: str) -> Path:
+    """Write a Rust source fixture into the temporary repo."""
+    path = repo / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _run_checker(repo: Path) -> subprocess.CompletedProcess[str]:
+    """Run the copied semantic-claim checker in its temporary repo."""
+    return subprocess.run(
+        ["python3", "scripts/hooks/check-rust-semantic-claims.py"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_flags_diverges_test_name_with_empty_divergence_assertion(
+    tmp_path: Path,
+) -> None:
+    """A positive-divergence test name must not assert no divergence."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/peer_drop.rs",
+        "#[test]\n"
+        "fn stale_echo_diverges_across_survivors() {\n"
+        "    let divergences: Vec<u8> = Vec::new();\n"
+        "    assert!(divergences.is_empty());\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "says divergence is expected" in combined
+    assert "stale_echo_diverges_across_survivors" in combined
+
+
+def test_accepts_convergence_test_name_with_empty_divergence_assertion(
+    tmp_path: Path,
+) -> None:
+    """A convergence/no-divergence test name may assert no divergence."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/peer_drop.rs",
+        "#[test]\n"
+        "fn stale_echo_converges_across_survivors() {\n"
+        "    let divergences: Vec<u8> = Vec::new();\n"
+        "    assert!(divergences.is_empty());\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+
+
+def test_accepts_diverges_test_name_with_positive_divergence_assertion(
+    tmp_path: Path,
+) -> None:
+    """A positive-divergence test name may assert a non-empty divergence set."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/peer_drop.rs",
+        "#[test]\n"
+        "fn double_failure_diverges_across_survivors() {\n"
+        "    let divergences = vec![1_u8];\n"
+        "    assert!(!divergences.is_empty());\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+
+
+def test_accepts_mixed_oracle_with_no_divergence_and_positive_cases(
+    tmp_path: Path,
+) -> None:
+    """A non-vacuity oracle may assert clean and divergent subcases together."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/network/in_process_chaos.rs",
+        "#[test]\n"
+        "fn npeer_oracle_detects_divergence() {\n"
+        "    let divergence = None;\n"
+        "    assert_eq!(divergence, None);\n"
+        "    let divergence = Some((2, 2));\n"
+        "    assert_eq!(divergence, Some((2, 2)));\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+
+
+def test_accepts_negative_divergence_name_with_no_divergence_assertion(
+    tmp_path: Path,
+) -> None:
+    """A name that explicitly says without/no divergence is not a positive claim."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "src/sessions/p2p_spectator_session.rs",
+        "#[test]\n"
+        "fn pending_failover_without_divergence() {\n"
+        "    assert!(session.spectator_divergence.is_none());\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+
+
+def test_flags_divergence_noun_test_name_with_absent_divergence_assertion(
+    tmp_path: Path,
+) -> None:
+    """A noun-form divergence test name must not assert no divergence."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "src/sessions/p2p_spectator_session.rs",
+        "#[test]\n"
+        "fn spectator_nonoverlapping_region_divergence() {\n"
+        "    assert!(session.spectator_divergence.is_none());\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "spectator_nonoverlapping_region_divergence" in combined
+
+
+def test_ignores_positive_divergence_assertions_inside_non_code(
+    tmp_path: Path,
+) -> None:
+    """Comments and strings must not satisfy positive-divergence claims."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/peer_drop.rs",
+        "#[test]\n"
+        "fn stale_echo_diverges_across_survivors() {\n"
+        "    let divergences: Vec<u8> = Vec::new();\n"
+        "    let _ = \"assert!(!divergences.is_empty());\";\n"
+        "    // assert!(!divergences.is_empty());\n"
+        "    assert!(divergences.is_empty());\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "says divergence is expected" in combined
+    assert "stale_echo_diverges_across_survivors" in combined
+
+
+def test_flags_inclusive_range_assertion_missing_upper_bound_in_docs(
+    tmp_path: Path,
+) -> None:
+    """Rustdoc contracts must document both bounds from inclusive assertions."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/common/channel_socket.rs",
+        "/// Creates a mesh.\n"
+        "///\n"
+        "/// # Arguments\n"
+        "///\n"
+        "/// * `n` - The number of peers in the mesh (must be `>= 2`).\n"
+        "///\n"
+        "/// # Panics\n"
+        "///\n"
+        "/// Panics if `n < 2`.\n"
+        "pub fn create_channel_mesh(n: usize) {\n"
+        "    assert!((2..=1000).contains(&n));\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "asserts `n` is in `2..=1000`" in combined
+    assert "# Panics section omits bound(s): 1000" in combined
+
+
+def test_ignores_range_assertions_inside_non_code(tmp_path: Path) -> None:
+    """Comments and strings must not trigger range-contract checks."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/common/channel_socket.rs",
+        "/// Creates a mesh.\n"
+        "pub fn create_channel_mesh(n: usize) {\n"
+        "    let _ = \"assert!((2..=1000).contains(&n));\";\n"
+        "    // assert!((2..=1000).contains(&n));\n"
+        "    let _ = n;\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+
+
+def test_flags_delegated_channel_mesh_panic_docs_missing_upper_bound(
+    tmp_path: Path,
+) -> None:
+    """Delegating helpers must document inherited mesh-size panic bounds."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/common/channel_socket.rs",
+        "/// Creates a mesh.\n"
+        "///\n"
+        "/// # Panics\n"
+        "///\n"
+        "/// Panics if fewer than 2 configs are provided.\n"
+        "pub fn create_chaos_channel_mesh(configs: &[u8]) {\n"
+        "    let _ = create_channel_mesh(configs.len());\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "delegates to `create_channel_mesh`" in combined
+    assert "omits bound(s): 1000" in combined
+
+
+def test_flags_delegated_channel_mesh_panic_docs_missing_panics_section(
+    tmp_path: Path,
+) -> None:
+    """Delegating helpers must have a # Panics section for inherited bounds."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/common/channel_socket.rs",
+        "/// Creates a mesh.\n"
+        "pub fn create_chaos_channel_mesh(configs: &[u8]) {\n"
+        "    let _ = create_channel_mesh(configs.len());\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "delegates to `create_channel_mesh`" in combined
+    assert "has no # Panics section" in combined
+
+
+def test_ignores_delegated_channel_mesh_calls_inside_non_code(
+    tmp_path: Path,
+) -> None:
+    """Comments and strings must not trigger delegated mesh-contract checks."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/common/channel_socket.rs",
+        "/// Creates a mesh.\n"
+        "pub fn create_chaos_channel_mesh(configs: &[u8]) {\n"
+        "    let _ = \"create_channel_mesh(configs.len())\";\n"
+        "    // create_channel_mesh(configs.len());\n"
+        "    let _ = configs;\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+
+
+def test_accepts_inclusive_range_assertion_with_complete_docs(
+    tmp_path: Path,
+) -> None:
+    """Rustdoc contracts pass when argument and panic docs name both bounds."""
+    repo = _setup_repo(tmp_path)
+    _write_rust(
+        repo,
+        "tests/common/channel_socket.rs",
+        "/// Creates a mesh.\n"
+        "///\n"
+        "/// # Arguments\n"
+        "///\n"
+        "/// * `n` - The number of peers in the mesh (must be in `2..=1000`).\n"
+        "///\n"
+        "/// # Panics\n"
+        "///\n"
+        "/// Panics if `n` is outside `2..=1000`.\n"
+        "pub fn create_channel_mesh(n: usize) {\n"
+        "    assert!((2..=1000).contains(&n));\n"
+        "}\n",
+    )
+
+    result = _run_checker(repo)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined

--- a/scripts/tests/test_ci_regex_portability.py
+++ b/scripts/tests/test_ci_regex_portability.py
@@ -10,6 +10,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOC_CLAIMS_SOURCE = REPO_ROOT / "scripts" / "ci" / "check-doc-claims.sh"
 DERIVE_BOUNDS_SOURCE = REPO_ROOT / "scripts" / "ci" / "check-derive-bounds.sh"
+RUST_SEMANTIC_CLAIMS_SOURCE = (
+    REPO_ROOT / "scripts" / "hooks" / "check-rust-semantic-claims.py"
+)
 
 
 def _setup_repo_with_script(tmp_path: Path, script_source: Path) -> tuple[Path, Path]:
@@ -18,6 +21,10 @@ def _setup_repo_with_script(tmp_path: Path, script_source: Path) -> tuple[Path, 
     script_path = repo / "scripts" / "ci" / script_source.name
     script_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(script_source, script_path)
+    if script_source == DOC_CLAIMS_SOURCE:
+        hook_path = repo / "scripts" / "hooks" / RUST_SEMANTIC_CLAIMS_SOURCE.name
+        hook_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(RUST_SEMANTIC_CLAIMS_SOURCE, hook_path)
     return repo, script_path
 
 

--- a/scripts/tests/test_workflow_script_executability.py
+++ b/scripts/tests/test_workflow_script_executability.py
@@ -25,6 +25,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS_DIR = PROJECT_ROOT / ".github" / "workflows"
@@ -133,6 +134,67 @@ def _discover_workflow_script_pairs() -> list[tuple[Path, str, int]]:
 DISCOVERED_PAIRS: list[tuple[Path, str, int]] = _discover_workflow_script_pairs()
 
 
+def _run_step_id(workflow: Path, job_name: str, step_index: int, step: dict) -> str:
+    """Return a stable test ID for a workflow step."""
+    step_name = step.get("name", f"step-{step_index}")
+    return f"{workflow.name}:{job_name}:{step_name}"
+
+
+def _iter_workflow_run_steps() -> list[tuple[Path, str, int, dict, str]]:
+    """Return every workflow step with a shell ``run:`` body."""
+    steps: list[tuple[Path, str, int, dict, str]] = []
+    if not WORKFLOWS_DIR.is_dir():
+        return steps
+
+    for workflow in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        try:
+            data = yaml.safe_load(workflow.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as error:
+            raise AssertionError(f"Failed to parse {workflow}: {error}") from error
+
+        jobs = data.get("jobs", {})
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            job_steps = job.get("steps", [])
+            if not isinstance(job_steps, list):
+                continue
+            for step_index, step in enumerate(job_steps, start=1):
+                if not isinstance(step, dict):
+                    continue
+                run = step.get("run")
+                if isinstance(run, str):
+                    steps.append((workflow, str(job_name), step_index, step, run))
+    return steps
+
+
+def _uses_tee_pipeline(run: str) -> bool:
+    """Return true when a run block pipes command output through ``tee``."""
+    return re.search(r"(?<!\|)\|\s*tee\b", run) is not None
+
+
+def _has_pipefail(run: str) -> bool:
+    """Return true when the run block enables Bash pipefail."""
+    return (
+        re.search(r"(?m)^\s*set\s+-[A-Za-z]*o\s+pipefail\b", run) is not None
+    )
+
+
+def _explicitly_handles_pipeline_status(run: str) -> bool:
+    """Return true when the run block intentionally handles command status."""
+    return (
+        "PIPESTATUS[0]" in run
+        or re.search(r"(?<!\|)\|\s*tee\b[^\n]*\|\|\s*true\b", run) is not None
+    )
+
+
+TEE_RUN_STEPS: list[tuple[Path, str, int, dict, str]] = [
+    step for step in _iter_workflow_run_steps() if _uses_tee_pipeline(step[4])
+]
+
+
 def _pair_id(triple: tuple[Path, str, int]) -> str:
     workflow, script, line = triple
     return f"{workflow.name}:{line}->{script}"
@@ -180,4 +242,29 @@ def test_workflow_script_is_executable_in_git_index(
         f"{workflow_path.relative_to(PROJECT_ROOT)}:{line_number} as "
         f"./{script_path}) has git-index mode {mode}, expected 100755. "
         f"Fix with: git update-index --chmod=+x {script_path}"
+    )
+
+
+@pytest.mark.parametrize(
+    "workflow_path,job_name,step_index,step,run",
+    TEE_RUN_STEPS,
+    ids=[
+        _run_step_id(workflow, job, index, step)
+        for workflow, job, index, step, _ in TEE_RUN_STEPS
+    ],
+)
+def test_workflow_tee_pipelines_preserve_command_failure(
+    workflow_path: Path,
+    job_name: str,
+    step_index: int,
+    step: dict,
+    run: str,
+) -> None:
+    """Workflow ``tee`` pipelines must not mask the piped command's exit code."""
+    assert _has_pipefail(run) or _explicitly_handles_pipeline_status(run), (
+        f"{workflow_path.relative_to(PROJECT_ROOT)} job {job_name!r} "
+        f"step {step.get('name', step_index)!r} pipes through tee without "
+        "preserving the command exit status. Add `set -o pipefail`, read "
+        "`PIPESTATUS[0]`, or make intentional advisory behavior explicit with "
+        "`|| true`."
     )

--- a/scripts/verification/verify-tla.sh
+++ b/scripts/verification/verify-tla.sh
@@ -63,6 +63,7 @@ SPECS=(
     "NPeerReactivation"
     "FreezeConvergence"
     "FrameAdvantageAggregation"
+    "DoubleFailureRelay"
 )
 
 # Track results

--- a/specs/tla/DoubleFailureRelay.cfg
+++ b/specs/tla/DoubleFailureRelay.cfg
@@ -1,0 +1,50 @@
+SPECIFICATION Spec
+
+\* DEFAULT config — the SOUND fix (candidate #3, "MeshAgree"): a survivor advances
+\* confirmation of a not-yet-mesh-agreed dropped slot only to the MESH-ACKED FLOOR
+\* (the min, over every alive peer reachable on a live link, of that peer's CURRENT
+\* freeze floor read via a fresh ack — NOT the possibly-stale per-endpoint cache),
+\* holds entirely while partitioned, and excludes the slot to MAX only once its
+\* freeze has fully converged. It therefore never irreversibly discards a frame a
+\* peer froze lower or a delayed relay could lower. Registered in verify-tla.sh;
+\* PASSES both the safety invariants AND the liveness property (~865K distinct
+\* states, ~2 min single worker).
+\*
+\* Bounds rationale (this repo's devcontainer, single TLC worker as
+\* verify-tla.sh / CI runs it):
+\* - SURVIVORS = {a, b, c}: three is the MINIMUM that exhibits the residual —
+\*   a victim (us), a dying global-min ORIGIN, and a RELAY survivor. The dropped
+\*   slot D is modeled by recvThrough, not a fourth survivor (it never observes).
+\* - MAX_FRAME = 3 with WINDOW = 1 is the smallest pair that makes an
+\*   irreversibly-DISCARDED contested frame reachable: a locked-and-contested
+\*   frame g needs GlobalMin < g < bound - WINDOW, i.e. M >= F + WINDOW + 2; with
+\*   WINDOW = 1 that is M - F >= 3, reachable at F = 0, M = 3 (frame 1 contested
+\*   and locked). Smaller bounds make the Baseline violation unreachable (vacuous).
+\* - RECEIPTS = {0, 3}: the load-bearing low/high asymmetry (global-min F = 0,
+\*   high receipt M = 3 = MAX_FRAME). Restricting receipts to the two extremes
+\*   (vs the full 0..MAX_FRAME) keeps the model tractable while preserving every
+\*   reachable freeze/lock interaction; widening RECEIPTS only adds intermediate
+\*   freeze frames the fix treats uniformly.
+\* - Links are chosen freely at Init (any post-warmup partition) and only HEAL
+\*   (monotone-up; no Block action), so the network stabilizes by construction —
+\*   the liveness obligation stays a plain `<>[]` checked under WEAK fairness
+\*   (strong fairness over this many actions blows up TLC's liveness tableau).
+\* - No SYMMETRY: the liveness property ConfirmationProgresses is checked and
+\*   TLC symmetry reduction is unsound for liveness.
+CONSTANT SURVIVORS = {a, b, c}
+CONSTANT MAX_FRAME = 3
+CONSTANT NULL_FRAME = 999
+CONSTANT WINDOW = 1
+CONSTANT RECEIPTS = {0, 3}
+CONSTANT FIX_MODE = "MeshAgree"
+
+\* Safety invariants
+INVARIANT TypeInvariant
+INVARIANT NoConfirmedDivergence
+INVARIANT LockedRecordMatchesFreeze
+INVARIANT FreezeNeverBelowGlobalMin
+INVARIANT RecordedSourceInRange
+
+\* Liveness: every alive survivor eventually reaches a stable fully-confirmed
+\* fixpoint for the dropped slot (requires the WF assumptions in Spec).
+PROPERTY ConfirmationProgresses

--- a/specs/tla/DoubleFailureRelay.tla
+++ b/specs/tla/DoubleFailureRelay.tla
@@ -38,7 +38,7 @@
 (* The S41 write-up records three candidate fixes and the project rule "no    *)
 (* partial fix shipped — a partial fix regresses liveness." This module turns  *)
 (* the prose arbitration into a machine-checked one. The confirmation rule is  *)
-(* a CONSTANT `FIX_MODE` with three values, each exercised by its own .cfg:    *)
+(* a CONSTANT `FIX_MODE` with four values, each exercised by its own .cfg:     *)
 (*                                                                          *)
 (*   - "Baseline"  — current production (prune the dead origin from the fold,  *)
 (*                   confirm/discard on the surviving stale-high cache). The   *)
@@ -75,6 +75,24 @@
 (*                   registered in verify-tla.sh) and the design a future        *)
 (*                   production red-green cycle should implement (a per-slot     *)
 (*                   ack/epoch on connect-status gossip).                       *)
+(*                                                                          *)
+(*   - "InheritedFloor" — candidate fix #4 (the CACHE-ONLY / NO-WIRE shortcut): *)
+(*                   the cheapest, most TEMPTING design — snapshot a departed     *)
+(*                   connected source's last cached low term (bounding the        *)
+(*                   confirm target AND the freeze), release it only on FRESH     *)
+(*                   gossip from every remaining alive peer reporting the slot     *)
+(*                   connected above it. No wire change, no peer-receipt oracle.   *)
+(*                   MACHINE-DISPROVEN UNSOUND: NoConfirmedDivergence is VIOLATED  *)
+(*                   via the CORROBORATE-THEN-DROP race (a peer corroborates       *)
+(*                   "healthy", the observer releases, then that peer drops the    *)
+(*                   slot low while its disconnect gossip is still in flight, so   *)
+(*                   the observer confirms+locks real inputs above the freeze).    *)
+(*                   Passive gossip corroboration is point-in-time and reversible  *)
+(*                   by the corroborator's own later drop, so NO cache-only        *)
+(*                   release is sound — the formal proof that the fix needs a      *)
+(*                   FRESH-ACK ROUND + DROP-EPOCH, not passive gossip. (Run via    *)
+(*                   DoubleFailureRelay_InheritedFloor.cfg — expected to FAIL on   *)
+(*                   safety; the third documented dead-end, the no-wire shortcut.) *)
 (*                                                                          *)
 (* Properties:                                                              *)
 (*   - Safety: NoConfirmedDivergence — no two alive survivors ever hold        *)
@@ -119,14 +137,18 @@
 (*     rather than as a concrete ack-round wire format; the wire format is the  *)
 (*     production design choice this proof informs, not constrains.            *)
 (*                                                                          *)
-(* SCOPE OF THE THREE RESULTS (honest bounds — what each claim does and does NOT *)
+(* SCOPE OF THE FOUR RESULTS (honest bounds — what each claim does and does NOT  *)
 (* prove; established in an adversarial faithfulness review):                    *)
 (*                                                                          *)
 (*   - The NEGATIVE results are UNCONDITIONAL within the modeled world. Baseline  *)
-(*     -unsafe and Tombstone-illiveness are demonstrated by REACHABLE             *)
-(*     counterexamples, and every abstraction here is conservative (it makes the  *)
-(*     model safer/more-restrictive than production), so a reachable violation is *)
-(*     a real one. These two are the load-bearing arbitration outcomes.          *)
+(*     -unsafe, Tombstone-illiveness, and InheritedFloor-unsafe are demonstrated  *)
+(*     by REACHABLE counterexamples, and every abstraction here is conservative   *)
+(*     (it makes the model safer/more-restrictive than production), so a reachable *)
+(*     violation is a real one. These three are the load-bearing arbitration       *)
+(*     outcomes: they rule out, respectively, doing nothing, the dead-survivor     *)
+(*     tombstone (liveness), and the cache-only no-wire shortcut (safety, via the  *)
+(*     corroborate-then-drop race) — establishing that the sound fix needs a       *)
+(*     fresh-ack ROUND + drop-epoch, not passive gossip.                          *)
 (*                                                                          *)
 (*   - The POSITIVE result (MeshAgree sound) is proven for the AGGREGATION RULE   *)
 (*     under two idealizing assumptions that the production fix must additionally *)
@@ -165,14 +187,14 @@ CONSTANTS
     NULL_FRAME,    \* sentinel "no frame" (-1 in impl)
     WINDOW,        \* prediction window: frames > bound - WINDOW are still re-rollable
     RECEIPTS,      \* allowed per-survivor receipts of the dropped slot (adversarial at Init)
-    FIX_MODE       \* "Baseline" | "Tombstone" | "MeshAgree"
+    FIX_MODE       \* "Baseline" | "Tombstone" | "MeshAgree" | "InheritedFloor"
 
 ASSUME SURVIVORS # {}
 ASSUME MAX_FRAME \in Nat /\ MAX_FRAME > 0
 ASSUME NULL_FRAME \notin 0..MAX_FRAME
 ASSUME WINDOW \in Nat /\ WINDOW >= 1
 ASSUME RECEIPTS \subseteq (0..MAX_FRAME) /\ RECEIPTS # {}
-ASSUME FIX_MODE \in {"Baseline", "Tombstone", "MeshAgree"}
+ASSUME FIX_MODE \in {"Baseline", "Tombstone", "MeshAgree", "InheritedFloor"}
 
 Frame == {NULL_FRAME} \union (0..MAX_FRAME)
 
@@ -192,10 +214,19 @@ VARIABLES
     cacheLast,     \* [SURVIVORS -> [SURVIVORS -> Frame]]: cacheLast[obs][src] = obs's cache of src's D last_frame
     link,          \* [SURVIVORS -> [SURVIVORS -> BOOLEAN]]: link[src][obs] = src->obs gossip flows
     bound,         \* [SURVIVORS -> Frame]: confirmed high-water for D (NULL = nothing confirmed)
-    recSrc         \* [SURVIVORS -> [0..MAX_FRAME -> Frame]]: recorded source frame per committed frame
+    recSrc,        \* [SURVIVORS -> [0..MAX_FRAME -> Frame]]: recorded source frame per committed frame
+    floor,         \* [SURVIVORS -> Frame] (InheritedFloor mode): inherited freeze-floor commitment
+                   \*   (NULL = none). While non-NULL, s must not confirm D past floor[s]. Snapshotted
+                   \*   SYNCHRONOUSLY when a CONNECTED folded source leaves s's fold (Die), from that
+                   \*   source's last cached term — the production "do not forget a departed low term."
+    corrob         \* [SURVIVORS -> [SURVIVORS -> BOOLEAN]] (InheritedFloor mode): corrob[s][o] = since
+                   \*   floor[s] was armed, o sent s FRESH gossip (a Gossip event, NOT a stale cache read)
+                   \*   reporting D CONNECTED above floor[s]. Releasing floor[s] requires every alive
+                   \*   folded source to corroborate — the event-driven "fresh ack" that closes the
+                   \*   S42 instantaneous-ack idealization without reading any peer's true receipt.
 
 vars == <<recvThrough, alive, localDisc, localFrame, cacheDisc, cacheLast,
-          link, bound, recSrc>>
+          link, bound, recSrc, floor, corrob>>
 
 (***************************************************************************)
 (* Min over a non-empty set of integers. CHOOSE ranges over integer frame    *)
@@ -331,8 +362,46 @@ MeshAgreeTarget(s) ==
     \* could still converge below).
     ELSE Min2(BaselineTarget(s), MeshAckedFloor(s))
 
+(***************************************************************************)
+(* Candidate fix #4 ("InheritedFloor"): the CACHE-ONLY / NO-WIRE / PASSIVE-          *)
+(* CORROBORATION variant — the cheapest, most TEMPTING design, MACHINE-DISPROVEN      *)
+(* UNSOUND here (run DoubleFailureRelay_InheritedFloor.cfg: `NoConfirmedDivergence`    *)
+(* VIOLATED). It is retained as the THIRD documented dead-end (alongside _Baseline,    *)
+(* a safety dead-end, and _Tombstone, a liveness dead-end) precisely because it looks   *)
+(* so plausible: it needs no wire-format change and no peer-receipt oracle.             *)
+(*                                                                                      *)
+(* The design reads ONLY the possibly-stale per-endpoint CACHE (`BaselineTarget`) plus  *)
+(* two pieces of LOCAL receiver state:                                                  *)
+(*   1. ARM (synchronous): the instant a CONNECTED folded source leaves a survivor's     *)
+(*      fold (Die), snapshot that source's last cached term into `floor[s]` (folded into  *)
+(*      BOTH the confirm target here AND the freeze via `QueueMin`) — "do not forget a     *)
+(*      departed low term." This part is fine and race-free.                              *)
+(*   2. RELEASE (event-driven): `floor[s]` lifts when EVERY alive folded source has        *)
+(*      delivered FRESH `Gossip` (tracked in `corrob`) reporting D CONNECTED above it.      *)
+(*                                                                                          *)
+(* WHY IT FAILS — the CORROBORATE-THEN-DROP race: a peer can gossip {connected, high}        *)
+(* (corroborating "healthy", releasing the observer's floor) and then DETECT THE DROP        *)
+(* itself and freeze the slot LOW, with its disconnect gossip still in flight — so the        *)
+(* observer, having already released, confirms+LOCKS the slot's real inputs above the         *)
+(* eventual freeze before the drop reaches it (the residual, un-fixed). The obstruction is     *)
+(* INTRINSIC: a cache LAGS the corroborator's own in-flight drop, so a passive release acts on  *)
+(* info already stale at the source. Disproven here for the natural rule and (in the adversarial *)
+(* review) for the strongest variants — re-validate-against-current-cache, never-release         *)
+(* (= Tombstone liveness), speculative-bound, link-reachability-hold, local generation counter   *)
+(* — each falling to the same race or to liveness. This is the evidence that the                  *)
+(* production fix needs a FRESH-ACK ROUND (request/response held until the ack postdates the      *)
+(* observer's intent to advance) + a per-slot DROP-EPOCH commitment — the MeshAgree direction      *)
+(* (the default), whose aggregation this module proves sound under exactly the instantaneous        *)
+(* -fresh-ack idealization that ack round must discharge.                                            *)
+(***************************************************************************)
+InheritedFloorTarget(s) ==
+    IF floor[s] = NULL_FRAME THEN BaselineTarget(s)
+    ELSE Min2(BaselineTarget(s), floor[s])
+
 BoundTarget(s) ==
-    IF FIX_MODE = "MeshAgree" THEN MeshAgreeTarget(s) ELSE BaselineTarget(s)
+    CASE FIX_MODE = "MeshAgree"      -> MeshAgreeTarget(s)
+      [] FIX_MODE = "InheritedFloor" -> InheritedFloorTarget(s)
+      [] OTHER                       -> BaselineTarget(s)
 
 (***************************************************************************)
 (* The value (recorded SOURCE frame) survivor s writes for the dropped slot at  *)
@@ -355,6 +424,8 @@ TypeInvariant ==
     /\ link \in [SURVIVORS -> [SURVIVORS -> BOOLEAN]]
     /\ bound \in [SURVIVORS -> Frame]
     /\ recSrc \in [SURVIVORS -> [0..MAX_FRAME -> Frame]]
+    /\ floor \in [SURVIVORS -> Frame]
+    /\ corrob \in [SURVIVORS -> [SURVIVORS -> BOOLEAN]]
 
 (***************************************************************************)
 (* Initial state. The warmup phase (repro Phase 1: all links open, all survivors *)
@@ -382,6 +453,8 @@ Init ==
     /\ \A s \in SURVIVORS : link[s][s]
     /\ bound = [s \in SURVIVORS |-> NULL_FRAME]
     /\ recSrc = [s \in SURVIVORS |-> [g \in 0..MAX_FRAME |-> NULL_FRAME]]
+    /\ floor = [s \in SURVIVORS |-> NULL_FRAME]
+    /\ corrob = [o \in SURVIVORS |-> [s \in SURVIVORS |-> FALSE]]
 
 (***************************************************************************)
 (* Action: src gossips its CURRENT local view of the dropped slot to obs        *)
@@ -408,7 +481,17 @@ Gossip(src, obs) ==
                       ELSE cf                               \* connected report, cache disc: no resurrect
        IN /\ cacheDisc' = [cacheDisc EXCEPT ![obs][src] = newDisc]
           /\ cacheLast' = [cacheLast EXCEPT ![obs][src] = newLast]
-    /\ UNCHANGED <<recvThrough, alive, localDisc, localFrame, link, bound, recSrc>>
+          \* InheritedFloor: a FRESH connected-above-floor delivery corroborates that
+          \* `src`'s slot is healthy above obs's armed floor (event-driven, post-merge:
+          \* a reordered stale connected packet that the merge rejects sets newDisc/newLast
+          \* unchanged, so it cannot falsely corroborate a converged-disconnect cache).
+          /\ corrob' = IF /\ FIX_MODE = "InheritedFloor"
+                          /\ floor[obs] # NULL_FRAME
+                          /\ ~newDisc
+                          /\ newLast > floor[obs]
+                       THEN [corrob EXCEPT ![obs][src] = TRUE]
+                       ELSE corrob
+    /\ UNCHANGED <<recvThrough, alive, localDisc, localFrame, link, bound, recSrc, floor>>
 
 (***************************************************************************)
 (* Action: src directly concludes the dropped slot disconnected (an explicit    *)
@@ -417,17 +500,31 @@ Gossip(src, obs) ==
 (* remove_player(D) on a survivor.                                              *)
 (***************************************************************************)
 QueueMin(s) ==
-    LET folded == FoldedSources(s)
-        base   == recvThrough[s]
-    IN IF folded = {}
-       THEN base
-       ELSE Min2(base, MinI({cacheLast[s][o] : o \in folded}))
+    LET folded   == FoldedSources(s)
+        base     == recvThrough[s]
+        cacheMin == IF folded = {}
+                    THEN base
+                    ELSE Min2(base, MinI({cacheLast[s][o] : o \in folded}))
+    IN \* InheritedFloor: the inherited floor is a departed CONNECTED source's low term
+       \* that the live fold no longer carries; it must mine the FREEZE down too (not just
+       \* cap the confirm bound), else a survivor that detects the drop itself freezes
+       \* ABOVE the departed origin's term and its discarded frames diverge. With the
+       \* floor folded here, the resulting freeze is always <= floor, so the post-freeze
+       \* subsume is safe.
+       IF FIX_MODE = "InheritedFloor" /\ floor[s] # NULL_FRAME
+       THEN Min2(cacheMin, floor[s])
+       ELSE cacheMin
 
 DetectDrop(s) ==
     /\ alive[s]
     /\ ~localDisc[s]
     /\ localDisc' = [localDisc EXCEPT ![s] = TRUE]
     /\ localFrame' = [localFrame EXCEPT ![s] = QueueMin(s)]
+    \* InheritedFloor: once s has its own disconnect view of D, the real freeze + frozen
+    \* value govern, so the pre-disconnect connected-term floor is obsolete (subsumed).
+    /\ floor' = IF FIX_MODE = "InheritedFloor" THEN [floor EXCEPT ![s] = NULL_FRAME] ELSE floor
+    /\ corrob' = IF FIX_MODE = "InheritedFloor"
+                 THEN [corrob EXCEPT ![s] = [x \in SURVIVORS |-> FALSE]] ELSE corrob
     /\ UNCHANGED <<recvThrough, alive, cacheDisc, cacheLast, link, bound, recSrc>>
 
 (***************************************************************************)
@@ -438,6 +535,32 @@ Die(s) ==
     /\ alive[s]
     /\ Cardinality({o \in SURVIVORS : alive[o]}) > 1   \* never empty the mesh
     /\ alive' = [alive EXCEPT ![s] = FALSE]
+    \* InheritedFloor ARM (synchronous with the death — the race-free core): every
+    \* surviving observer o that still folded s as a CONNECTED source snapshots s's
+    \* last cached term into floor[o], so the bound cannot jump up when s leaves the
+    \* fold. `~cacheDisc[o][s]` (s connected in o's cache) implies o is not yet
+    \* mesh-agreed, so this only arms while the slot is still contested.
+    \* Arm only for observers that have NOT yet detected the drop themselves
+    \* (`~localDisc[o]`): one that already has its own disconnect view froze its slot
+    \* while s was still folded, so it missed no term and an armed floor would only
+    \* (wrongly) pin its confirmation below the living floor forever.
+    /\ floor' = IF FIX_MODE = "InheritedFloor"
+                THEN [o \in SURVIVORS |->
+                       IF o # s /\ alive[o] /\ ~localDisc[o] /\ ~cacheDisc[o][s]
+                       THEN IF floor[o] = NULL_FRAME
+                            THEN cacheLast[o][s]
+                            ELSE Min2(floor[o], cacheLast[o][s])
+                       ELSE floor[o]]
+                ELSE floor
+    \* A (re)arm to a fresh-or-strictly-lower floor resets corroboration: the
+    \* remaining alive peers must freshly re-corroborate against the new floor.
+    /\ corrob' = IF FIX_MODE = "InheritedFloor"
+                 THEN [o \in SURVIVORS |->
+                        IF /\ o # s /\ alive[o] /\ ~localDisc[o] /\ ~cacheDisc[o][s]
+                           /\ (floor[o] = NULL_FRAME \/ cacheLast[o][s] < floor[o])
+                        THEN [x \in SURVIVORS |-> FALSE]
+                        ELSE corrob[o]]
+                 ELSE corrob
     /\ UNCHANGED <<recvThrough, localDisc, localFrame, cacheDisc, cacheLast,
                    link, bound, recSrc>>
 
@@ -461,7 +584,7 @@ Unblock(src, dst) ==
     /\ ~link[src][dst]
     /\ link' = [link EXCEPT ![src][dst] = TRUE]
     /\ UNCHANGED <<recvThrough, alive, localDisc, localFrame, cacheDisc,
-                   cacheLast, bound, recSrc>>
+                   cacheLast, bound, recSrc, floor, corrob>>
 
 (***************************************************************************)
 (* Action: update_player_disconnects — fold the caches, and if the dropped      *)
@@ -489,6 +612,14 @@ UpdateDisconnects(s) ==
                         /\ ~Locked(s, g)                  \* still re-rollable (not discarded)
                      THEN newFrame                        \* re-roll to frozen value
                      ELSE recSrc[s][g]]]
+          \* InheritedFloor SUBSUME: once s has folded a disconnect and converged its
+          \* own freeze, the real freeze (<= floor, carried by the relay that triggers
+          \* this) governs the slot; the connected-term floor is obsolete and lifts so
+          \* the slot can later mesh-agree-exclude (avoids capping below the exclusion).
+          /\ floor' = IF FIX_MODE = "InheritedFloor"
+                      THEN [floor EXCEPT ![s] = NULL_FRAME] ELSE floor
+          /\ corrob' = IF FIX_MODE = "InheritedFloor"
+                       THEN [corrob EXCEPT ![s] = [x \in SURVIVORS |-> FALSE]] ELSE corrob
     /\ UNCHANGED <<recvThrough, alive, cacheDisc, cacheLast, link, bound>>
 
 (***************************************************************************)
@@ -510,7 +641,26 @@ AdvanceConfirm(s) ==
                      THEN RecordValue(s, g)
                      ELSE recSrc[s][g]]]
     /\ UNCHANGED <<recvThrough, alive, localDisc, localFrame, cacheDisc,
-                   cacheLast, link>>
+                   cacheLast, link, floor, corrob>>
+
+(***************************************************************************)
+(* Action (InheritedFloor mode): RELEASE the inherited floor once EVERY alive       *)
+(* folded source has freshly corroborated D connected above it — positive,           *)
+(* event-driven proof the departed peer was a benign laggard, so confirmation may     *)
+(* resume past the floor. A survivor partitioned from a peer it needs never collects   *)
+(* that peer's corroboration, so it cannot release and HOLDS (the production           *)
+(* partition-hold); WF on Gossip+Unblock guarantees the corroborations eventually      *)
+(* arrive (or the peer dies and leaves the fold), so the hold is bounded.              *)
+(***************************************************************************)
+ReleaseFloor(s) ==
+    /\ FIX_MODE = "InheritedFloor"
+    /\ alive[s]
+    /\ floor[s] # NULL_FRAME
+    /\ \A o \in FoldedSources(s) : corrob[s][o]   \* all alive folded peers corroborated
+    /\ floor' = [floor EXCEPT ![s] = NULL_FRAME]
+    /\ corrob' = [corrob EXCEPT ![s] = [x \in SURVIVORS |-> FALSE]]
+    /\ UNCHANGED <<recvThrough, alive, localDisc, localFrame, cacheDisc, cacheLast,
+                   link, bound, recSrc>>
 
 Next ==
     \/ \E src, obs \in SURVIVORS : Gossip(src, obs)
@@ -519,6 +669,7 @@ Next ==
     \/ \E src, dst \in SURVIVORS : Unblock(src, dst)
     \/ \E s \in SURVIVORS : UpdateDisconnects(s)
     \/ \E s \in SURVIVORS : AdvanceConfirm(s)
+    \/ \E s \in SURVIVORS : ReleaseFloor(s)
 
 (***************************************************************************)
 (* Fairness for the liveness property. WEAK fairness suffices because partitions    *)
@@ -538,6 +689,7 @@ Fairness ==
     /\ \A src, obs \in SURVIVORS : WF_vars(Gossip(src, obs))
     /\ \A s \in SURVIVORS : WF_vars(UpdateDisconnects(s))
     /\ \A s \in SURVIVORS : WF_vars(AdvanceConfirm(s))
+    /\ \A s \in SURVIVORS : WF_vars(ReleaseFloor(s))
     /\ WF_vars(\E src, dst \in SURVIVORS : Unblock(src, dst))
 
 Spec == Init /\ [][Next]_vars /\ Fairness

--- a/specs/tla/DoubleFailureRelay.tla
+++ b/specs/tla/DoubleFailureRelay.tla
@@ -1,0 +1,667 @@
+----------------------------- MODULE DoubleFailureRelay -----------------------------
+(***************************************************************************)
+(* TLA+ arbitration of the "double-failure relay" residual — the single    *)
+(* remaining potential-desync item in N-PLAYER-DESYNC-AUDIT.md (arbitrated  *)
+(* REAL, fix deferred-with-spec, in Session 41).                            *)
+(*                                                                          *)
+(* WHAT THIS MODELS (and why it is the companion to FreezeConvergence.tla)   *)
+(*                                                                          *)
+(* FreezeConvergence.tla proves that ONCE every survivor converges to the    *)
+(* global-min agreed freeze frame F, the dropped slot's reported stream is    *)
+(* byte-identical (no desync). It assumes the frozen value is always          *)
+(* re-rollable (InputQueue::set_frozen_value_at) — it abstracts away the      *)
+(* prediction WINDOW and the IRREVERSIBLE DISCARD of confirmed frames below   *)
+(* the window floor, and it abstracts away FOLD MEMBERSHIP (which survivors a  *)
+(* given peer can still "see").                                              *)
+(*                                                                          *)
+(* The double-failure relay residual lives in exactly those two abstracted    *)
+(* gaps. The S32 "freeze barrier" bounds each survivor's confirmed frame for a *)
+(* dropping slot by the mesh-gossip minimum (`remote_slot_confirmed_bound`),  *)
+(* and BOTH that bound and the freeze override (`update_player_disconnects`)  *)
+(* iterate the IDENTICAL `is_running()` / non-reserved remote-endpoint set.   *)
+(* So within one snapshot, bound == applied freeze, and confirmation can      *)
+(* never outrun a freeze the mesh later agrees on — UNLESS the low value's     *)
+(* source endpoint LEAVES the fold between confirming and freezing            *)
+(* (fold-membership asymmetry). That happens when the global-min ORIGIN       *)
+(* survivor DIES (its endpoint pruned from both folds) after relaying its low  *)
+(* freeze F to a third survivor but before delivering it to us, AND the relay  *)
+(* is partition-delayed past our record+discard of the higher frames. We then  *)
+(* confirm and DISCARD the dropped slot's real inputs in (F, window_floor],    *)
+(* the late relay forces a rollback below the window floor (the S20 clamp      *)
+(* keeps us live), and the discarded frames keep our real-input state while    *)
+(* the relayer froze at F -> a permanent cross-survivor confirmed-STATE        *)
+(* divergence whose CONVERGED INPUTS nonetheless match (so the input-checksum  *)
+(* desync detector stays silent).                                            *)
+(*                                                                          *)
+(* WHAT THIS MODULE ARBITRATES                                              *)
+(*                                                                          *)
+(* The S41 write-up records three candidate fixes and the project rule "no    *)
+(* partial fix shipped — a partial fix regresses liveness." This module turns  *)
+(* the prose arbitration into a machine-checked one. The confirmation rule is  *)
+(* a CONSTANT `FIX_MODE` with three values, each exercised by its own .cfg:    *)
+(*                                                                          *)
+(*   - "Baseline"  — current production (prune the dead origin from the fold,  *)
+(*                   confirm/discard on the surviving stale-high cache). The   *)
+(*                   safety invariant NoConfirmedDivergence is VIOLATED: TLC   *)
+(*                   reproduces the residual as a counterexample. (Run via     *)
+(*                   DoubleFailureRelay_Baseline.cfg — expected to FAIL; this  *)
+(*                   is the model-level RED that mirrors the in-process repro  *)
+(*                   p2p_n4_double_failure_relay_dropped_slot_diverges_*.)     *)
+(*                                                                          *)
+(*   - "Tombstone" — candidate fix #2 (non-wire): keep folding a dead          *)
+(*                   survivor's last gossiped term. Safety holds, but the      *)
+(*                   liveness property ConfirmationProgresses is VIOLATED: a    *)
+(*                   dead survivor that held a stale-low view of a slot that    *)
+(*                   is in fact still LIVE pins every survivor's confirmation   *)
+(*                   forever (a survivor cannot tell a real freeze from        *)
+(*                   ordinary lag at the moment of death — see                 *)
+(*                   N-PLAYER-DESYNC-AUDIT.md / the S25 critic-#3 `is_running`  *)
+(*                   arbitration). This is the formal proof of "a partial fix  *)
+(*                   regresses liveness." (Run via                            *)
+(*                   DoubleFailureRelay_Tombstone.cfg — expected to FAIL on    *)
+(*                   the PROPERTY, not on safety.)                            *)
+(*                                                                          *)
+(*   - "MeshAgree" — candidate fix #3 (the sound one): a survivor advances       *)
+(*                   confirmation of a not-yet-mesh-agreed slot only to the      *)
+(*                   MESH-ACKED FLOOR — the min, over the local view and every    *)
+(*                   still-alive peer REACHABLE over a live link, of that peer's  *)
+(*                   CURRENT floor (a fresh ack, NOT the possibly-stale          *)
+(*                   per-endpoint cache the barrier folds) — and HOLDS entirely  *)
+(*                   while any alive peer is unreachable (the ack round cannot    *)
+(*                   complete). It therefore never discards a frame a peer has    *)
+(*                   already frozen lower or a partitioned peer might lower.      *)
+(*                   BOTH the safety invariant AND the liveness property hold.    *)
+(*                   This is the default config (DoubleFailureRelay.cfg,         *)
+(*                   registered in verify-tla.sh) and the design a future        *)
+(*                   production red-green cycle should implement (a per-slot     *)
+(*                   ack/epoch on connect-status gossip).                       *)
+(*                                                                          *)
+(* Properties:                                                              *)
+(*   - Safety: NoConfirmedDivergence — no two alive survivors ever hold        *)
+(*     divergent recorded confirmed state for the dropped slot at any frame    *)
+(*     both have committed. (VIOLATED under Baseline; holds under              *)
+(*     Tombstone/MeshAgree.)                                                  *)
+(*   - Safety: FreezeNeverBelowGlobalMin / BoundNeverBelowCommit — sanity      *)
+(*     invariants on the fold arithmetic.                                     *)
+(*   - Liveness: ConfirmationProgresses — every alive survivor eventually      *)
+(*     confirms the dropped slot through to its proper target (the mesh        *)
+(*     reaches a stable, fully-confirmed fixpoint). (VIOLATED under            *)
+(*     Tombstone; holds under Baseline/MeshAgree.)                            *)
+(*                                                                          *)
+(* FAITHFUL ABSTRACTIONS (honest scope)                                      *)
+(*   - The dropped slot D is modeled by a per-survivor high-water RECEIPT      *)
+(*     `recvThrough` (its asymmetric-loss confirmed range) rather than a       *)
+(*     packet stream; this is the FreezeConvergence convention. The agreed     *)
+(*     freeze frame is GlobalMin == Min(recvThrough).                          *)
+(*   - Confirmed INPUT bytes are injective in the source frame (realInput[f]   *)
+(*     == f, so two survivors recorded the SAME byte at frame g iff they        *)
+(*     recorded it from the same SOURCE frame). We therefore track only the    *)
+(*     recorded SOURCE frame `recSrc` (g for a real record, the freeze frame   *)
+(*     for a frozen record) and compare those — a byte divergence iff the       *)
+(*     source frames differ. This drops the stream variable with no loss.      *)
+(*   - The prediction window is the constant WINDOW; a committed frame g is     *)
+(*     LOCKED (irreversibly discarded, no longer re-rollable) once bound has    *)
+(*     advanced past g + WINDOW. This is the S20-clamp / ring-floor mechanism. *)
+(*   - A peer "death" (an explicit remove_player or a disconnect timeout) is    *)
+(*     modeled by `alive[s] = FALSE`, which prunes s from every other          *)
+(*     survivor's fold (the production `!endpoint.is_running()` skip).         *)
+(*   - "Partition" between src and obs is `~link[src][obs]`; gossip from src    *)
+(*     reaches obs only while the link is up. A down link does NOT prune the    *)
+(*     endpoint (production keeps it `Running` until the long timeout) — that   *)
+(*     decoupling of "link down" from "endpoint pruned" is exactly the          *)
+(*     fold-membership asymmetry the residual exploits. Partitions are present  *)
+(*     post-warmup (chosen by Init) and only HEAL (monotone-up links; see       *)
+(*     Unblock) — faithful to the repro (warm up all-open, sever, re-open) and  *)
+(*     it keeps the liveness obligation a plain `<>[]` (no oscillation to       *)
+(*     defend against, so weak fairness and a small TLC tableau suffice).       *)
+(*   - The MeshAgree fix is modeled at the policy level ("hold confirmation     *)
+(*     of a not-yet-mesh-agreed slot while partitioned from any alive peer")    *)
+(*     rather than as a concrete ack-round wire format; the wire format is the  *)
+(*     production design choice this proof informs, not constrains.            *)
+(*                                                                          *)
+(* SCOPE OF THE THREE RESULTS (honest bounds — what each claim does and does NOT *)
+(* prove; established in an adversarial faithfulness review):                    *)
+(*                                                                          *)
+(*   - The NEGATIVE results are UNCONDITIONAL within the modeled world. Baseline  *)
+(*     -unsafe and Tombstone-illiveness are demonstrated by REACHABLE             *)
+(*     counterexamples, and every abstraction here is conservative (it makes the  *)
+(*     model safer/more-restrictive than production), so a reachable violation is *)
+(*     a real one. These two are the load-bearing arbitration outcomes.          *)
+(*                                                                          *)
+(*   - The POSITIVE result (MeshAgree sound) is proven for the AGGREGATION RULE   *)
+(*     under two idealizing assumptions that the production fix must additionally *)
+(*     discharge — both already tracked as the deferred wire-epoch work (S41 fix  *)
+(*     candidate #1, the per-slot drop-epoch on connect-status gossip):           *)
+(*       (a) INSTANTANEOUS, FRESH ACK. `MeshAckedFloor` reads each reachable alive *)
+(*           peer's CURRENT floor (`PeerFloor`) with no in-flight delay. Real      *)
+(*           floors converge monotone-DOWN, so a DELAYED ack reads a stale-HIGH    *)
+(*           floor; discarding against it could lock a frame the peer later        *)
+(*           freezes below — exactly this residual, recursed one level. The        *)
+(*           production fix must therefore make the acked floor a COMMITMENT       *)
+(*           ("I will not freeze below X"), which is what the drop-epoch provides;  *)
+(*           a bare floor snapshot is not enough. This model proves the floor      *)
+(*           AGGREGATION (min over reachable-alive committed floors, hold-on-       *)
+(*           partition, exclude-on-convergence) is the right POLICY; the epoch is   *)
+(*           what turns a snapshot into the commitment the policy assumes.          *)
+(*       (b) SYNCHRONIZED DEATH. `alive[s]` is a single global flag; production     *)
+(*           death is per-observer (a peer can be `Running` in one survivor's       *)
+(*           registry and `Disconnected` in another's during the disconnect-timeout *)
+(*           skew). The fix's ack-set is computed from this shared alive view;       *)
+(*           production must tolerate survivors briefly disagreeing on who is alive. *)
+(*       Also: this is the NON-hot-join world — the bound fold's hot-join            *)
+(*       `attempt_clamp` / reserved-endpoint arms and the merge's                   *)
+(*       `disconnect_requested` / reactivation-floor skips are out of scope (a       *)
+(*       second instance of this residual may live in the hot-join reactivation      *)
+(*       paths, which share the fold-pruning relay shape). And the MeshAgree         *)
+(*       LIVENESS pass assumes monotone-healing partitions (no flap); the Tombstone  *)
+(*       liveness FAILURE is structural and needs no such assumption.               *)
+(***************************************************************************)
+
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    SURVIVORS,     \* observing survivors, e.g. {a, b, c} (a=us, b=dying origin, c=relay)
+    MAX_FRAME,     \* maximum frame number for model checking
+    NULL_FRAME,    \* sentinel "no frame" (-1 in impl)
+    WINDOW,        \* prediction window: frames > bound - WINDOW are still re-rollable
+    RECEIPTS,      \* allowed per-survivor receipts of the dropped slot (adversarial at Init)
+    FIX_MODE       \* "Baseline" | "Tombstone" | "MeshAgree"
+
+ASSUME SURVIVORS # {}
+ASSUME MAX_FRAME \in Nat /\ MAX_FRAME > 0
+ASSUME NULL_FRAME \notin 0..MAX_FRAME
+ASSUME WINDOW \in Nat /\ WINDOW >= 1
+ASSUME RECEIPTS \subseteq (0..MAX_FRAME) /\ RECEIPTS # {}
+ASSUME FIX_MODE \in {"Baseline", "Tombstone", "MeshAgree"}
+
+Frame == {NULL_FRAME} \union (0..MAX_FRAME)
+
+(***************************************************************************)
+(* Variables.                                                              *)
+(*                                                                          *)
+(* recvThrough is an adversarial fixed-at-Init choice (each survivor's        *)
+(* high-water received frame of the dropped slot under asymmetric loss). The  *)
+(* rest evolve.                                                              *)
+(***************************************************************************)
+VARIABLES
+    recvThrough,   \* [SURVIVORS -> 0..MAX_FRAME]: per-survivor receipt of dropped slot
+    alive,         \* [SURVIVORS -> BOOLEAN]: still running in the mesh (is_running)
+    localDisc,     \* [SURVIVORS -> BOOLEAN]: my local_connect_status[D].disconnected
+    localFrame,    \* [SURVIVORS -> Frame]: my local_connect_status[D].last_frame (freeze once disc)
+    cacheDisc,     \* [SURVIVORS -> [SURVIVORS -> BOOLEAN]]: cacheDisc[obs][src] = obs's cache of src's D-disc
+    cacheLast,     \* [SURVIVORS -> [SURVIVORS -> Frame]]: cacheLast[obs][src] = obs's cache of src's D last_frame
+    link,          \* [SURVIVORS -> [SURVIVORS -> BOOLEAN]]: link[src][obs] = src->obs gossip flows
+    bound,         \* [SURVIVORS -> Frame]: confirmed high-water for D (NULL = nothing confirmed)
+    recSrc         \* [SURVIVORS -> [0..MAX_FRAME -> Frame]]: recorded source frame per committed frame
+
+vars == <<recvThrough, alive, localDisc, localFrame, cacheDisc, cacheLast,
+          link, bound, recSrc>>
+
+(***************************************************************************)
+(* Min over a non-empty set of integers. CHOOSE ranges over integer frame    *)
+(* values only (never over SURVIVORS), so it is symmetry-safe — though this   *)
+(* module checks liveness and therefore declares no SYMMETRY anyway.          *)
+(***************************************************************************)
+MinI(S) == CHOOSE x \in S : \A y \in S : x <= y
+Min2(a, b) == IF a <= b THEN a ELSE b
+Max2(a, b) == IF a >= b THEN a ELSE b
+
+(***************************************************************************)
+(* GlobalMin: the agreed freeze frame F if the dropped slot drops — the        *)
+(* minimum over ALL survivors of their received frame. Because frames are       *)
+(* contiguous from 0, every survivor has a confirmed input at GlobalMin.        *)
+(***************************************************************************)
+GlobalMin == MinI({recvThrough[s] : s \in SURVIVORS})
+
+(***************************************************************************)
+(* The window floor for survivor s: frames strictly below it are LOCKED        *)
+(* (discarded, no longer re-rollable). Mirrors adjust_gamestate's              *)
+(* frame_to_load.max(current - max_prediction).                               *)
+(***************************************************************************)
+WindowFloor(s) ==
+    IF bound[s] = NULL_FRAME THEN 0
+    ELSE Max2(0, bound[s] - WINDOW)
+
+Locked(s, g) == g < WindowFloor(s)
+
+Committed(s, g) == recSrc[s][g] # NULL_FRAME
+
+(***************************************************************************)
+(* The set of OTHER survivors whose cached view survivor s folds. Production    *)
+(* skips `!endpoint.is_running()` (dead) endpoints. The "Tombstone" candidate   *)
+(* fix additionally retains a dead survivor's last gossiped term for a          *)
+(* not-yet-mesh-agreed slot (the proposal under test).                          *)
+(***************************************************************************)
+SlotMeshAgreed(s) ==
+    \* s considers D mesh-agreed-disconnected: s locally disconnected AND no
+    \* folded running peer still reports it connected (the (true,false,_) arm).
+    /\ localDisc[s]
+    /\ \A o \in SURVIVORS \ {s} : alive[o] => cacheDisc[s][o]
+
+FoldedSources(s) ==
+    \* Tombstone (candidate fix #2): retain a DEAD survivor's last gossiped term
+    \* for a not-yet-mesh-agreed slot, REGARDLESS of its disconnect bit — the
+    \* relay residual leaves us with a dead origin's {connected, F} term (the
+    \* origin died before gossiping its disconnect to us), so a tombstone that
+    \* only kept DISCONNECTED dead terms would not even fix the relay. Keeping
+    \* the connected-low term is exactly what regresses liveness (a dead laggy
+    \* peer's {connected, F} pins a still-LIVE slot's confirmation forever).
+    IF FIX_MODE = "Tombstone"
+    THEN { o \in SURVIVORS \ {s} : alive[o] \/ ~SlotMeshAgreed(s) }
+    ELSE { o \in SURVIVORS \ {s} : alive[o] }
+
+(***************************************************************************)
+(* remote_slot_confirmed_bound(s): the freeze-barrier bound on s's confirmed    *)
+(* frame for the dropped slot. Faithful to the four production arms.            *)
+(*   - localConn: D still connected in s's own local_connect_status.            *)
+(*   - localLast: s's own receipt (connected) or freeze (disconnected).         *)
+(*   - gossipMin: min folded cached last_frame.                                *)
+(*   - anyConn: some folded peer still reports D connected.                     *)
+(* Returns NULL_FRAME for the mesh-agreed (excluded) slot — D imposes no bound  *)
+(* and confirmation may advance to MAX_FRAME (other slots, unmodeled, gate it). *)
+(***************************************************************************)
+ConfirmedBound(s) ==
+    LET localConn == ~localDisc[s]
+        localLast == localFrame[s]
+        folded    == FoldedSources(s)
+        anyConn   == \E o \in folded : ~cacheDisc[s][o]
+    IN  IF folded = {}
+        THEN IF localConn THEN localLast ELSE NULL_FRAME
+        ELSE LET gossipMin == MinI({cacheLast[s][o] : o \in folded})
+             IN  IF localConn THEN Min2(localLast, gossipMin)
+                 ELSE IF anyConn THEN gossipMin
+                 ELSE NULL_FRAME
+
+(***************************************************************************)
+(* The Baseline / Tombstone confirmation target: the freeze-barrier bound        *)
+(* computed from the CACHES, promoted to MAX_FRAME when the slot is excluded      *)
+(* (mesh-agreed — the frozen value carries it). Tombstone differs only in          *)
+(* FoldedSources (it keeps dead survivors' caches), so it rides this same target.  *)
+(***************************************************************************)
+BaselineTarget(s) ==
+    LET b == ConfirmedBound(s)
+    IN IF b = NULL_FRAME THEN MAX_FRAME ELSE b
+
+(***************************************************************************)
+(* Candidate fix #3 ("MeshAgree", the sound one): confirmation of a               *)
+(* not-yet-mesh-agreed slot may advance only to the MESH-ACKED FLOOR — the min,     *)
+(* across the local view and every alive peer REACHABLE over a live link, of that   *)
+(* peer's CURRENT floor (its receipt while it still sees D live, its freeze frame    *)
+(* once it has dropped D). Two faithfulness points distinguish it from Baseline:      *)
+(*                                                                                  *)
+(*   1. It reads each peer's CURRENT floor (PeerFloor), an abstraction of a fresh     *)
+(*      ack round, NOT the possibly-STALE per-endpoint cache the barrier folds. The    *)
+(*      residual is precisely a survivor trusting a stale-high cache of a peer that     *)
+(*      has since frozen D lower; a fresh ack cannot be stale.                          *)
+(*   2. If ANY alive peer is currently UNREACHABLE (partitioned: the ack round           *)
+(*      cannot complete), the survivor HOLDS — it does not advance past its current      *)
+(*      bound — because an unheard peer might hold a lower freeze. A DEAD peer has         *)
+(*      left the ack set (its endpoint is pruned), so it imposes no hold; the living       *)
+(*      mesh floor is over the survivors that remain.                                       *)
+(*                                                                                       *)
+(* Once the slot is mesh-agreed-excluded, the frozen value carries it and the hold        *)
+(* lifts (target MAX_FRAME). This is the design a production red-green cycle should        *)
+(* implement (a per-slot ack/epoch on connect-status gossip); the wire format is the        *)
+(* production choice this proof informs, not constrains.                                     *)
+(***************************************************************************)
+PeerFloor(o) == IF localDisc[o] THEN localFrame[o] ELSE recvThrough[o]
+
+ReachableAlive(s) == { o \in SURVIVORS \ {s} : alive[o] /\ link[o][s] }
+
+AllAliveReachable(s) == \A o \in SURVIVORS \ {s} : alive[o] => link[o][s]
+
+MeshAckedFloor(s) ==
+    MinI({PeerFloor(s)} \union {PeerFloor(o) : o \in ReachableAlive(s)})
+
+CurBound(s) == IF bound[s] = NULL_FRAME THEN -1 ELSE bound[s]
+
+MeshAgreeTarget(s) ==
+    \* Partitioned: hold — an unheard alive peer might hold a lower freeze, and the
+    \* ack round cannot complete. Safe default; the WF heal lifts it.
+    IF ~AllAliveReachable(s) THEN CurBound(s)
+    \* Mesh-agreed AND the local freeze has FULLY CONVERGED to the mesh-acked floor:
+    \* the slot is excluded, every frame above the (now final) freeze is the same
+    \* frozen value, so advancing to MAX_FRAME and locking is safe. Requiring the
+    \* convergence (localFrame == MeshAckedFloor) is load-bearing: excluding while the
+    \* freeze is still ABOVE the mesh floor would lock real/early-frozen frames that a
+    \* later converge-down must rewrite — the discard-before-convergence half of the
+    \* residual (a survivor that froze high off a stale cache after the low source died).
+    ELSE IF SlotMeshAgreed(s) /\ localFrame[s] = MeshAckedFloor(s) THEN MAX_FRAME
+    \* Otherwise cap by the fresh mesh-acked floor (never lock past a frame the freeze
+    \* could still converge below).
+    ELSE Min2(BaselineTarget(s), MeshAckedFloor(s))
+
+BoundTarget(s) ==
+    IF FIX_MODE = "MeshAgree" THEN MeshAgreeTarget(s) ELSE BaselineTarget(s)
+
+(***************************************************************************)
+(* The value (recorded SOURCE frame) survivor s writes for the dropped slot at  *)
+(* frame g, given s's CURRENT freeze view: the frozen frame when s has          *)
+(* concluded D disconnected and g is above the freeze, else the real frame g.   *)
+(***************************************************************************)
+RecordValue(s, g) ==
+    IF localDisc[s] /\ g > localFrame[s] THEN localFrame[s] ELSE g
+
+(***************************************************************************)
+(* Type invariant.                                                          *)
+(***************************************************************************)
+TypeInvariant ==
+    /\ recvThrough \in [SURVIVORS -> 0..MAX_FRAME]
+    /\ alive \in [SURVIVORS -> BOOLEAN]
+    /\ localDisc \in [SURVIVORS -> BOOLEAN]
+    /\ localFrame \in [SURVIVORS -> Frame]
+    /\ cacheDisc \in [SURVIVORS -> [SURVIVORS -> BOOLEAN]]
+    /\ cacheLast \in [SURVIVORS -> [SURVIVORS -> Frame]]
+    /\ link \in [SURVIVORS -> [SURVIVORS -> BOOLEAN]]
+    /\ bound \in [SURVIVORS -> Frame]
+    /\ recSrc \in [SURVIVORS -> [0..MAX_FRAME -> Frame]]
+
+(***************************************************************************)
+(* Initial state. The warmup phase (repro Phase 1: all links open, all survivors *)
+(* confirm together) has completed: every survivor has gossiped its true receipt *)
+(* to every other, so each cache holds the source's real receipt and nobody is   *)
+(* disconnected. Nothing is confirmed yet (AdvanceConfirm catches up from here).  *)
+(* recvThrough is the adversarial asymmetric-loss choice. Initialising the cache  *)
+(* to the true receipt (not 0) is load-bearing: a survivor that drops a peer      *)
+(* freezes at its queue-min over these caches, which must be >= GlobalMin — the   *)
+(* asymmetry the residual needs comes from a (post-warmup) partition leaving a     *)
+(* link's cache to go stale as the source's view changes, not from a cold cache.  *)
+(* Links are chosen freely at Init (any post-warmup partition) and only heal.      *)
+(***************************************************************************)
+Init ==
+    /\ recvThrough \in [SURVIVORS -> RECEIPTS]
+    /\ alive = [s \in SURVIVORS |-> TRUE]
+    /\ localDisc = [s \in SURVIVORS |-> FALSE]
+    /\ localFrame = [s \in SURVIVORS |-> recvThrough[s]]
+    /\ cacheDisc = [o \in SURVIVORS |-> [s \in SURVIVORS |-> FALSE]]
+    /\ cacheLast = [o \in SURVIVORS |-> [s \in SURVIVORS |-> recvThrough[s]]]
+    \* Links: any post-warmup partition (the FilterBus severs of the in-process repro),
+    \* with the irrelevant self-links pinned up to avoid spurious initial states.
+    \* Links only heal from here (Unblock), so the network monotonically stabilizes.
+    /\ link \in [SURVIVORS -> [SURVIVORS -> BOOLEAN]]
+    /\ \A s \in SURVIVORS : link[s][s]
+    /\ bound = [s \in SURVIVORS |-> NULL_FRAME]
+    /\ recSrc = [s \in SURVIVORS |-> [g \in 0..MAX_FRAME |-> NULL_FRAME]]
+
+(***************************************************************************)
+(* Action: src gossips its CURRENT local view of the dropped slot to obs        *)
+(* (one connect-status vector entry). Requires src alive and the link up. obs   *)
+(* merges into its cache via the faithful merge_peer_connect_status semantics:  *)
+(*   - src reports disconnected, obs first learns: ADOPT src's frame.            *)
+(*   - both disconnected: MIN (converge down).                                  *)
+(*   - src reports connected, cache connected: MAX (monotone up).                *)
+(*   - src reports connected, cache already disconnected: leave (no resurrect).  *)
+(***************************************************************************)
+Gossip(src, obs) ==
+    /\ src # obs
+    /\ alive[src]
+    /\ alive[obs]
+    /\ link[src][obs]
+    /\ LET sd == localDisc[src]
+           sf == localFrame[src]
+           cd == cacheDisc[obs][src]
+           cf == cacheLast[obs][src]
+           newDisc == cd \/ sd
+           newLast == IF sd /\ ~cd THEN sf                 \* first-learn disconnect: adopt
+                      ELSE IF sd /\ cd THEN Min2(cf, sf)    \* both disconnected: min down
+                      ELSE IF ~sd /\ ~cd THEN Max2(cf, sf)  \* both connected: max up
+                      ELSE cf                               \* connected report, cache disc: no resurrect
+       IN /\ cacheDisc' = [cacheDisc EXCEPT ![obs][src] = newDisc]
+          /\ cacheLast' = [cacheLast EXCEPT ![obs][src] = newLast]
+    /\ UNCHANGED <<recvThrough, alive, localDisc, localFrame, link, bound, recSrc>>
+
+(***************************************************************************)
+(* Action: src directly concludes the dropped slot disconnected (an explicit    *)
+(* remove_player or a disconnect timeout). It freezes at its own current        *)
+(* queue-min (its receipt, mined no lower than any folded lower cache). Models   *)
+(* remove_player(D) on a survivor.                                              *)
+(***************************************************************************)
+QueueMin(s) ==
+    LET folded == FoldedSources(s)
+        base   == recvThrough[s]
+    IN IF folded = {}
+       THEN base
+       ELSE Min2(base, MinI({cacheLast[s][o] : o \in folded}))
+
+DetectDrop(s) ==
+    /\ alive[s]
+    /\ ~localDisc[s]
+    /\ localDisc' = [localDisc EXCEPT ![s] = TRUE]
+    /\ localFrame' = [localFrame EXCEPT ![s] = QueueMin(s)]
+    /\ UNCHANGED <<recvThrough, alive, cacheDisc, cacheLast, link, bound, recSrc>>
+
+(***************************************************************************)
+(* Action: a survivor dies / is pruned (explicit remove_player by a peer, or a  *)
+(* disconnect timeout). Removed from every fold immediately.                    *)
+(***************************************************************************)
+Die(s) ==
+    /\ alive[s]
+    /\ Cardinality({o \in SURVIVORS : alive[o]}) > 1   \* never empty the mesh
+    /\ alive' = [alive EXCEPT ![s] = FALSE]
+    /\ UNCHANGED <<recvThrough, localDisc, localFrame, cacheDisc, cacheLast,
+                   link, bound, recSrc>>
+
+(***************************************************************************)
+(* Action: a partitioned (directed) link HEALS. Partitions are modeled as          *)
+(* present POST-WARMUP (chosen by Init) and MONOTONICALLY HEALING — once a link is  *)
+(* up it stays up. This is faithful (the in-process repro warms up with all links   *)
+(* open, then severs and later re-opens) AND it makes the liveness obligation        *)
+(* tractable: links monotonically reach all-up, so the network eventually           *)
+(* stabilizes by construction — no adversarial Block/Unblock flap, so the plain      *)
+(* `<>[] AllConfirmed` property suffices (no co-Buechi `<>[]Stable` antecedent).     *)
+(* A partition that appears only LATER (after some confirmation) is captured by      *)
+(* relabeling: the only confirmations that matter for the residual happen DURING     *)
+(* the partition (the victim confirms past the freeze while it cannot hear the relay *)
+(* lower it), and starting in that partition with those confirmations not-yet-done   *)
+(* covers exactly that window. Weak fairness (in Fairness) forces every down link to *)
+(* eventually heal — a real partition heals or the peer times out and dies.          *)
+(***************************************************************************)
+Unblock(src, dst) ==
+    /\ src # dst
+    /\ ~link[src][dst]
+    /\ link' = [link EXCEPT ![src][dst] = TRUE]
+    /\ UNCHANGED <<recvThrough, alive, localDisc, localFrame, cacheDisc,
+                   cacheLast, bound, recSrc>>
+
+(***************************************************************************)
+(* Action: update_player_disconnects — fold the caches, and if the dropped      *)
+(* slot now shows disconnected-and-lower than our local view, adopt the          *)
+(* disconnect and mine our freeze frame DOWN, re-rolling every still-rollable    *)
+(* (non-locked) committed frame above the new freeze to the frozen value.        *)
+(* LOCKED (discarded) frames keep their stale recorded value — the residual.     *)
+(***************************************************************************)
+FoldedDisc(s) == \E o \in FoldedSources(s) : cacheDisc[s][o]
+
+UpdateDisconnects(s) ==
+    /\ alive[s]
+    /\ FoldedDisc(s)                          \* some folded peer reports D disconnected
+    /\ LET qmin == QueueMin(s)
+           newDisc == TRUE
+           newFrame == IF localDisc[s] THEN Min2(localFrame[s], qmin) ELSE qmin
+       IN /\ \/ ~localDisc[s]                  \* first adopt
+             \/ qmin < localFrame[s]           \* or a strictly-lower converge-down
+          /\ localDisc' = [localDisc EXCEPT ![s] = newDisc]
+          /\ localFrame' = [localFrame EXCEPT ![s] = newFrame]
+          /\ recSrc' = [recSrc EXCEPT ![s] =
+                 [g \in 0..MAX_FRAME |->
+                     IF /\ recSrc[s][g] # NULL_FRAME      \* committed
+                        /\ g > newFrame                   \* above the new freeze
+                        /\ ~Locked(s, g)                  \* still re-rollable (not discarded)
+                     THEN newFrame                        \* re-roll to frozen value
+                     ELSE recSrc[s][g]]]
+    /\ UNCHANGED <<recvThrough, alive, cacheDisc, cacheLast, link, bound>>
+
+(***************************************************************************)
+(* Action: AdvanceConfirm — confirm the dropped slot up to the freeze-barrier    *)
+(* target, committing a recorded source-frame value for each newly confirmed     *)
+(* frame. Under MeshAgree, a partitioned survivor holds (does not advance a       *)
+(* not-yet-mesh-agreed slot). The commit is irreversible once the frame later     *)
+(* falls below the window floor.                                                 *)
+(***************************************************************************)
+AdvanceConfirm(s) ==
+    /\ alive[s]
+    /\ LET target == BoundTarget(s)
+           cur == CurBound(s)
+       IN /\ target > cur                       \* genuine progress (MeshAgree holds = no progress)
+          /\ bound' = [bound EXCEPT ![s] = target]
+          /\ recSrc' = [recSrc EXCEPT ![s] =
+                 [g \in 0..MAX_FRAME |->
+                     IF g > cur /\ g <= target /\ recSrc[s][g] = NULL_FRAME
+                     THEN RecordValue(s, g)
+                     ELSE recSrc[s][g]]]
+    /\ UNCHANGED <<recvThrough, alive, localDisc, localFrame, cacheDisc,
+                   cacheLast, link>>
+
+Next ==
+    \/ \E src, obs \in SURVIVORS : Gossip(src, obs)
+    \/ \E s \in SURVIVORS : DetectDrop(s)
+    \/ \E s \in SURVIVORS : Die(s)
+    \/ \E src, dst \in SURVIVORS : Unblock(src, dst)
+    \/ \E s \in SURVIVORS : UpdateDisconnects(s)
+    \/ \E s \in SURVIVORS : AdvanceConfirm(s)
+
+(***************************************************************************)
+(* Fairness for the liveness property. WEAK fairness suffices because partitions    *)
+(* only HEAL (links are monotone-up), so there is no adversarial flap that could      *)
+(* starve a continuously-enabled action — once the network has stabilized, every      *)
+(* enabled progress action stays enabled until it fires, which is exactly the WF      *)
+(* obligation. (Weak, not strong, fairness keeps TLC's liveness tableau small;        *)
+(* strong fairness over this many actions blows the check up.) Per-survivor gossip,   *)
+(* disconnect-folding, and confirmation advancement are each weakly fair; healing is  *)
+(* one existential WF (each Unblock strictly reduces the down-link count, so a single  *)
+(* obligation drives the network to fully connected). The Tombstone liveness FAILURE  *)
+(* survives this: it is STRUCTURAL — a dead survivor's tombstone caps the              *)
+(* confirmation TARGET below the living floor, so AdvanceConfirm makes no progress no  *)
+(* matter how fairly it is scheduled.                                                 *)
+(***************************************************************************)
+Fairness ==
+    /\ \A src, obs \in SURVIVORS : WF_vars(Gossip(src, obs))
+    /\ \A s \in SURVIVORS : WF_vars(UpdateDisconnects(s))
+    /\ \A s \in SURVIVORS : WF_vars(AdvanceConfirm(s))
+    /\ WF_vars(\E src, dst \in SURVIVORS : Unblock(src, dst))
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(***************************************************************************)
+(* SAFETY: no two ALIVE survivors ever hold PERMANENTLY divergent recorded        *)
+(* confirmed state for the dropped slot. Because recorded inputs are injective in   *)
+(* the source frame, equal recorded source frames mean byte-identical confirmed     *)
+(* state. The divergence is PERMANENT — a genuine desync, not the benign staggered  *)
+(* -detection transient FreezeConvergence permits pre-convergence — exactly when     *)
+(* the frame is LOCKED (irreversibly discarded below the window floor) on BOTH        *)
+(* survivors: neither can ever re-roll it to re-converge. This is the headline        *)
+(* desync-closing property: VIOLATED under Baseline (the residual reproduces) and     *)
+(* holds under Tombstone / MeshAgree. (A divergence where one side is still rollable   *)
+(* is either re-converged by ConvergeDown or, if it never settles, caught by the       *)
+(* liveness property ConfirmationProgresses.)                                          *)
+(***************************************************************************)
+NoConfirmedDivergence ==
+    \A s1, s2 \in SURVIVORS :
+        (alive[s1] /\ alive[s2]) =>
+            \A g \in 0..MAX_FRAME :
+                (/\ Committed(s1, g) /\ Committed(s2, g)
+                 /\ Locked(s1, g) /\ Locked(s2, g)) =>
+                    recSrc[s1][g] = recSrc[s2][g]
+
+(***************************************************************************)
+(* SAFETY (single-survivor sharpening): once a survivor has mesh-agreed the slot   *)
+(* disconnected (its freeze frame is final at the global min), every LOCKED frame   *)
+(* it committed must hold the AGREED value — the real input at g for g at or below   *)
+(* the freeze, the frozen value (= the freeze frame's input) above it. A locked       *)
+(* REAL record above the freeze (recSrc = g > freeze) is precisely the residual: a    *)
+(* frame confirmed+discarded with the dropped peer's real input before the freeze      *)
+(* converged below it, now unrecoverable. Catches the victim WITHOUT needing a          *)
+(* second survivor; VIOLATED under Baseline, holds under Tombstone / MeshAgree.         *)
+(***************************************************************************)
+LockedRecordMatchesFreeze ==
+    \A s \in SURVIVORS :
+        (alive[s] /\ SlotMeshAgreed(s)) =>
+            \A g \in 0..MAX_FRAME :
+                (Committed(s, g) /\ Locked(s, g)) =>
+                    recSrc[s][g] = IF g <= localFrame[s] THEN g ELSE localFrame[s]
+
+(***************************************************************************)
+(* SAFETY sanity: a survivor never freezes the dropped slot below the true        *)
+(* global min (it would repeat a value no peer confirmed), and never records a      *)
+(* source frame above what it actually received.                                   *)
+(***************************************************************************)
+FreezeNeverBelowGlobalMin ==
+    \A s \in SURVIVORS :
+        localDisc[s] /\ localFrame[s] # NULL_FRAME => localFrame[s] >= GlobalMin
+
+RecordedSourceInRange ==
+    \A s \in SURVIVORS :
+        \A g \in 0..MAX_FRAME :
+            Committed(s, g) =>
+                /\ recSrc[s][g] >= 0
+                /\ recSrc[s][g] <= recvThrough[s]
+                /\ recSrc[s][g] <= g
+
+SafetyInvariant ==
+    /\ TypeInvariant
+    /\ NoConfirmedDivergence
+    /\ LockedRecordMatchesFreeze
+    /\ FreezeNeverBelowGlobalMin
+    /\ RecordedSourceInRange
+
+(***************************************************************************)
+(* NON-VACUITY WITNESSES (used ONLY by DoubleFailureRelay_Witness.cfg — a demo      *)
+(* config expected to REPORT VIOLATIONS). The two headline safety invariants above   *)
+(* are universally-quantified implications; they would be VACUOUSLY true if their     *)
+(* hypotheses (two alive survivors both LOCKING the same frame; a mesh-agreed         *)
+(* survivor holding a LOCKED frame) were never reached. Each witness is the NEGATION  *)
+(* of "the interesting state is reachable", so TLC reporting it VIOLATED proves the   *)
+(* hypothesis IS reached under the MeshAgree (passing) config — i.e. the PASS is not  *)
+(* hollow. The mesh-agreed witness is deliberately NON-DEGENERATE: it requires >= 2   *)
+(* alive survivors and a genuine cross-survivor `cacheDisc` agreement, ruling out the *)
+(* trivial all-peers-dead path that makes `SlotMeshAgreed`'s `\A` vacuous.            *)
+(***************************************************************************)
+WitnessTwoSurvivorsLockSameFrame ==
+    ~(\E s1, s2 \in SURVIVORS, g \in 0..MAX_FRAME :
+         /\ s1 # s2 /\ alive[s1] /\ alive[s2]
+         /\ Committed(s1, g) /\ Committed(s2, g)
+         /\ Locked(s1, g) /\ Locked(s2, g))
+
+WitnessMeshAgreedWithLockedNonDegenerate ==
+    ~(\E s \in SURVIVORS :
+         /\ alive[s] /\ SlotMeshAgreed(s)
+         /\ Cardinality({o \in SURVIVORS : alive[o]}) >= 2
+         /\ \E o \in SURVIVORS : o # s /\ alive[o] /\ cacheDisc[s][o]
+         /\ \E g \in 0..MAX_FRAME : Committed(s, g) /\ Locked(s, g))
+
+(***************************************************************************)
+(* LIVENESS: every alive survivor eventually reaches a stable fully-confirmed      *)
+(* fixpoint for the dropped slot — its confirmation advances to its proper          *)
+(* target (its own receipt while the slot is live, or MAX_FRAME once the slot is     *)
+(* mesh-agreed and excluded). VIOLATED under Tombstone (a dead survivor's stale       *)
+(* -low tombstone pins live confirmation forever) and holds under Baseline /          *)
+(* MeshAgree.                                                                         *)
+(*                                                                                   *)
+(* "Proper target" is the LIVING MESH FLOOR — the min receipt over survivors that         *)
+(* are still ALIVE (a peer's confirmed frame for a slot is GGPO-bounded by the SLOWEST     *)
+(* surviving peer's receipt, never its own; a dead peer leaves the floor). Once the slot   *)
+(* mesh-agrees-disconnects it is excluded and confirmation runs to MAX_FRAME (>= the floor *)
+(* trivially). So the obligation is: eventually, every alive survivor has confirmed at      *)
+(* least to the living mesh floor. Baseline and MeshAgree both reach it; Tombstone pins a    *)
+(* survivor BELOW it forever (a dead laggard's retained low term), which is the violation.   *)
+(***************************************************************************)
+LivingFloor == MinI({recvThrough[o] : o \in {x \in SURVIVORS : alive[x]}})
+
+FullyConfirmed(s) ==
+    \/ ~alive[s]
+    \/ (bound[s] # NULL_FRAME /\ bound[s] >= LivingFloor)
+
+(***************************************************************************)
+(* Because partitions only HEAL (links are monotone-up; see Unblock) and Unblock   *)
+(* is weakly fair, the network stabilizes by construction, so the obligation is the  *)
+(* plain "eventually, forever, every alive survivor is fully confirmed." It          *)
+(* distinguishes the fixes: under Baseline and MeshAgree the mesh converges and       *)
+(* every survivor reaches the living floor; under Tombstone a dead laggard's retained *)
+(* low term caps a survivor below the living floor FOREVER — independent of the        *)
+(* (fully healed) network — so the property is violated.                              *)
+(***************************************************************************)
+ConfirmationProgresses == <>[](\A s \in SURVIVORS : FullyConfirmed(s))
+
+THEOREM Spec => []SafetyInvariant
+
+=============================================================================

--- a/specs/tla/DoubleFailureRelay_Baseline.cfg
+++ b/specs/tla/DoubleFailureRelay_Baseline.cfg
@@ -1,0 +1,40 @@
+SPECIFICATION Spec
+
+\* DEMONSTRATION CONFIG (NOT the default; not registered in verify-tla.sh).
+\*
+\* Differs from DoubleFailureRelay.cfg in: FIX_MODE = "Baseline" (current
+\* production — prune the dead origin from the fold, confirm/discard on the
+\* surviving stale-high cache). The point of the demonstration is that the
+\* safety invariant NoConfirmedDivergence is NOT pinned: TLC reports a
+\* COUNTEREXAMPLE reproducing the double-failure relay residual — the global-min
+\* origin dies and is pruned, the victim confirms+discards the dropped slot's
+\* real inputs above the freeze on the surviving stale-high cache, the late relay
+\* lowers the freeze below the already-discarded window, and the victim's locked
+\* real-input record diverges from the relayer's frozen-at-F record. This is the
+\* model-level RED that mirrors the in-process repro
+\* p2p_n4_double_failure_relay_dropped_slot_diverges_across_survivors.
+\*
+\* Expected result: TLC reports "Invariant NoConfirmedDivergence is violated"
+\* with a trace. Run this manually:
+\*
+\*   java -jar .tla-tools/tla2tools.jar -deadlock \
+\*        -config specs/tla/DoubleFailureRelay_Baseline.cfg \
+\*        specs/tla/DoubleFailureRelay.tla
+\*
+\* Do NOT add this config to verify-tla.sh; it is meant to FAIL (on the safety
+\* invariant) — it proves the residual is real and the fix is load-bearing.
+CONSTANT SURVIVORS = {a, b, c}
+CONSTANT MAX_FRAME = 3
+CONSTANT NULL_FRAME = 999
+CONSTANT WINDOW = 1
+CONSTANT RECEIPTS = {0, 3}
+CONSTANT FIX_MODE = "Baseline"
+
+\* Only the safety invariants — the counterexample is a safety violation; the
+\* liveness property is irrelevant to the demonstration (and Baseline satisfies
+\* it anyway).
+INVARIANT TypeInvariant
+INVARIANT NoConfirmedDivergence
+INVARIANT LockedRecordMatchesFreeze
+INVARIANT FreezeNeverBelowGlobalMin
+INVARIANT RecordedSourceInRange

--- a/specs/tla/DoubleFailureRelay_InheritedFloor.cfg
+++ b/specs/tla/DoubleFailureRelay_InheritedFloor.cfg
@@ -1,0 +1,50 @@
+SPECIFICATION Spec
+
+\* DEMONSTRATION CONFIG (NOT the default; not registered in verify-tla.sh) — the
+\* machine-checked NEGATIVE result that rules out the most TEMPTING (cheapest, no-wire)
+\* candidate fix for the double-failure relay residual.
+\*
+\* FIX_MODE = "InheritedFloor" models a CACHE-ONLY / NO-WIRE / PASSIVE-CORROBORATION
+\* design: when a CONNECTED source leaves a survivor's fold (Die), the survivor
+\* SNAPSHOTS that source's last cached low term into a local `floor` (bounding BOTH the
+\* confirm target AND the freeze convergence), and RELEASES the floor only when every
+\* remaining alive folded peer has delivered FRESH gossip (a `Gossip` event, tracked in
+\* `corrob`) reporting the slot CONNECTED above the floor. It needs no wire-format change
+\* and no peer-receipt oracle — which is exactly why it is tempting.
+\*
+\* It is UNSOUND. TLC reports `NoConfirmedDivergence` VIOLATED via the CORROBORATE-THEN
+\* -DROP race: a peer gossips {connected, high} (corroborating "healthy"), the observer
+\* releases its floor on that corroboration, and then the SAME peer detects the drop and
+\* freezes the slot LOW — but its disconnect gossip has not yet reached the observer, so
+\* the observer has already confirmed+LOCKED the slot's real inputs above the freeze.
+\* The obstruction is intrinsic — a cache lags the corroborator's own in-flight drop — and the
+\* adversarial review additionally disproved the strongest cache-only variants (re-validate-
+\* against-current-cache, never-release = Tombstone liveness, speculative-bound, link-reachability
+\* -hold, local generation counter). This is the
+\* evidence that the production fix genuinely needs a FRESH-ACK ROUND (request/response,
+\* held until responses postdate the observer's intent to advance) plus a per-slot
+\* DROP-EPOCH commitment — the MeshAgree direction (the default config), whose aggregation
+\* this module proves sound under the instantaneous-fresh-ack idealization a real ack round
+\* must discharge. It joins _Baseline (safety dead-end: the residual) and _Tombstone
+\* (liveness dead-end) as the THIRD machine-checked dead-end — the no-wire shortcut.
+\*
+\* Expected result: TLC reports "Invariant NoConfirmedDivergence is violated".
+\* Run manually:
+\*   java -jar .tla-tools/tla2tools.jar -deadlock \
+\*        -config specs/tla/DoubleFailureRelay_InheritedFloor.cfg \
+\*        specs/tla/DoubleFailureRelay.tla
+\* Do NOT add this config to verify-tla.sh; it is meant to FAIL (on the safety invariant).
+CONSTANT SURVIVORS = {a, b, c}
+CONSTANT MAX_FRAME = 3
+CONSTANT NULL_FRAME = 999
+CONSTANT WINDOW = 1
+CONSTANT RECEIPTS = {0, 3}
+CONSTANT FIX_MODE = "InheritedFloor"
+
+\* Only the safety invariants — the counterexample is a safety violation (the
+\* corroborate-then-drop race), mirroring _Baseline.
+INVARIANT TypeInvariant
+INVARIANT NoConfirmedDivergence
+INVARIANT LockedRecordMatchesFreeze
+INVARIANT FreezeNeverBelowGlobalMin
+INVARIANT RecordedSourceInRange

--- a/specs/tla/DoubleFailureRelay_Tombstone.cfg
+++ b/specs/tla/DoubleFailureRelay_Tombstone.cfg
@@ -1,0 +1,42 @@
+SPECIFICATION Spec
+
+\* DEMONSTRATION CONFIG (NOT the default; not registered in verify-tla.sh).
+\*
+\* Differs from DoubleFailureRelay.cfg in: FIX_MODE = "Tombstone" (candidate
+\* fix #2 from the S41 deferred-fix spec — keep folding a DEAD survivor's last
+\* gossiped term for a not-yet-mesh-agreed slot). The point of the demonstration
+\* is that this fix CLOSES the safety hole (NoConfirmedDivergence holds) but
+\* REGRESSES LIVENESS: the liveness property ConfirmationProgresses is NOT pinned.
+\* TLC reports a COUNTEREXAMPLE (a lasso) in which a survivor that died while
+\* holding a stale-LOW view of a slot that is in fact still LIVE pins every
+\* other survivor's confirmation BELOW its own receipt forever — because a
+\* survivor cannot tell a genuine freeze from ordinary lag at the moment of
+\* death (the N-PLAYER-DESYNC-AUDIT.md / S25 critic-#3 `is_running` arbitration).
+\* This is the FORMAL proof of the project rule "no partial fix shipped — a
+\* partial fix regresses liveness."
+\*
+\* Expected result: TLC reports "Temporal properties were violated" with a
+\* lasso trace for ConfirmationProgresses (NOT a safety violation). Run this
+\* manually:
+\*
+\*   java -jar .tla-tools/tla2tools.jar -deadlock \
+\*        -config specs/tla/DoubleFailureRelay_Tombstone.cfg \
+\*        specs/tla/DoubleFailureRelay.tla
+\*
+\* Do NOT add this config to verify-tla.sh; it is meant to FAIL (on the
+\* liveness PROPERTY, while the safety invariants pass).
+CONSTANT SURVIVORS = {a, b, c}
+CONSTANT MAX_FRAME = 3
+CONSTANT NULL_FRAME = 999
+CONSTANT WINDOW = 1
+CONSTANT RECEIPTS = {0, 3}
+CONSTANT FIX_MODE = "Tombstone"
+
+\* Safety holds under Tombstone; the demonstration is the liveness FAILURE.
+INVARIANT TypeInvariant
+INVARIANT NoConfirmedDivergence
+INVARIANT LockedRecordMatchesFreeze
+INVARIANT FreezeNeverBelowGlobalMin
+INVARIANT RecordedSourceInRange
+
+PROPERTY ConfirmationProgresses

--- a/specs/tla/DoubleFailureRelay_Witness.cfg
+++ b/specs/tla/DoubleFailureRelay_Witness.cfg
@@ -1,0 +1,31 @@
+SPECIFICATION Spec
+
+\* NON-VACUITY DEMONSTRATION CONFIG (NOT the default; not registered in
+\* verify-tla.sh). Identical constants to DoubleFailureRelay.cfg (the MeshAgree
+\* PASS), but it checks the two NON-VACUITY WITNESS invariants instead of the
+\* safety/liveness properties. Each witness is the NEGATION of "the interesting
+\* state is reachable", so TLC reporting it VIOLATED proves the headline safety
+\* invariants' hypotheses are actually reached under the passing config — i.e. the
+\* MeshAgree PASS is NOT vacuous (it is not trivially true because two survivors
+\* never both lock the same frame, or because the mesh-agreed-with-locked state is
+\* never reached non-degenerately).
+\*
+\* Expected result: TLC reports a COUNTEREXAMPLE to BOTH witnesses (run them one at
+\* a time — TLC stops at the first violated invariant; comment out the first to see
+\* the second). Run manually:
+\*
+\*   java -jar .tla-tools/tla2tools.jar -deadlock \
+\*        -config specs/tla/DoubleFailureRelay_Witness.cfg \
+\*        specs/tla/DoubleFailureRelay.tla
+\*
+\* Do NOT add this config to verify-tla.sh; it is meant to FAIL (each witness is a
+\* reachability assertion expressed as a violated invariant).
+CONSTANT SURVIVORS = {a, b, c}
+CONSTANT MAX_FRAME = 3
+CONSTANT NULL_FRAME = 999
+CONSTANT WINDOW = 1
+CONSTANT RECEIPTS = {0, 3}
+CONSTANT FIX_MODE = "MeshAgree"
+
+INVARIANT WitnessTwoSurvivorsLockSameFrame
+INVARIANT WitnessMeshAgreedWithLockedNonDegenerate

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -38,7 +38,7 @@ This directory contains TLA+ specifications for formally verifying the correctne
 | `FreezeConvergence.tla` | `FreezeConvergence.cfg` | ✓ CI | Cross-survivor freeze-value convergence to the global-min agreed frame (the c25fc1f desync fix, N=3 survivors) |
 | `FrameAdvantageAggregation.tla` | `FrameAdvantageAggregation.cfg` | ✓ CI | Cross-endpoint `max_frame_advantage` fold over N≥3 remotes — multi-handle idempotence, disconnect-gate exclusion, `i32::MIN→0` fallback (companion to `TimeSync.tla`) |
 | `SpectatorFailover.tla` | `SpectatorFailover.cfg` | ✓ CI | Multi-host spectator connect-status merge — converge-down to live global-min freeze + provenance-gated reactivation under host failover (companion to `SpectatorSession.tla`; audit F4 / critic-#1 / critic-#2) |
-| `DoubleFailureRelay.tla` | `DoubleFailureRelay.cfg` (+ `_Baseline.cfg`, `_Tombstone.cfg` demos) | ✓ CI | N≥4 "double-failure relay" freeze-barrier residual arbitration: reproduces the residual under the current fold (Baseline → safety violated), proves candidate fix #2 regresses liveness (Tombstone → liveness violated), and proves candidate fix #3 (mesh-acked-floor) sound (MeshAgree → safety+liveness PASS). The audit's last open potential-desync item (S41 REAL/deferred) |
+| `DoubleFailureRelay.tla` | `DoubleFailureRelay.cfg` (+ `_Baseline.cfg`, `_Tombstone.cfg`, `_InheritedFloor.cfg` demos) | ✓ CI | N≥4 "double-failure relay" freeze-barrier residual arbitration: reproduces the residual under the current fold (Baseline → safety violated), proves the dead-survivor tombstone regresses liveness (Tombstone → liveness violated), proves the cache-only no-wire shortcut unsound via the corroborate-then-drop race (InheritedFloor → safety violated), and proves candidate fix #3 (mesh-acked-floor) sound (MeshAgree → safety+liveness PASS). The audit's last open potential-desync item (S41 REAL/deferred) |
 
 ## Properties Verified
 
@@ -211,7 +211,7 @@ the per-endpoint gossip caches (which can go stale under partition), endpoint de
 (pruning), the prediction window (irreversible discard of confirmed frames below the
 window floor), and the freeze re-roll.
 
-The confirmation rule is a `FIX_MODE` constant exercised by three configs:
+The confirmation rule is a `FIX_MODE` constant exercised by four configs:
 
 - **Baseline** (`DoubleFailureRelay_Baseline.cfg`, expected to FAIL): the current
   production fold. TLC reproduces the residual as a **safety** counterexample
@@ -232,17 +232,37 @@ The confirmation rule is a `FIX_MODE` constant exercised by three configs:
   *current* freeze floor, read via a fresh ack — not the stale cache), holds while
   partitioned, and excludes the slot to MAX only once its freeze has fully converged.
   **Both** the safety invariants and the liveness property hold.
+- **InheritedFloor** (`DoubleFailureRelay_InheritedFloor.cfg`, expected to FAIL on
+  safety): candidate fix #4 — the **cache-only / no-wire shortcut**, the cheapest and
+  most tempting design. A survivor snapshots a departed connected source's last cached
+  low term (bounding both the confirm target and the freeze convergence) and releases
+  it only on *fresh* gossip from every remaining alive peer reporting the slot
+  connected above it — no wire change, no peer-receipt oracle. TLC reports
+  `NoConfirmedDivergence` **violated** via the **corroborate-then-drop race**: a peer
+  gossips `{connected, high}` (corroborating "healthy", releasing the observer's
+  floor), then detects the drop and freezes the slot *low* while its disconnect gossip
+  is still in flight — so the observer has already confirmed+locked the slot's real
+  inputs above the eventual freeze. The obstruction is **intrinsic** — a cache lags the
+  corroborator's own in-flight drop — and the adversarial review additionally disproved
+  the strongest cache-only variants (re-validate-against-current-cache, never-release =
+  Tombstone liveness, speculative-bound, link-reachability-hold, local generation
+  counter). This is the evidence that the production fix needs a fresh-ack *round* +
+  drop-epoch commitment, not passive gossip. The third documented dead-end.
 
 **Safety:** `NoConfirmedDivergence` (no two alive survivors permanently — both
 window-locked — disagree on the dropped slot's recorded confirmed value);
 `LockedRecordMatchesFreeze` (a mesh-agreed survivor's locked record equals the agreed
 freeze value); plus `FreezeNeverBelowGlobalMin` and `RecordedSourceInRange` sanity
 invariants. **Liveness:** `ConfirmationProgresses` (every alive survivor eventually
-confirms to the living mesh floor; partitions heal monotonically). The three configs
+confirms to the living mesh floor; partitions heal monotonically). The four configs
 together are the machine-checked arbitration: the residual is real (Baseline), the
-obvious non-wire fix regresses liveness (Tombstone), and the mesh-acked-floor design
-is sound (MeshAgree). The MeshAgree config is the design a future production
-red-green cycle should implement (a per-slot ack/epoch on connect-status gossip).
+dead-survivor tombstone regresses liveness (Tombstone), the cache-only no-wire
+shortcut is unsound via the corroborate-then-drop race (InheritedFloor), and the
+mesh-acked-floor design is sound (MeshAgree). The MeshAgree config is the design a
+future production red-green cycle should implement — and the InheritedFloor result is
+why it cannot be done without the wire piece: it needs a per-slot ack/epoch
+(fresh-ack round + drop-epoch commitment) on connect-status gossip, not passive
+gossip corroboration.
 
 ### PeerDrop.tla
 
@@ -416,6 +436,7 @@ Each spec has a `.cfg` file with TLC-compatible settings:
 | `FrameAdvantageAggregation.cfg` | NUM_ENDPOINTS=3, MAX_ADVANTAGE=4, MULTI_HANDLE_COUNT=2, MIN_RECOMMENDATION=3 (no symmetry) | ~26,200 distinct states (~901,000 generated) |
 | `SpectatorFailover.cfg` | HOSTS={1,2,3}, MAX_FRAME=3, NULL_FRAME=999 (no symmetry — canonical=min(live), liveness) | ~96,800 distinct states (~446,000 generated), ~6s single worker |
 | `DoubleFailureRelay.cfg` | SURVIVORS={a,b,c}, MAX_FRAME=3, WINDOW=1, RECEIPTS={0,3}, FIX_MODE="MeshAgree" (no symmetry — liveness; links monotone-heal, weak fairness) | ~865,600 distinct states (~3.88M generated), ~2min single worker |
+| `DoubleFailureRelay_InheritedFloor.cfg` (demo, expected FAIL — safety) | same constants, FIX_MODE="InheritedFloor" (cache-only no-wire shortcut) | `NoConfirmedDivergence` violated in ~2min (corroborate-then-drop race) |
 
 **Note on NULL_FRAME:** TLC config files don't support negative numbers,
 so we use `NULL_FRAME = 999` as a sentinel value instead of -1.
@@ -514,7 +535,7 @@ These specifications model the key algorithms from:
 | `TimeSync` | `src/time_sync.rs` (TimeSync; `advance_frame`, `average_frame_advantage`) |
 | `FrameAdvantageAggregation` | `src/sessions/p2p_session.rs` (`max_frame_advantage`, `check_wait_recommendation`, `frames_ahead`), `src/network/protocol/mod.rs` (`average_frame_advantage`, `handles`), `src/lib.rs` (`FortressEvent::WaitRecommendation`) |
 | `SpectatorFailover` | `src/sessions/p2p_spectator_session.rs` (`merge_connection_status`, `converged_drop_status`, `converge_latched_drop_status`, `reactivation_provenance`, `witness_host_drop_reports`, `consume_drop_witnesses`, `witness_adopted_drop`, `commit_canonical_snapshot`, `host_drop_witness`, `host_connect_status`) |
-| `DoubleFailureRelay` | `src/sessions/p2p_session.rs` (`remote_slot_confirmed_bound`, `update_player_disconnects`, `confirmed_frame`, the freeze-barrier fold and `!endpoint.is_running()` skip), `src/network/protocol/mod.rs` (`merge_peer_connect_status`, `is_running`); models the N≥4 residual the in-process test `tests/sessions/peer_drop.rs::p2p_n4_double_failure_relay_dropped_slot_diverges_across_survivors` characterizes. The MeshAgree fix is a *design* (mesh-acked-floor / per-slot ack-epoch) for a future production red-green cycle — not yet implemented in `src/` |
+| `DoubleFailureRelay` | `src/sessions/p2p_session.rs` (`remote_slot_confirmed_bound`, `update_player_disconnects`, `confirmed_frame`, the freeze-barrier fold and `!endpoint.is_running()` skip), `src/network/protocol/mod.rs` (`merge_peer_connect_status`, `is_running`); models the N≥4 residual the in-process test `tests/sessions/peer_drop.rs::p2p_n4_double_failure_relay_dropped_slot_diverges_across_survivors` characterizes. The MeshAgree fix is a *design* (mesh-acked-floor / per-slot ack-epoch) for a future production red-green cycle — not yet implemented in `src/`; the InheritedFloor result proves the cheaper cache-only / no-wire variant is unsound, so the wire ack-epoch is necessary |
 
 ## Extending the Specifications
 

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -38,6 +38,7 @@ This directory contains TLA+ specifications for formally verifying the correctne
 | `FreezeConvergence.tla` | `FreezeConvergence.cfg` | ✓ CI | Cross-survivor freeze-value convergence to the global-min agreed frame (the c25fc1f desync fix, N=3 survivors) |
 | `FrameAdvantageAggregation.tla` | `FrameAdvantageAggregation.cfg` | ✓ CI | Cross-endpoint `max_frame_advantage` fold over N≥3 remotes — multi-handle idempotence, disconnect-gate exclusion, `i32::MIN→0` fallback (companion to `TimeSync.tla`) |
 | `SpectatorFailover.tla` | `SpectatorFailover.cfg` | ✓ CI | Multi-host spectator connect-status merge — converge-down to live global-min freeze + provenance-gated reactivation under host failover (companion to `SpectatorSession.tla`; audit F4 / critic-#1 / critic-#2) |
+| `DoubleFailureRelay.tla` | `DoubleFailureRelay.cfg` (+ `_Baseline.cfg`, `_Tombstone.cfg` demos) | ✓ CI | N≥4 "double-failure relay" freeze-barrier residual arbitration: reproduces the residual under the current fold (Baseline → safety violated), proves candidate fix #2 regresses liveness (Tombstone → liveness violated), and proves candidate fix #3 (mesh-acked-floor) sound (MeshAgree → safety+liveness PASS). The audit's last open potential-desync item (S41 REAL/deferred) |
 
 ## Properties Verified
 
@@ -195,6 +196,53 @@ host-failover stale-resurrection trace; tightening the gate `>=` to `>` breaks
 Reachability probes confirm the interesting states (converge-down, genuine
 follow, failover-while-disconnected, latch-disconnected, gate boundary) are
 non-vacuously reached.
+
+### DoubleFailureRelay.tla
+
+Arbitrates the N≥4 **"double-failure relay"** freeze-barrier residual — the audit's
+last open potential-desync item, arbitrated REAL with the fix deferred-with-spec in
+Session 41. The S32 freeze barrier bounds each survivor's confirmed frame for a
+dropping slot by the mesh-gossip minimum, and both that **bound**
+(`remote_slot_confirmed_bound`) and the freeze **override**
+(`update_player_disconnects`) iterate the identical `is_running()` endpoint set — so
+confirmation can outrun a later-agreed freeze **only** when the low value's source
+endpoint LEAVES the fold (fold-membership asymmetry). The model captures the fold,
+the per-endpoint gossip caches (which can go stale under partition), endpoint death
+(pruning), the prediction window (irreversible discard of confirmed frames below the
+window floor), and the freeze re-roll.
+
+The confirmation rule is a `FIX_MODE` constant exercised by three configs:
+
+- **Baseline** (`DoubleFailureRelay_Baseline.cfg`, expected to FAIL): the current
+  production fold. TLC reproduces the residual as a **safety** counterexample
+  (`NoConfirmedDivergence` / `LockedRecordMatchesFreeze` violated) — the model-level
+  RED mirroring the in-process repro. The global-min source dies and is pruned, the
+  victim confirms+discards real inputs on a stale-high cache, and a late relay lowers
+  the freeze below the already-discarded window.
+- **Tombstone** (`DoubleFailureRelay_Tombstone.cfg`, expected to FAIL on the
+  PROPERTY): candidate fix #2 (keep folding a dead survivor's last term). Safety
+  holds, but the **liveness** property `ConfirmationProgresses` is violated — a dead
+  laggard's retained low term pins a still-live slot's confirmation below the living
+  floor forever (a survivor cannot tell a real freeze from ordinary lag at the moment
+  of death). The formal proof of the project rule "no partial fix — a partial fix
+  regresses liveness."
+- **MeshAgree** (`DoubleFailureRelay.cfg`, the default, ✓ CI): candidate fix #3.
+  Confirmation of a not-yet-mesh-agreed slot advances only to the **mesh-acked
+  floor** (the min over every alive peer reachable on a live link of that peer's
+  *current* freeze floor, read via a fresh ack — not the stale cache), holds while
+  partitioned, and excludes the slot to MAX only once its freeze has fully converged.
+  **Both** the safety invariants and the liveness property hold.
+
+**Safety:** `NoConfirmedDivergence` (no two alive survivors permanently — both
+window-locked — disagree on the dropped slot's recorded confirmed value);
+`LockedRecordMatchesFreeze` (a mesh-agreed survivor's locked record equals the agreed
+freeze value); plus `FreezeNeverBelowGlobalMin` and `RecordedSourceInRange` sanity
+invariants. **Liveness:** `ConfirmationProgresses` (every alive survivor eventually
+confirms to the living mesh floor; partitions heal monotonically). The three configs
+together are the machine-checked arbitration: the residual is real (Baseline), the
+obvious non-wire fix regresses liveness (Tombstone), and the mesh-acked-floor design
+is sound (MeshAgree). The MeshAgree config is the design a future production
+red-green cycle should implement (a per-slot ack/epoch on connect-status gossip).
 
 ### PeerDrop.tla
 
@@ -367,6 +415,7 @@ Each spec has a `.cfg` file with TLC-compatible settings:
 | `FreezeConvergence.cfg` | SURVIVORS={s1,s2,s3}, MAX_FRAME=3, NULL_FRAME=999 (no symmetry — liveness) | ~24,100 distinct states (~79,000 generated) |
 | `FrameAdvantageAggregation.cfg` | NUM_ENDPOINTS=3, MAX_ADVANTAGE=4, MULTI_HANDLE_COUNT=2, MIN_RECOMMENDATION=3 (no symmetry) | ~26,200 distinct states (~901,000 generated) |
 | `SpectatorFailover.cfg` | HOSTS={1,2,3}, MAX_FRAME=3, NULL_FRAME=999 (no symmetry — canonical=min(live), liveness) | ~96,800 distinct states (~446,000 generated), ~6s single worker |
+| `DoubleFailureRelay.cfg` | SURVIVORS={a,b,c}, MAX_FRAME=3, WINDOW=1, RECEIPTS={0,3}, FIX_MODE="MeshAgree" (no symmetry — liveness; links monotone-heal, weak fairness) | ~865,600 distinct states (~3.88M generated), ~2min single worker |
 
 **Note on NULL_FRAME:** TLC config files don't support negative numbers,
 so we use `NULL_FRAME = 999` as a sentinel value instead of -1.
@@ -465,6 +514,7 @@ These specifications model the key algorithms from:
 | `TimeSync` | `src/time_sync.rs` (TimeSync; `advance_frame`, `average_frame_advantage`) |
 | `FrameAdvantageAggregation` | `src/sessions/p2p_session.rs` (`max_frame_advantage`, `check_wait_recommendation`, `frames_ahead`), `src/network/protocol/mod.rs` (`average_frame_advantage`, `handles`), `src/lib.rs` (`FortressEvent::WaitRecommendation`) |
 | `SpectatorFailover` | `src/sessions/p2p_spectator_session.rs` (`merge_connection_status`, `converged_drop_status`, `converge_latched_drop_status`, `reactivation_provenance`, `witness_host_drop_reports`, `consume_drop_witnesses`, `witness_adopted_drop`, `commit_canonical_snapshot`, `host_drop_witness`, `host_connect_status`) |
+| `DoubleFailureRelay` | `src/sessions/p2p_session.rs` (`remote_slot_confirmed_bound`, `update_player_disconnects`, `confirmed_frame`, the freeze-barrier fold and `!endpoint.is_running()` skip), `src/network/protocol/mod.rs` (`merge_peer_connect_status`, `is_running`); models the N≥4 residual the in-process test `tests/sessions/peer_drop.rs::p2p_n4_double_failure_relay_dropped_slot_diverges_across_survivors` characterizes. The MeshAgree fix is a *design* (mesh-acked-floor / per-slot ack-epoch) for a future production red-green cycle — not yet implemented in `src/` |
 
 ## Extending the Specifications
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,12 @@ pub mod network {
     /// Provides centralized, zero-allocation-where-possible encoding and decoding
     /// of network messages using bincode.
     pub mod codec;
+    /// Recursion-depth-limited serde wrapper for peer-controlled decodes
+    /// (closes the recursive-`Config::State` stack-overflow surface, B-codec).
+    /// Only the hot-join `Config::State` snapshot decode (`codec::decode_bounded`)
+    /// needs it, so it is gated with that feature.
+    #[cfg(feature = "hot-join")]
+    mod codec_depth;
     #[doc(hidden)]
     pub mod compression;
     #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,31 @@
 #![warn(rustdoc::invalid_html_tags)]
 #![warn(rustdoc::bare_urls)]
 //#![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
+// Zero-panic policy: enforce the panic-prone-pattern lints on non-test library
+// code in the *normal* `cargo clippy` gate (the same set as the dedicated
+// `No Panics Check` job in ci-safety.yml). Putting them here means the standard
+// `cargo clippy --all-targets` that developers and CI already run catches an
+// unchecked `[index]`, `.unwrap()`, `panic!()`, etc. in `src/` — closing the
+// gap where such patterns previously only surfaced in the separate library-only
+// job. `not(any(test, loom, kani))` exempts the crate's own `#[cfg(test)]`
+// modules plus the `#[cfg(loom)]` concurrency-model and `#[cfg(kani)]` proof
+// code (all test-only configurations that legitimately index/unwrap, e.g.
+// loom's `Mutex::lock().unwrap()`); under normal `cargo clippy` none of those
+// cfgs are set, so the deny stays active on production `src/`. Integration tests
+// and examples are separate crates and are unaffected. Use a scoped
+// `#[allow(...)]` with justification for a deliberate exception.
+#![cfg_attr(
+    not(any(test, loom, kani)),
+    deny(
+        clippy::indexing_slicing,
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::unreachable
+    )
+)]
 use std::{fmt::Debug, hash::Hash};
 
 pub use error::{

--- a/src/network/codec.rs
+++ b/src/network/codec.rs
@@ -768,39 +768,71 @@ pub(crate) const MAX_BOUNDED_DECODE_LEN: usize = crate::rle::DEFAULT_MAX_DECODED
 /// Use this (not [`decode_value`]) for any value reconstructed from
 /// peer-controlled bytes whose type can contain a length-prefixed container.
 ///
-/// # Bounds *allocation*, not *recursion depth*
+/// # Bounds both *allocation* and *recursion depth*
 ///
-/// The limit caps total bytes allocated; it does **not** cap the decode's call
-/// stack. bincode decodes a recursive type (one transitively containing
-/// `Box<Self>`, `Vec<Self>`, etc.) by recursing once per level of nesting, and a
-/// deeply-nested value can be encoded in far fewer bytes than
-/// [`MAX_BOUNDED_DECODE_LEN`] (each nesting level adds only a tag/length byte or
-/// two). Such input therefore stays under the byte cap yet can still overflow
-/// the stack mid-decode — an uncatchable abort, not a recoverable `Err`. This
-/// limit cannot prevent that; callers must keep peer-decoded types non-recursive
-/// / shallow. (Thread-based stack bounding is intentionally avoided: it would
-/// require `T: Send`, which `T` here is not guaranteed to be.)
+/// The byte limit above caps total bytes allocated; on its own it does **not**
+/// cap the decode's call stack. bincode decodes a recursive type (one
+/// transitively containing `Box<Self>`, `Vec<Self>`, etc.) by recursing once per
+/// level of nesting, and a deeply-nested value can be encoded in far fewer bytes
+/// than [`MAX_BOUNDED_DECODE_LEN`] (each level adds only a tag/length byte or
+/// two), so a malicious blob could stay under the byte cap yet overflow the
+/// stack mid-decode — an uncatchable abort, not a recoverable `Err`. Because
+/// `Config::State` is only `DeserializeOwned` (it may legitimately be
+/// recursive), this function decodes through
+/// [`deserialize_depth_limited`](super::codec_depth::deserialize_depth_limited),
+/// which **rejects** nesting deeper than
+/// [`MAX_DECODE_DEPTH`](super::codec_depth::MAX_DECODE_DEPTH) with a recoverable
+/// `Err` before the stack can overflow. A `Send` bound (which a thread-stack
+/// trick would require) is therefore not needed, and no value shallower than the
+/// limit is affected.
 ///
 /// # Errors
 ///
-/// Returns [`CodecError::DecodeError`] when `bytes` exceeds the cap, when a
-/// declared container length would exceed the cap, or when bincode otherwise
-/// fails to decode (truncated input, trailing bytes are *not* rejected here —
-/// use [`decode_bounded_with_consumed`] if you need the consumed length).
+/// Returns [`CodecError::DecodeError`] when `bytes` exceeds the byte cap, when a
+/// declared container length would exceed the cap, when container nesting exceeds
+/// [`MAX_DECODE_DEPTH`](super::codec_depth::MAX_DECODE_DEPTH), or when bincode
+/// otherwise fails to decode (truncated input; trailing bytes are *not* rejected
+/// here — use [`decode_bounded_with_consumed`] if you need the consumed length).
 #[cfg(feature = "hot-join")]
 pub(crate) fn decode_bounded<T: DeserializeOwned>(bytes: &[u8]) -> CodecResult<T> {
-    decode_bounded_with_consumed(bytes).map(|(value, _consumed)| value)
+    // alloc-bound: the same MAX_BOUNDED_DECODE_LEN byte cap as
+    // `decode_bounded_with_consumed` (pre-reject + bincode `Limit`); see
+    // `bounded_decode_config` / `reject_over_cap` for the full allocation
+    // analysis. This path additionally bounds recursion DEPTH via the
+    // depth-limited deserializer below.
+    reject_over_cap(bytes.len())?;
+    let config = bounded_decode_config();
+    // Wrap bincode's deserializer so a deeply-nested (recursive) `Config::State`
+    // blob is rejected with a recoverable error instead of overflowing the stack
+    // (B-codec). `BorrowedSerdeDecoder` exposes the serde deserializer; the
+    // borrowed reader is correct for a `DeserializeOwned` type (no field actually
+    // borrows from the slice).
+    let mut decoder = bincode::serde::BorrowedSerdeDecoder::from_slice(bytes, config, ());
+    super::codec_depth::deserialize_depth_limited::<T, _>(
+        decoder.as_deserializer(),
+        super::codec_depth::MAX_DECODE_DEPTH,
+    )
+    .map_err(|e| CodecError::decode(e.to_string(), CodecOperation::Decode))
 }
 
 /// [`decode_bounded`] variant that also returns the number of bytes consumed,
 /// for callers that decode several bounded values back-to-back from one slice
 /// (e.g. the hot-join bridge-input blob: `num_players` fixed-width inputs
 /// concatenated) and must verify exact consumption.
+///
+/// Unlike [`decode_bounded`], this path is **not** recursion-depth-limited, and
+/// it does not need to be: its only callers decode `Config::Input`, which is
+/// bound `Copy`, and a `Copy + Sized` type is provably non-recursive (recursion
+/// requires `Box`/`Vec`/heap indirection, none of which are `Copy`; a direct
+/// `enum E { N([E; 2]) }` is infinite-size and rejected by the compiler). So
+/// malicious bytes cannot drive this decode into unbounded recursion, and the
+/// hot input-decode path stays on the direct bincode call.
 pub(crate) fn decode_bounded_with_consumed<T: DeserializeOwned>(
     bytes: &[u8],
 ) -> CodecResult<(T, usize)> {
     // alloc-bound: this decode is bounded to MAX_BOUNDED_DECODE_LEN (64 MiB) two
-    // ways. (1) `bytes` is pre-rejected when longer than the cap. (2) The bincode
+    // ways (see `reject_over_cap` + `bounded_decode_config`). (1) `bytes` is
+    // pre-rejected when longer than the cap. (2) The bincode
     // `Limit<MAX_BOUNDED_DECODE_LEN>` config makes every container decoder claim
     // its `len * size_of::<element>()` byte footprint against a running total
     // *before* allocating and error once it would exceed the cap, so a malicious
@@ -808,26 +840,34 @@ pub(crate) fn decode_bounded_with_consumed<T: DeserializeOwned>(
     // never a giant `vec![0u8; len]`. No input this function accepts can drive an
     // allocation past the cap. Empirically verified for both the per-element
     // (`Vec<T>`) and native (`serde_bytes`) decode paths.
-    if bytes.len() > MAX_BOUNDED_DECODE_LEN {
+    reject_over_cap(bytes.len())?;
+    let config = bounded_decode_config();
+    bincode::serde::decode_from_slice(bytes, config)
+        .map_err(|e| CodecError::decode(e.to_string(), CodecOperation::Decode))
+}
+
+/// Rejects an input slice longer than [`MAX_BOUNDED_DECODE_LEN`] before any
+/// decode begins — the first of the two allocation bounds shared by
+/// [`decode_bounded`] and [`decode_bounded_with_consumed`].
+fn reject_over_cap(len: usize) -> CodecResult<()> {
+    if len > MAX_BOUNDED_DECODE_LEN {
         return Err(CodecError::decode(
-            format!(
-                "input length {} exceeds bounded-decode cap {}",
-                bytes.len(),
-                MAX_BOUNDED_DECODE_LEN
-            ),
+            format!("input length {len} exceeds bounded-decode cap {MAX_BOUNDED_DECODE_LEN}"),
             CodecOperation::Decode,
         ));
     }
-    // `with_limit` is an inherent method on the concrete `Configuration`, so the
-    // limited config is built from the same `standard().with_fixed_int_encoding()`
-    // base as `config()` (kept byte-for-byte identical to the shared codec config,
-    // only adding the limit) rather than from the `impl Config` return of
-    // `config()`.
-    let config = bincode::config::standard()
+    Ok(())
+}
+
+/// The bincode config for bounded peer-decodes: the shared codec config
+/// ([`config`]'s `standard().with_fixed_int_encoding()`, kept byte-for-byte
+/// identical) plus a [`MAX_BOUNDED_DECODE_LEN`] byte limit. `with_limit` is an
+/// inherent method on the concrete `Configuration`, so this is built from the
+/// concrete base rather than the `impl Config` return of [`config`].
+fn bounded_decode_config() -> impl bincode::config::Config {
+    bincode::config::standard()
         .with_fixed_int_encoding()
-        .with_limit::<MAX_BOUNDED_DECODE_LEN>();
-    bincode::serde::decode_from_slice(bytes, config)
-        .map_err(|e| CodecError::decode(e.to_string(), CodecOperation::Decode))
+        .with_limit::<MAX_BOUNDED_DECODE_LEN>()
 }
 
 #[cfg(test)]

--- a/src/network/codec_depth.rs
+++ b/src/network/codec_depth.rs
@@ -2,7 +2,7 @@
 //!
 //! # The surface this closes (B-codec)
 //!
-//! The bounded decode in [`super::codec`] caps the total *bytes* a peer-supplied
+//! The bounded decode in [`codec`](crate::network::codec) caps the total *bytes* a peer-supplied
 //! blob may allocate, but it does **not** cap the decode's *call-stack depth*.
 //! bincode decodes a recursive type — one transitively containing `Box<Self>`,
 //! `Vec<Self>`, `Option<Box<Self>>`, etc. — by recursing once per level of
@@ -11,12 +11,14 @@
 //! under the byte cap yet can overflow the thread stack mid-decode — an
 //! **uncatchable abort**, not a recoverable `Err`. A malicious peer can craft
 //! exactly this blob for a hot-join [`Config::State`](crate::Config::State)
-//! snapshot ([`Config::State`] is only `Serialize + DeserializeOwned`, so it may
+//! snapshot ([`Config::State`](crate::Config::State) is only
+//! `Serialize + DeserializeOwned`, so it may
 //! be recursive).
 //!
 //! # What this does
 //!
-//! [`deserialize_depth_limited`] wraps any [`serde::Deserializer`] so that every
+//! [`deserialize_depth_limited`](crate::network::codec_depth::deserialize_depth_limited)
+//! wraps any [`serde::Deserializer`] so that every
 //! level of container nesting (`seq`/`tuple`/`map`/`struct`/`enum`/`option`/
 //! newtype) increments a depth counter, and a value nested deeper than the
 //! configured `limit` is **rejected with a recoverable error** before the stack
@@ -33,7 +35,8 @@
 //! `Box`/`Vec`/`String` — none of which are `Copy`; a direct `enum E { N([E;2]) }`
 //! is infinite-size and rejected by the compiler). So the input decode path
 //! cannot be driven into unbounded recursion by malicious bytes and needs no
-//! depth guard; only the `State` path (`super::codec::decode_bounded`) is
+//! depth guard; only the `State` path
+//! ([`codec::decode_bounded`](crate::network::codec::decode_bounded)) is
 //! wrapped.
 
 use serde::de::{

--- a/src/network/codec_depth.rs
+++ b/src/network/codec_depth.rs
@@ -1,0 +1,941 @@
+//! Recursion-depth-limited serde deserialization for peer-controlled values.
+//!
+//! # The surface this closes (B-codec)
+//!
+//! The bounded decode in [`super::codec`] caps the total *bytes* a peer-supplied
+//! blob may allocate, but it does **not** cap the decode's *call-stack depth*.
+//! bincode decodes a recursive type — one transitively containing `Box<Self>`,
+//! `Vec<Self>`, `Option<Box<Self>>`, etc. — by recursing once per level of
+//! nesting, and a deeply-nested value can be encoded in far fewer bytes than the
+//! byte cap (each level costs only a tag/length byte or two). Such input stays
+//! under the byte cap yet can overflow the thread stack mid-decode — an
+//! **uncatchable abort**, not a recoverable `Err`. A malicious peer can craft
+//! exactly this blob for a hot-join [`Config::State`](crate::Config::State)
+//! snapshot ([`Config::State`] is only `Serialize + DeserializeOwned`, so it may
+//! be recursive).
+//!
+//! # What this does
+//!
+//! [`deserialize_depth_limited`] wraps any [`serde::Deserializer`] so that every
+//! level of container nesting (`seq`/`tuple`/`map`/`struct`/`enum`/`option`/
+//! newtype) increments a depth counter, and a value nested deeper than the
+//! configured `limit` is **rejected with a recoverable error** before the stack
+//! can overflow. It is a transparent forwarding adapter otherwise: scalars and
+//! the value itself are decoded byte-for-byte identically to an unwrapped
+//! decode, so legitimate (shallow) states are unaffected. This is a *reject*,
+//! not a *grow* (no `unsafe` stack manipulation, no new dependency), matching
+//! the library's bounded-allocation / fail-closed discipline.
+//!
+//! # Why only `Config::State`
+//!
+//! [`Config::Input`](crate::Config::Input) is bound `Copy`, and a `Copy + Sized`
+//! type is **provably non-recursive** (recursion requires heap indirection —
+//! `Box`/`Vec`/`String` — none of which are `Copy`; a direct `enum E { N([E;2]) }`
+//! is infinite-size and rejected by the compiler). So the input decode path
+//! cannot be driven into unbounded recursion by malicious bytes and needs no
+//! depth guard; only the `State` path (`super::codec::decode_bounded`) is
+//! wrapped.
+
+use serde::de::{
+    self, DeserializeSeed, Deserializer, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor,
+};
+use std::fmt;
+
+/// Maximum container-nesting depth permitted when decoding a peer-controlled
+/// value. A value nested deeper is rejected with a recoverable error instead of
+/// overflowing the stack.
+///
+/// 128 mirrors `serde_json`'s default recursion limit: comfortably deeper than
+/// any realistic game state, yet far below the depth at which serde decoding
+/// overflows a typical thread stack (the exact overflow depth is type-dependent,
+/// since per-level stack cost varies by `T`, but is many times this limit), so a
+/// rejected blob can never have come close to a crash.
+pub(crate) const MAX_DECODE_DEPTH: usize = 128;
+
+/// Deserializes `T` from `deserializer`, rejecting any value whose container
+/// nesting exceeds `limit` with a recoverable error rather than overflowing the
+/// stack. Behaviourally identical to a plain decode for any value nested at most
+/// `limit` levels deep.
+pub(crate) fn deserialize_depth_limited<'de, T, D>(
+    deserializer: D,
+    limit: usize,
+) -> Result<T, D::Error>
+where
+    T: serde::Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    T::deserialize(DepthDeserializer {
+        inner: deserializer,
+        depth: 0,
+        limit,
+    })
+}
+
+/// The recoverable error returned when nesting exceeds the limit. Built on the
+/// cold path only.
+fn too_deep<E: de::Error>(limit: usize) -> E {
+    E::custom(format!(
+        "decode recursion depth exceeded the maximum nesting limit of {limit}"
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Deserializer wrapper
+// ---------------------------------------------------------------------------
+
+/// Wraps a deserializer at nesting level `depth`. Scalars forward unchanged;
+/// each composite forwards through a [`DepthVisitor`] that performs the depth
+/// check and re-wraps children at `depth + 1`.
+struct DepthDeserializer<D> {
+    inner: D,
+    depth: usize,
+    limit: usize,
+}
+
+/// Forwards a scalar `deserialize_*` directly: scalar visits never recurse, so
+/// the original visitor is passed through unchanged.
+macro_rules! forward_scalar_deserialize {
+    ($($m:ident),* $(,)?) => {$(
+        #[inline]
+        fn $m<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor<'de> {
+            self.inner.$m(visitor)
+        }
+    )*};
+}
+
+/// Forwards a composite `deserialize_*` (simple `(self, visitor)` signature)
+/// through a depth-tracking [`DepthVisitor`].
+macro_rules! forward_composite_deserialize {
+    ($($m:ident),* $(,)?) => {$(
+        #[inline]
+        fn $m<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor<'de> {
+            self.inner.$m(DepthVisitor { inner: visitor, depth: self.depth, limit: self.limit })
+        }
+    )*};
+}
+
+impl<'de, D> Deserializer<'de> for DepthDeserializer<D>
+where
+    D: Deserializer<'de>,
+{
+    type Error = D::Error;
+
+    forward_scalar_deserialize!(
+        deserialize_bool,
+        deserialize_i8,
+        deserialize_i16,
+        deserialize_i32,
+        deserialize_i64,
+        deserialize_i128,
+        deserialize_u8,
+        deserialize_u16,
+        deserialize_u32,
+        deserialize_u64,
+        deserialize_u128,
+        deserialize_f32,
+        deserialize_f64,
+        deserialize_char,
+        deserialize_str,
+        deserialize_string,
+        deserialize_bytes,
+        deserialize_byte_buf,
+        deserialize_unit,
+        deserialize_identifier,
+    );
+
+    // `option`, `seq` and `map` use the simple `(self, visitor)` signature and
+    // dispatch to recursive visits (`visit_some`/`visit_seq`/`visit_map`), so
+    // they wrap the visitor. `any`/`ignored_any` are wrapped defensively: for a
+    // non-self-describing format bincode errors on them, but if a future format
+    // supported them they could recurse.
+    forward_composite_deserialize!(
+        deserialize_option,
+        deserialize_seq,
+        deserialize_map,
+        deserialize_any,
+        deserialize_ignored_any,
+    );
+
+    #[inline]
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // A unit struct carries no nested value (`visit_unit`); forward the
+        // original visitor.
+        self.inner.deserialize_unit_struct(name, visitor)
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.deserialize_newtype_struct(
+            name,
+            DepthVisitor {
+                inner: visitor,
+                depth: self.depth,
+                limit: self.limit,
+            },
+        )
+    }
+
+    #[inline]
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.deserialize_tuple(
+            len,
+            DepthVisitor {
+                inner: visitor,
+                depth: self.depth,
+                limit: self.limit,
+            },
+        )
+    }
+
+    #[inline]
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.deserialize_tuple_struct(
+            name,
+            len,
+            DepthVisitor {
+                inner: visitor,
+                depth: self.depth,
+                limit: self.limit,
+            },
+        )
+    }
+
+    #[inline]
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.deserialize_struct(
+            name,
+            fields,
+            DepthVisitor {
+                inner: visitor,
+                depth: self.depth,
+                limit: self.limit,
+            },
+        )
+    }
+
+    #[inline]
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.deserialize_enum(
+            name,
+            variants,
+            DepthVisitor {
+                inner: visitor,
+                depth: self.depth,
+                limit: self.limit,
+            },
+        )
+    }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        self.inner.is_human_readable()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Visitor wrapper — performs the depth check and re-wraps children
+// ---------------------------------------------------------------------------
+
+/// Wraps a visitor for a value at nesting level `depth`. Scalar visits forward
+/// unchanged; recursive visits (`some`/`newtype`/`seq`/`map`/`enum`) reject when
+/// `depth >= limit` and otherwise re-wrap the child deserializer/accessor at
+/// `depth + 1`.
+struct DepthVisitor<V> {
+    inner: V,
+    depth: usize,
+    limit: usize,
+}
+
+/// Forwards a scalar `visit_*` (`(self, v: $t)` signature) to the inner visitor.
+macro_rules! forward_scalar_visit {
+    ($($m:ident($t:ty)),* $(,)?) => {$(
+        #[inline]
+        fn $m<E>(self, v: $t) -> Result<Self::Value, E>
+        where E: de::Error {
+            self.inner.$m(v)
+        }
+    )*};
+}
+
+impl<'de, V> Visitor<'de> for DepthVisitor<V>
+where
+    V: Visitor<'de>,
+{
+    type Value = V::Value;
+
+    #[inline]
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.expecting(formatter)
+    }
+
+    forward_scalar_visit!(
+        visit_bool(bool),
+        visit_i8(i8),
+        visit_i16(i16),
+        visit_i32(i32),
+        visit_i64(i64),
+        visit_i128(i128),
+        visit_u8(u8),
+        visit_u16(u16),
+        visit_u32(u32),
+        visit_u64(u64),
+        visit_u128(u128),
+        visit_f32(f32),
+        visit_f64(f64),
+        visit_char(char),
+        visit_str(&str),
+        visit_string(String),
+        visit_bytes(&[u8]),
+        visit_byte_buf(Vec<u8>),
+    );
+
+    #[inline]
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.inner.visit_borrowed_str(v)
+    }
+
+    #[inline]
+    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.inner.visit_borrowed_bytes(v)
+    }
+
+    #[inline]
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.inner.visit_none()
+    }
+
+    #[inline]
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.inner.visit_unit()
+    }
+
+    #[inline]
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if self.depth >= self.limit {
+            return Err(too_deep(self.limit));
+        }
+        self.inner.visit_some(DepthDeserializer {
+            inner: deserializer,
+            depth: self.depth + 1,
+            limit: self.limit,
+        })
+    }
+
+    #[inline]
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if self.depth >= self.limit {
+            return Err(too_deep(self.limit));
+        }
+        self.inner.visit_newtype_struct(DepthDeserializer {
+            inner: deserializer,
+            depth: self.depth + 1,
+            limit: self.limit,
+        })
+    }
+
+    #[inline]
+    fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        if self.depth >= self.limit {
+            return Err(too_deep(self.limit));
+        }
+        self.inner.visit_seq(DepthSeqAccess {
+            inner: seq,
+            depth: self.depth + 1,
+            limit: self.limit,
+        })
+    }
+
+    #[inline]
+    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        if self.depth >= self.limit {
+            return Err(too_deep(self.limit));
+        }
+        self.inner.visit_map(DepthMapAccess {
+            inner: map,
+            depth: self.depth + 1,
+            limit: self.limit,
+        })
+    }
+
+    #[inline]
+    fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+    where
+        A: EnumAccess<'de>,
+    {
+        if self.depth >= self.limit {
+            return Err(too_deep(self.limit));
+        }
+        self.inner.visit_enum(DepthEnumAccess {
+            inner: data,
+            depth: self.depth + 1,
+            limit: self.limit,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Access wrappers — propagate `depth + 1` to every child deserialize
+// ---------------------------------------------------------------------------
+
+/// Wraps a `SeqAccess`; every element deserializes at the child `depth`.
+struct DepthSeqAccess<A> {
+    inner: A,
+    depth: usize,
+    limit: usize,
+}
+
+impl<'de, A> SeqAccess<'de> for DepthSeqAccess<A>
+where
+    A: SeqAccess<'de>,
+{
+    type Error = A::Error;
+
+    #[inline]
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        self.inner.next_element_seed(DepthSeed {
+            inner: seed,
+            depth: self.depth,
+            limit: self.limit,
+        })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> Option<usize> {
+        self.inner.size_hint()
+    }
+}
+
+/// Wraps a `MapAccess`; every key and value deserializes at the child `depth`.
+struct DepthMapAccess<A> {
+    inner: A,
+    depth: usize,
+    limit: usize,
+}
+
+impl<'de, A> MapAccess<'de> for DepthMapAccess<A>
+where
+    A: MapAccess<'de>,
+{
+    type Error = A::Error;
+
+    #[inline]
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        self.inner.next_key_seed(DepthSeed {
+            inner: seed,
+            depth: self.depth,
+            limit: self.limit,
+        })
+    }
+
+    #[inline]
+    fn next_value_seed<Va>(&mut self, seed: Va) -> Result<Va::Value, Self::Error>
+    where
+        Va: DeserializeSeed<'de>,
+    {
+        self.inner.next_value_seed(DepthSeed {
+            inner: seed,
+            depth: self.depth,
+            limit: self.limit,
+        })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> Option<usize> {
+        self.inner.size_hint()
+    }
+}
+
+/// Wraps an `EnumAccess`. The variant *selector* is an identifier (a scalar that
+/// cannot recurse) and is deserialized directly; only the variant *payload*
+/// (via [`DepthVariantAccess`]) is depth-tracked.
+struct DepthEnumAccess<A> {
+    inner: A,
+    depth: usize,
+    limit: usize,
+}
+
+impl<'de, A> EnumAccess<'de> for DepthEnumAccess<A>
+where
+    A: EnumAccess<'de>,
+{
+    type Error = A::Error;
+    type Variant = DepthVariantAccess<A::Variant>;
+
+    #[inline]
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let (value, variant) = self.inner.variant_seed(seed)?;
+        Ok((
+            value,
+            DepthVariantAccess {
+                inner: variant,
+                depth: self.depth,
+                limit: self.limit,
+            },
+        ))
+    }
+}
+
+/// Wraps a `VariantAccess`; the variant payload deserializes at the child
+/// `depth`.
+struct DepthVariantAccess<A> {
+    inner: A,
+    depth: usize,
+    limit: usize,
+}
+
+impl<'de, A> VariantAccess<'de> for DepthVariantAccess<A>
+where
+    A: VariantAccess<'de>,
+{
+    type Error = A::Error;
+
+    #[inline]
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        self.inner.unit_variant()
+    }
+
+    #[inline]
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        self.inner.newtype_variant_seed(DepthSeed {
+            inner: seed,
+            depth: self.depth,
+            limit: self.limit,
+        })
+    }
+
+    #[inline]
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.tuple_variant(
+            len,
+            DepthVisitor {
+                inner: visitor,
+                depth: self.depth,
+                limit: self.limit,
+            },
+        )
+    }
+
+    #[inline]
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.struct_variant(
+            fields,
+            DepthVisitor {
+                inner: visitor,
+                depth: self.depth,
+                limit: self.limit,
+            },
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Seed wrapper — re-enters the depth-limited deserializer for each child
+// ---------------------------------------------------------------------------
+
+/// Wraps a `DeserializeSeed` so the child value is deserialized through a
+/// [`DepthDeserializer`] at `depth`.
+struct DepthSeed<S> {
+    inner: S,
+    depth: usize,
+    limit: usize,
+}
+
+impl<'de, S> DeserializeSeed<'de> for DepthSeed<S>
+where
+    S: DeserializeSeed<'de>,
+{
+    type Value = S::Value;
+
+    #[inline]
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        self.inner.deserialize(DepthDeserializer {
+            inner: deserializer,
+            depth: self.depth,
+            limit: self.limit,
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+    use serde::de::DeserializeOwned;
+    use serde::{Deserialize, Serialize};
+    use std::collections::BTreeMap;
+
+    fn bincode_config() -> impl bincode::config::Config {
+        bincode::config::standard().with_fixed_int_encoding()
+    }
+
+    fn encode<T: Serialize>(value: &T) -> Vec<u8> {
+        bincode::serde::encode_to_vec(value, bincode_config()).expect("encode")
+    }
+
+    /// Decode through the depth-limited wrapper at `limit`.
+    fn decode_depth_limited<T: DeserializeOwned>(
+        bytes: &[u8],
+        limit: usize,
+    ) -> Result<T, bincode::error::DecodeError> {
+        let mut decoder =
+            bincode::serde::BorrowedSerdeDecoder::from_slice(bytes, bincode_config(), ());
+        deserialize_depth_limited::<T, _>(decoder.as_deserializer(), limit)
+    }
+
+    /// Decode WITHOUT the wrapper — the control for non-vacuity (proves a
+    /// rejection comes from the depth guard, not malformed bytes).
+    fn decode_plain<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, bincode::error::DecodeError> {
+        bincode::serde::decode_from_slice(bytes, bincode_config()).map(|(v, _)| v)
+    }
+
+    // A type exercising every serde container kind so a missing forward or
+    // accessor bug in the wrapper would corrupt the round-trip.
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Inner {
+        x: u32,
+        next: Option<Box<Self>>, // recursive + option + newtype
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    enum Choice {
+        Unit,
+        Newtype(i64),
+        Tuple(u8, bool),
+        Struct { values: Vec<u8> },
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Rich {
+        flag: bool,
+        nums: Vec<i64>,
+        name: String,
+        maybe: Option<u32>,
+        pair: (u8, i16),
+        map: BTreeMap<String, u64>,
+        raw: Vec<u8>,
+        nested: Vec<Inner>,
+        choices: Vec<Choice>,
+        unit: (),
+    }
+
+    fn sample_rich() -> Rich {
+        let mut map = BTreeMap::new();
+        map.insert("a".to_owned(), 1u64);
+        map.insert("bb".to_owned(), 22u64);
+        Rich {
+            flag: true,
+            nums: vec![-1, 0, 7, i64::MAX, i64::MIN],
+            name: "fortress".to_owned(),
+            maybe: Some(99),
+            pair: (3, -300),
+            map,
+            raw: vec![0, 1, 2, 250, 255],
+            nested: vec![
+                Inner { x: 1, next: None },
+                Inner {
+                    x: 2,
+                    next: Some(Box::new(Inner { x: 3, next: None })),
+                },
+            ],
+            choices: vec![
+                Choice::Unit,
+                Choice::Newtype(-5),
+                Choice::Tuple(9, true),
+                Choice::Struct {
+                    values: vec![4, 5, 6],
+                },
+            ],
+            unit: (),
+        }
+    }
+
+    /// The wrapper is transparent: any value within the depth limit decodes
+    /// byte-for-byte identically to a plain decode (catches a missing `visit_*`
+    /// forward or a broken access wrapper).
+    #[test]
+    fn depth_limited_decode_is_transparent_for_diverse_types() {
+        let value = sample_rich();
+        let bytes = encode(&value);
+
+        let via_wrapper: Rich =
+            decode_depth_limited(&bytes, MAX_DECODE_DEPTH).expect("decode within limit");
+        assert_eq!(
+            via_wrapper, value,
+            "wrapper must not alter the decoded value"
+        );
+
+        // And identical to a plain (unwrapped) decode.
+        let via_plain: Rich = decode_plain(&bytes).expect("plain decode");
+        assert_eq!(
+            via_wrapper, via_plain,
+            "wrapper must match an unwrapped decode"
+        );
+    }
+
+    /// Scalars and an empty/shallow value are unaffected.
+    #[test]
+    fn depth_limited_decode_handles_scalars_and_empty_containers() {
+        for limit in [1usize, 2, MAX_DECODE_DEPTH] {
+            let n = encode(&123_456_789u64);
+            assert_eq!(decode_depth_limited::<u64>(&n, limit).unwrap(), 123_456_789);
+
+            let empty: Vec<u32> = Vec::new();
+            let e = encode(&empty);
+            assert_eq!(decode_depth_limited::<Vec<u32>>(&e, limit).unwrap(), empty);
+        }
+    }
+
+    // A linearly-recursive type so we can dial nesting depth precisely.
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    enum Nest {
+        Leaf(u32),
+        Node(Box<Self>),
+    }
+
+    fn build_nest(nodes: usize) -> Nest {
+        let mut n = Nest::Leaf(7);
+        for _ in 0..nodes {
+            n = Nest::Node(Box::new(n));
+        }
+        n
+    }
+
+    /// The guard rejects nesting at/above the limit with a recoverable error and
+    /// accepts nesting below it — and is NON-VACUOUS: the rejected blob decodes
+    /// fine WITHOUT the guard, so the `Err` is the guard, not malformed bytes.
+    #[test]
+    fn depth_limited_decode_rejects_beyond_limit_accepts_below() {
+        let limit = 5usize;
+
+        // `build_nest(d)` reaches serde nesting depth `d`; the guard fires when
+        // depth reaches `limit`, so `d < limit` is accepted and `d >= limit` is
+        // rejected.
+        let shallow = encode(&build_nest(limit - 1));
+        assert_eq!(
+            decode_depth_limited::<Nest>(&shallow, limit).unwrap(),
+            build_nest(limit - 1),
+            "nesting just below the limit must decode"
+        );
+
+        let deep = encode(&build_nest(limit));
+        let err = decode_depth_limited::<Nest>(&deep, limit);
+        assert!(
+            err.is_err(),
+            "nesting at the limit must be rejected with an error, not accepted"
+        );
+
+        // Non-vacuity: the same bytes decode fine without the guard.
+        assert_eq!(
+            decode_plain::<Nest>(&deep).unwrap(),
+            build_nest(limit),
+            "control: the rejected blob is well-formed (rejection is the guard)"
+        );
+
+        // A much deeper blob is also rejected (not an abort) — the whole point.
+        let very_deep = encode(&build_nest(limit + 500));
+        assert!(
+            decode_depth_limited::<Nest>(&very_deep, limit).is_err(),
+            "far-too-deep nesting must be a recoverable Err, never a stack-overflow abort"
+        );
+    }
+
+    // Recursion through a MAP (value type is `Self`) — exercises the
+    // `DepthMapAccess` path, distinct from the seq/enum path `Nest` uses.
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Default)]
+    struct MapNest(BTreeMap<u8, Self>);
+
+    fn build_map_nest(depth: usize) -> MapNest {
+        let mut n = MapNest::default();
+        for _ in 0..depth {
+            let mut m = BTreeMap::new();
+            m.insert(0u8, n);
+            n = MapNest(m);
+        }
+        n
+    }
+
+    // Recursion through a STRUCT-VARIANT payload — exercises
+    // `DepthVariantAccess::struct_variant`, distinct again.
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    enum StructVariantNest {
+        Leaf,
+        Node { child: Box<Self> },
+    }
+
+    fn build_struct_variant_nest(depth: usize) -> StructVariantNest {
+        let mut n = StructVariantNest::Leaf;
+        for _ in 0..depth {
+            n = StructVariantNest::Node { child: Box::new(n) };
+        }
+        n
+    }
+
+    /// The guard also bounds recursion that flows through the MAP and
+    /// STRUCT-VARIANT accessors (not just the seq/enum path the other tests use),
+    /// each proven non-vacuous by a successful unguarded control decode. This
+    /// locks in `DepthMapAccess` and `DepthVariantAccess::struct_variant` against
+    /// a future refactor that forgot to re-wrap one of those child paths.
+    #[test]
+    fn depth_limit_covers_map_and_struct_variant_recursion() {
+        let limit = 5usize;
+
+        let deep_map = encode(&build_map_nest(limit + 10));
+        assert!(
+            decode_depth_limited::<MapNest>(&deep_map, limit).is_err(),
+            "map-value recursion past the limit must be rejected (DepthMapAccess)"
+        );
+        assert!(
+            decode_plain::<MapNest>(&deep_map).is_ok(),
+            "control: the deep map blob is well-formed (rejection is the guard)"
+        );
+
+        let deep_sv = encode(&build_struct_variant_nest(limit + 10));
+        assert!(
+            decode_depth_limited::<StructVariantNest>(&deep_sv, limit).is_err(),
+            "struct-variant payload recursion past the limit must be rejected (DepthVariantAccess)"
+        );
+        assert!(
+            decode_plain::<StructVariantNest>(&deep_sv).is_ok(),
+            "control: the deep struct-variant blob is well-formed (rejection is the guard)"
+        );
+
+        // And a shallow value of each still round-trips unchanged under the
+        // production limit. (Each logical level of these types costs ~2 serde
+        // nesting levels — the newtype-struct/enum wrapper plus the map/struct —
+        // so the guard is conservatively stricter than the logical depth; use
+        // the generous production limit here to show shallow values are fine.)
+        let shallow_map = encode(&build_map_nest(2));
+        assert_eq!(
+            decode_depth_limited::<MapNest>(&shallow_map, MAX_DECODE_DEPTH).unwrap(),
+            build_map_nest(2),
+        );
+        let shallow_sv = encode(&build_struct_variant_nest(2));
+        assert_eq!(
+            decode_depth_limited::<StructVariantNest>(&shallow_sv, MAX_DECODE_DEPTH).unwrap(),
+            build_struct_variant_nest(2),
+        );
+    }
+
+    /// End-to-end through the production entry point `codec::decode_bounded`
+    /// (which uses [`MAX_DECODE_DEPTH`]): a deeply-recursive `Config::State`-shaped
+    /// blob is rejected with a recoverable error instead of aborting, while a
+    /// realistically-nested one decodes.
+    #[test]
+    fn decode_bounded_rejects_deeply_nested_state() {
+        use crate::network::codec;
+
+        let ok = encode(&build_nest(MAX_DECODE_DEPTH - 1));
+        assert_eq!(
+            codec::decode_bounded::<Nest>(&ok).expect("within MAX_DECODE_DEPTH"),
+            build_nest(MAX_DECODE_DEPTH - 1),
+        );
+
+        let too_deep = encode(&build_nest(MAX_DECODE_DEPTH + 50));
+        assert!(
+            codec::decode_bounded::<Nest>(&too_deep).is_err(),
+            "decode_bounded must reject a state nested past MAX_DECODE_DEPTH"
+        );
+        // Non-vacuity: well-formed bytes (a plain decode succeeds).
+        assert_eq!(
+            decode_plain::<Nest>(&too_deep).unwrap(),
+            build_nest(MAX_DECODE_DEPTH + 50),
+        );
+    }
+}

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -397,7 +397,10 @@ pub fn fuzz_protocol_input_packet(
     if packet_bytes.try_reserve_exact(byte_limit).is_err() {
         return;
     }
-    packet_bytes.extend_from_slice(&bytes[..byte_limit]);
+    // byte_limit <= bytes.len() by construction, so `get(..byte_limit)` is always
+    // Some; `unwrap_or_default()` keeps this panic-free (zero-panic policy /
+    // `clippy::indexing_slicing`) rather than indexing with `[..byte_limit]`.
+    packet_bytes.extend_from_slice(bytes.get(..byte_limit).unwrap_or_default());
 
     let body = Input {
         peer_connect_status: status,

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -214,6 +214,19 @@ where
     /// not leak into another remote's sync verdict (an N>=3 logical error if it
     /// were session-global). `None` until the first matching checksum.
     pub(crate) last_verified_frame: Option<Frame>,
+    /// Number of confirmed frames at which this peer's checksum did NOT match
+    /// our local history (the per-peer persistence signal behind B3 trust
+    /// downgrade). Monotonic (saturating), per-peer (never leaks across
+    /// remotes). On a confirmed frame a mismatch is a genuine state divergence
+    /// in the trusted-peer model; in an untrusted deployment a single one may be
+    /// a malicious/buggy peer's one-off bad checksum, so a count that climbs is
+    /// what marks a peer whose state *persistently* disagrees. Counted per
+    /// confirmed frame, so one divergence spanning many frames increments many
+    /// times. The library does NOT auto-eject on this — with two endpoints it
+    /// cannot tell which side is wrong — it only surfaces it (one advisory
+    /// WARNING at `CHECKSUM_MISMATCH_TRUST_DOWNGRADE_THRESHOLD`, plus
+    /// `P2PSession::peer_checksum_mismatch_count` for the raw value).
+    pub(crate) checksum_mismatch_count: u32,
     desync_detection: DesyncDetection,
 
     /// Optional deterministic RNG for protocol randomness.
@@ -658,6 +671,7 @@ impl<T: Config> UdpProtocol<T> {
             // debug desync
             pending_checksums: BTreeMap::new(),
             last_verified_frame: None,
+            checksum_mismatch_count: 0,
             desync_detection,
 
             // deterministic protocol RNG (if configured)

--- a/src/rle.rs
+++ b/src/rle.rs
@@ -203,20 +203,27 @@ fn try_encode_with_offset(buf: &[u8], offset: usize) -> RleResult<Vec<u8>> {
     };
 
     let mut cursor = 0;
-    while cursor < slice.len() {
-        let byte = slice[cursor];
+    // `slice.get(..)` is used instead of `slice[..]` so the scanner is panic-free
+    // by construction (zero-panic policy / `clippy::indexing_slicing`); the bounds
+    // checks are identical to the previous `cursor < slice.len()` guards.
+    while let Some(&byte) = slice.get(cursor) {
         let start = cursor;
         cursor += 1;
         if byte == 0 || byte == 255 {
-            while cursor < slice.len() && slice[cursor] == byte {
+            while slice.get(cursor) == Some(&byte) {
                 cursor += 1;
             }
             write_contiguous(&mut enc, (cursor - start) as u64, byte);
         } else {
-            while cursor < slice.len() && slice[cursor] != 0 && slice[cursor] != 255 {
+            while let Some(&b) = slice.get(cursor) {
+                if b == 0 || b == 255 {
+                    break;
+                }
                 cursor += 1;
             }
-            write_noncontiguous_slice(&mut enc, &slice[start..cursor]);
+            // start <= cursor <= slice.len() by construction, so this range is
+            // always valid; `unwrap_or_default()` is an unreachable safety net.
+            write_noncontiguous_slice(&mut enc, slice.get(start..cursor).unwrap_or_default());
         }
     }
 
@@ -236,7 +243,10 @@ fn write_contiguous(enc: &mut Vec<u8>, len: u64, prev_bits: u8) {
     // Use stack-allocated buffer to avoid heap allocation in hot path
     let mut temp_buf = [0u8; 10]; // Max varint size for u64
     let written = varint::encode(value, &mut temp_buf);
-    enc.extend_from_slice(&temp_buf[..written]);
+    // `written` is always <= temp_buf.len() (max 10 varint bytes for a u64), so
+    // `get(..written)` is always Some; `unwrap_or_default()` keeps it panic-free
+    // (zero-panic policy / `clippy::indexing_slicing`) without a real fallback.
+    enc.extend_from_slice(temp_buf.get(..written).unwrap_or_default());
 }
 
 /// Write a non-contiguous (uncompressed) sequence to the output.
@@ -250,7 +260,10 @@ fn write_noncontiguous_slice(enc: &mut Vec<u8>, noncontiguous_bits: &[u8]) {
     // Use stack-allocated buffer to avoid heap allocation in hot path
     let mut temp_buf = [0u8; 10]; // Max varint size for u64
     let written = varint::encode(value, &mut temp_buf);
-    enc.extend_from_slice(&temp_buf[..written]);
+    // `written` is always <= temp_buf.len() (max 10 varint bytes for a u64), so
+    // `get(..written)` is always Some; `unwrap_or_default()` keeps it panic-free
+    // (zero-panic policy / `clippy::indexing_slicing`) without a real fallback.
+    enc.extend_from_slice(temp_buf.get(..written).unwrap_or_default());
     enc.extend_from_slice(noncontiguous_bits);
 }
 

--- a/src/sessions/hot_join.rs
+++ b/src/sessions/hot_join.rs
@@ -8,7 +8,7 @@
 //!
 //! All items are `pub(crate)` and gated behind the `hot-join` feature.
 //!
-//! # Bounded deserialization (allocation only)
+//! # Bounded deserialization (allocation and recursion depth)
 //!
 //! A received `StateSnapshot::state_bytes` is peer-controlled. The wire-level
 //! [`decode_message`](crate::network::codec::decode_message) already bounds the
@@ -20,19 +20,20 @@
 //! caps every container claim at `MAX_BOUNDED_DECODE_LEN` so a hostile length
 //! prefix cannot drive an oversized *allocation*.
 //!
-//! This bounds allocation only — it does **not** bound *recursion depth*.
-//! bincode decodes a recursive type by recursing, and a pathologically
-//! deeply-nested `Config::State` (e.g. `enum Tree { Leaf(u8), Node(Box<Tree>) }`
-//! nested thousands deep) can be encoded in far fewer bytes than the
-//! `MAX_BOUNDED_DECODE_LEN` cap yet still exhaust the
-//! call stack while decoding — an uncatchable abort, not a recoverable `Err`.
-//! Reaching that requires a peer feeding such bytes through a custom socket
-//! large enough to carry them. Consistent with the project's "the user owns
-//! `Config::State`'s shape and determinism" stance, **save-state types should be
-//! non-recursive / shallow**; the bounded decoder cannot make a deeply recursive
-//! state safe to decode. See `decode_bounded` in the
-//! [`codec`](crate::network::codec) module for the analysis of bincode's
-//! *allocation* bounds.
+//! The byte cap alone bounds *allocation* but not *recursion depth*: bincode
+//! decodes a recursive type by recursing, and a pathologically deeply-nested
+//! `Config::State` (e.g. `enum Tree { Leaf(u8), Node(Box<Tree>) }` nested
+//! thousands deep) can be encoded in far fewer bytes than the
+//! `MAX_BOUNDED_DECODE_LEN` cap yet still exhaust the call stack while decoding.
+//! `codec::decode_bounded` therefore *also* bounds recursion depth: it decodes
+//! through a depth-limited serde wrapper that **rejects** nesting beyond
+//! `codec_depth::MAX_DECODE_DEPTH` with a recoverable `Err` instead of
+//! overflowing the stack (B-codec). So a deeply-recursive snapshot blob from a
+//! hostile peer is a clean decode error, not an uncatchable abort. (A
+//! `Config::State` nested *within* that generous limit decodes normally; the
+//! limit is far deeper than any realistic game state.) See `decode_bounded` /
+//! `codec_depth` in the [`codec`](crate::network::codec) module for the full
+//! allocation- and depth-bound analysis.
 
 use crate::network::codec;
 use crate::network::messages::{ConnectionStatus, Message, MessageBody, MessageHeader};
@@ -224,22 +225,23 @@ fn validate_snapshot_wire_size(
 /// incoming `bytes` slice is itself already bounded to the packet by chunk-2's
 /// [`decode_message`](crate::network::codec::decode_message).
 ///
-/// # Allocation is bounded; recursion depth is not
+/// # Allocation AND recursion depth are bounded
 ///
-/// The cap bounds memory, not stack depth. A `Config::State` that is recursive
-/// (e.g. a linked/tree type holding `Box<Self>`) can be encoded deeply nested in
-/// far fewer bytes than the cap, and bincode decodes it by recursing — so such
-/// input can still overflow the stack (an uncatchable abort, not an `Err`).
-/// `Config::State` save-state types should therefore be non-recursive / shallow;
-/// see the [module docs](self#bounded-deserialization-allocation-only).
+/// The byte cap bounds memory; `codec::decode_bounded` additionally bounds stack
+/// depth. A `Config::State` that is recursive (e.g. a linked/tree type holding
+/// `Box<Self>`) can be encoded deeply nested in far fewer bytes than the cap, and
+/// bincode decodes it by recursing — so it decodes through a depth-limited serde
+/// wrapper that **rejects** nesting beyond `codec_depth::MAX_DECODE_DEPTH` with a
+/// recoverable `Err` rather than overflowing the stack. A state nested within
+/// that (generous) limit decodes normally; see the
+/// [module docs](self#bounded-deserialization-allocation-and-recursion-depth).
 ///
 /// # Errors
 ///
 /// Returns [`FortressError::SerializationErrorStructured`] if `bytes` are
-/// truncated, malformed, exceed the bounded-decode cap, or declare a container
-/// length larger than the cap. Does not over-allocate on hostile input (a
-/// hostile *length prefix* yields `Err`, never an OOM); a deeply recursive
-/// `Config::State` is the documented exception — see above.
+/// truncated, malformed, exceed the bounded-decode cap, declare a container
+/// length larger than the cap, or are nested past the recursion-depth limit.
+/// Hostile input yields `Err`, never an OOM or a stack-overflow abort.
 // dead_code: consumed by chunk 5's joiner snapshot orchestration.
 #[cfg(feature = "hot-join")]
 #[allow(dead_code)]

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -5592,8 +5592,11 @@ impl<T: Config> P2PSession<T> {
     /// peer — so the dropped slot's input at the agreed frame is never lost
     /// and the post-agreement rollback target always stays inside the
     /// prediction window. At `N >= 4` the same bound strictly NARROWS the
-    /// race but does not fully close it: two corners (the stale-echo freeze
-    /// and the double-failure relay) are documented as residuals in
+    /// race but does not fully close it: one residual remains (the
+    /// **double-failure relay** — confirmation outruns a freeze only when the
+    /// low value's origin survivor dies and is pruned from the fold before its
+    /// relayed value lands; the sibling "stale-echo" framing was arbitrated
+    /// NOTABUG in Session 41). See the "Documented residuals" section of
     /// `remote_slot_confirmed_bound`.
     ///
     /// A slot whose disconnect is **mesh-agreed** (locally disconnected and no
@@ -7783,31 +7786,75 @@ impl<T: Config> P2PSession<T> {
     /// # Documented residuals (`N >= 4`; not closed by the barrier or nudge)
     ///
     /// The barrier closes the desync at `N == 3` and strictly narrows it at
-    /// `N >= 4`. Two `N >= 4` corners remain open (both require at least
-    /// three survivors; neither is a regression — the pre-barrier code had no
-    /// bound at all):
+    /// `N >= 4`. Two `N >= 4` corners were originally documented here as open;
+    /// **Session 41 arbitrated both red-test-first** and found they collapse to
+    /// ONE genuine residual. The unifying invariant: confirmation can outrun a
+    /// freeze frame ONLY when the low value's source endpoint LEAVES this
+    /// session's fold (fold-membership asymmetry). Both folds —
+    /// [`Self::remote_slot_confirmed_bound`] (the confirmed bound) and
+    /// [`Self::update_player_disconnects`] (the freeze override) — iterate the
+    /// identical `is_running()` / non-reserved endpoint set, so a term in one
+    /// fold is in the other (the membership is identical unconditionally).
+    /// Within any snapshot the bound equals the applied freeze in the
+    /// general-drop case both corners live in; an active reopened hot-join
+    /// reactivation instead clamps the bound conservatively ABOVE the raw terms
+    /// (`attempt_clamp`) while the override skips that handle — `bound >=
+    /// override`, never an overrun. Neither corner is a regression (the
+    /// pre-barrier code had no bound at all). Both require at least three
+    /// survivors.
     ///
-    /// - **Stale-echo freeze:** a third survivor `X` can freeze the dropped
-    ///   slot using its stale cache of OUR old (lower) claim — the moment
-    ///   ANOTHER peer's disconnect report flips `X`'s `queue_connected`,
-    ///   `X`'s endpoint-terms override mins that stale-low cached term and
-    ///   converges a freeze frame BELOW our current bound, which our
-    ///   confirmation may already have passed (re-exposing the window-floor
-    ///   mechanism). Impossible at `N == 3`: there the only packet that can
-    ///   flip `X`'s `queue_connected` comes from the endpoint whose term it
-    ///   would min, and the connect-status merge refreshes that same term
-    ///   BEFORE the fold runs. Not a mute problem, so the nudge does not
-    ///   close it (it is a stale-cache race).
-    /// - **Double-failure relay:** an origin survivor that dies AFTER
-    ///   relaying its low freeze value to a third peer but BEFORE delivering
-    ///   it to us leaves a window where our bound (no longer folding the dead
-    ///   origin's endpoint) exceeds the override later relayed through the
-    ///   third peer.
+    /// - **Stale-echo freeze — NOTABUG (arbitrated S41).** A stale-low term
+    ///   held by a STILL-RUNNING endpoint is folded into the confirmed bound
+    ///   AND the override identically, so confirmation is pinned AT the freeze
+    ///   value and never overruns it (proven by the `stale_echo_*` unit probes
+    ///   and `p2p_n4_stale_echo_freeze_*` in `tests/sessions/peer_drop.rs`,
+    ///   where the victim is pinned low with byte-identical confirmed state).
+    ///   The only cross-call escape — a still-running endpoint adopting a lower
+    ///   freeze on its disconnect-flip (`merge_peer_connect_status`'s
+    ///   first-disconnect `last_frame = remote.last_frame`) below an
+    ///   already-confirmed frame — is UNREACHABLE in a full mesh: for any
+    ///   endpoint to gossip a low `{disconnected, F}` we would adopt, some
+    ///   running endpoint must have gossiped that low `F`, and broadcast gossip
+    ///   (every input packet carries the full connect-status vector; the merge
+    ///   runs even for undecodable packets) delivers the same low `F` to US,
+    ///   pinning our own bound at `F` before we can confirm past it. The escape
+    ///   requires that source endpoint to be absent from our fold — i.e. the
+    ///   double-failure relay below. (`N == 3` is doubly safe: a survivor has
+    ///   one other survivor endpoint, so the flipping packet IS the term it
+    ///   would min.)
+    /// - **Double-failure relay — REAL (arbitrated S41).** The genuine
+    ///   residual. When the global-min origin survivor DIES (its endpoint goes
+    ///   non-running and is pruned from BOTH folds) AFTER relaying its low
+    ///   freeze `F` to a third survivor but BEFORE delivering it to us, and the
+    ///   relay is loss-delayed, our bound (no longer folding the dead origin)
+    ///   lets us confirm and DISCARD the dropped slot's real inputs in
+    ///   `(F, window_floor]`; the relayed `{disconnected, F}` then lands, the
+    ///   rollback target `F + 1` is below the prediction-window floor, the S20
+    ///   clamp keeps us live, and the discarded frames keep our real-input
+    ///   state while the relaying survivor froze at `F` — a permanent
+    ///   cross-survivor confirmed-STATE divergence. Insidiously the dropped
+    ///   slot's CONVERGED confirmed inputs match (frozen at `F` on both), so the
+    ///   input-checksum desync detector stays silent. This is the `N >= 4`
+    ///   instance of the discard-before-convergence residual the barrier closed
+    ///   at `N == 3`; it needs TWO simultaneous failures (origin death + relay
+    ///   delay). Deterministically reproduced (first divergence at `F + 1`,
+    ///   non-vacuous) by `p2p_n4_double_failure_relay_*` in
+    ///   `tests/sessions/peer_drop.rs`.
     ///
-    /// Future work for both: a stale-aware override fold (ignore cached terms
-    /// older than the slot's disconnect epoch) or full
-    /// mesh-agreement-before-freeze convergence. Byzantine peers are out of
-    /// scope entirely.
+    /// **Deferred fix (S41 — needs its own red-green + adversarial cycle; a
+    /// partial fix would regress liveness, so none is shipped):** close the
+    /// fold-membership asymmetry by one of (a) a per-slot DROP-EPOCH carried on
+    /// connect-status gossip so a relayed low `F` is recognized as authoritative
+    /// even after its origin dies and confirmation is held back (the wire-epoch
+    /// direction, shared with the host->spectator reactivation/epoch signal);
+    /// (b) a dead-survivor TOMBSTONE fold that retains a pruned survivor's last
+    /// gossiped term for a not-yet-mesh-agreed dropped slot until agreement
+    /// (non-wire, but must be reconciled with the S25 completeness-critic-#3
+    /// arbitration that the `is_running()` filter is correct — the tombstone is
+    /// a snapshot captured at death, distinct from folding a rearm-reset live
+    /// cache, and must `NULL`-guard the min); or (c) full
+    /// mesh-agreement-before-freeze (an ack round before discarding below a
+    /// freeze). Byzantine peers are out of scope entirely.
     ///
     /// # `N == 2` identity (normal operation)
     ///
@@ -12065,6 +12112,405 @@ mod tests {
             Frame::new(4),
             "the mined-down local view (4) must persist after B goes non-running — \
              nothing a non-running survivor knew is lost"
+        );
+    }
+
+    // ======================================================================
+    // ARBITRATION (N>=4 residual): the "stale-echo freeze" corner (VERDICT:
+    // NOTABUG) documented in `remote_slot_confirmed_bound`'s rustdoc. These
+    // tests directly manufacture the stale-echo cache state — a survivor X
+    // holding a STALE-LOW running-endpoint cache of survivor U's old gossip
+    // about dropped peer D, plus a disconnect-flip from a THIRD endpoint — and
+    // pin the INTRA-SNAPSHOT invariant: with that stale-low term already folded,
+    // is X's confirmed BOUND <= the freeze `update_player_disconnects` mines (so
+    // the freeze never lands BELOW the simultaneously-computed bound, never
+    // re-exposing the window-floor)?
+    //
+    // Verdict (these tests establish the intra-snapshot half): YES, bound ==
+    // applied freeze. The barrier (`remote_slot_confirmed_bound`) folds the SAME
+    // stale-low running-endpoint term into X's confirmed bound that the override
+    // (`update_player_disconnects`) later mins — a running endpoint cannot be in
+    // one fold but absent from the other (both gate on `is_running()` and, under
+    // hot-join, the reserved-endpoint guard). So a folded stale-low term pins the
+    // bound AT (or below) itself: the freeze never lands below it, and the mine
+    // -down rewrites only PREDICTED frames. (These probes capture `cf_before`
+    // AFTER the term is in the fold, so they pin THIS intra-snapshot invariant —
+    // NOT the temporal/reachability claim. The cross-call/reachability argument —
+    // broadcast gossip pins our bound, so the genuine escape needs fold-membership
+    // asymmetry, the PRUNED-endpoint double-failure relay — lives in the rustdoc
+    // and the `p2p_n4_stale_echo_freeze_*` integration test.)
+    // ======================================================================
+
+    /// Pins the INTRA-SNAPSHOT `bound == override` invariant. Manufactures the
+    /// canonical stale-echo shape on a live A(local)+B,C,D session with B's
+    /// stale-low term ALREADY folded, captures the confirmed bound (`cf_before`),
+    /// then drives the flip (`update_player_disconnects`) and proves the mined
+    /// freeze frame never lands strictly below that bound. Because `cf_before` is
+    /// read AFTER the stale-low term is in the fold, this pins the intra-snapshot
+    /// invariant — a folded stale-low term constrains the confirmed bound and the
+    /// freeze EQUALLY — NOT the temporal claim that X never confirms past it. The
+    /// cross-call/reachability argument (broadcast gossip pins our bound; the
+    /// genuine escape needs fold-membership asymmetry) lives in the rustdoc and the
+    /// `p2p_n4_stale_echo_freeze_*` integration test.
+    ///
+    /// Slot map: D = handle 3 is the dropped peer. U = endpoint B (handle 1)
+    /// holds the STALE-LOW connected cache of D (its `B->A` gossip about D went
+    /// stale low). The flip is delivered by endpoint C (handle 2) reporting D
+    /// disconnected. A's own (local) receipt of D is HIGH.
+    #[test]
+    fn stale_echo_barrier_pins_bound_to_stale_low_term_no_confirmation_overrun() {
+        let (mut session, addr_b, addr_c, addr_d) = build_abcd_live_session();
+        let d = PlayerHandle::new(3);
+
+        // A received D through a HIGH frame (20) and still believes D connected.
+        session.local_connect_status[d.as_usize()] = ConnectionStatus {
+            disconnected: false,
+            last_frame: Frame::new(20),
+        };
+        // A's own slots (handle 0) and the non-dropped survivors' slots must not
+        // pin the confirmed frame BELOW D's terms — give them all a high
+        // last_frame so D is the binding slot.
+        session.local_connect_status[0] = ConnectionStatus {
+            disconnected: false,
+            last_frame: Frame::new(20),
+        };
+        session.local_connect_status[1] = ConnectionStatus {
+            disconnected: false,
+            last_frame: Frame::new(20),
+        };
+        session.local_connect_status[2] = ConnectionStatus {
+            disconnected: false,
+            last_frame: Frame::new(20),
+        };
+
+        // Endpoint B (U): STALE-LOW connected cache of D at frame 3 (B's `B->A`
+        // gossip about D went stale low — the `B->A` link lost B's later, higher
+        // D gossip). For B/C's OWN slots and A's slot, high frames so only D's
+        // term is low.
+        {
+            let b = session
+                .player_reg
+                .remotes
+                .get_mut(&addr_b)
+                .expect("B endpoint");
+            b.set_peer_connect_status_for_tests(
+                d,
+                ConnectionStatus {
+                    disconnected: false,
+                    last_frame: Frame::new(3),
+                },
+            );
+            for h in [0, 1, 2] {
+                b.set_peer_connect_status_for_tests(
+                    PlayerHandle::new(h),
+                    ConnectionStatus {
+                        disconnected: false,
+                        last_frame: Frame::new(20),
+                    },
+                );
+            }
+        }
+        // Endpoint C (flip-trigger, not yet flipped): still reports D connected
+        // at a HIGH frame (18). Its OWN/other slots high too.
+        {
+            let c_ep = session
+                .player_reg
+                .remotes
+                .get_mut(&addr_c)
+                .expect("C endpoint");
+            for h in [0, 1, 2, 3] {
+                c_ep.set_peer_connect_status_for_tests(
+                    PlayerHandle::new(h),
+                    ConnectionStatus {
+                        disconnected: false,
+                        last_frame: Frame::new(if h == 3 { 18 } else { 20 }),
+                    },
+                );
+            }
+        }
+        // D's own endpoint is the dropped peer: take it down (non-running) so it
+        // leaves both folds, exactly like a dropped peer.
+        session
+            .player_reg
+            .remotes
+            .get_mut(&addr_d)
+            .expect("D endpoint")
+            .disconnect();
+
+        // STEP 1 — confirmation BEFORE the flip. The barrier folds B's stale-low
+        // connected cache of D (3) into the bound, so the confirmed frame is
+        // PINNED at 3 even though A received D through 20. This is the whole
+        // reason the corner cannot manifest: X never confirms past the stale-low
+        // term, because that term bounds X's confirmed frame directly.
+        let cf_before = session.confirmed_frame();
+        assert_eq!(
+            cf_before,
+            Frame::new(3),
+            "the barrier must pin the confirmed frame at the stale-low cached term (3); \
+             a confirmation that PASSED 3 here would be the prerequisite for the desync"
+        );
+
+        // STEP 2 — the flip. Endpoint C now reports D disconnected (a third
+        // peer's disconnect report), and A locally drops D at its own HIGH
+        // detection (20) — the pair the disconnect path sets together.
+        session
+            .player_reg
+            .remotes
+            .get_mut(&addr_c)
+            .expect("C endpoint")
+            .set_peer_connect_status_for_tests(
+                d,
+                ConnectionStatus {
+                    disconnected: true,
+                    last_frame: Frame::new(18),
+                },
+            );
+        session.local_connect_status[d.as_usize()] = ConnectionStatus {
+            disconnected: true,
+            last_frame: Frame::new(20),
+        };
+
+        // STEP 3 — the override fires. `update_player_disconnects` folds the SAME
+        // running endpoints (B still running, stale-low 3; C running,
+        // disconnected 18). `queue_connected(D)` flips false (C disconnected), and
+        // `queue_min_confirmed` mins B's stale-low term -> D is mined to 3.
+        session.update_player_disconnects();
+        let mined = session.local_connect_status[d.as_usize()].last_frame;
+        assert_eq!(
+            mined,
+            Frame::new(3),
+            "the override DOES mine D's freeze frame to the stale-low term (3) — but the \
+             barrier already held the confirmed bound there"
+        );
+
+        // THE DECISIVE INVARIANT: the override never freezes D BELOW the frame
+        // the session previously reported as confirmed. Equal is sound (the
+        // frozen value at the confirmed frame equals D's real input there); only
+        // STRICTLY BELOW would re-expose the window-floor (rewrite confirmed
+        // history). On current code it is exactly equal.
+        assert!(
+            mined >= cf_before,
+            "STALE-ECHO RED: the override mined D's freeze frame ({mined:?}) STRICTLY BELOW \
+             the previously-confirmed frame ({cf_before:?}) — confirmation overran the freeze, \
+             re-exposing the window-floor"
+        );
+    }
+
+    /// Non-vacuity / mechanism pin for the INTRA-SNAPSHOT invariant: proves the
+    /// stale-low term is what binds, by toggling ONLY whether endpoint B's cache
+    /// of D is stale-low vs fresh-high. With B stale-low (3) the bound is 3 and the
+    /// override mines to 3; with B fresh-high (20) the bound is min over the OTHER
+    /// terms and the override mines to that — the stale-low term is the sole cause
+    /// of the low freeze, AND in BOTH cases `mined >= cf_before` (a folded term
+    /// constrains the simultaneously-computed bound and freeze EQUALLY). Like its
+    /// sibling, `cf_before` is captured AFTER the term is folded, so this pins the
+    /// intra-snapshot `bound == override` equality, not the temporal/reachability
+    /// claim (which lives in the rustdoc and the `p2p_n4_stale_echo_freeze_*` test).
+    #[test]
+    fn stale_echo_stale_low_term_drives_freeze_but_never_below_confirmed() {
+        fn run(b_stale_low: bool) -> (Frame, Frame) {
+            let (mut session, addr_b, addr_c, addr_d) = build_abcd_live_session();
+            let d = PlayerHandle::new(3);
+            for h in [0, 1, 2] {
+                session.local_connect_status[h] = ConnectionStatus {
+                    disconnected: false,
+                    last_frame: Frame::new(20),
+                };
+            }
+            session.local_connect_status[d.as_usize()] = ConnectionStatus {
+                disconnected: false,
+                last_frame: Frame::new(20),
+            };
+            let b_d_frame = if b_stale_low { 3 } else { 20 };
+            {
+                let b = session
+                    .player_reg
+                    .remotes
+                    .get_mut(&addr_b)
+                    .expect("B endpoint");
+                for h in [0, 1, 2, 3] {
+                    b.set_peer_connect_status_for_tests(
+                        PlayerHandle::new(h),
+                        ConnectionStatus {
+                            disconnected: false,
+                            last_frame: Frame::new(if h == 3 { b_d_frame } else { 20 }),
+                        },
+                    );
+                }
+            }
+            {
+                let c_ep = session
+                    .player_reg
+                    .remotes
+                    .get_mut(&addr_c)
+                    .expect("C endpoint");
+                for h in [0, 1, 2, 3] {
+                    c_ep.set_peer_connect_status_for_tests(
+                        PlayerHandle::new(h),
+                        ConnectionStatus {
+                            disconnected: false,
+                            last_frame: Frame::new(if h == 3 { 18 } else { 20 }),
+                        },
+                    );
+                }
+            }
+            session
+                .player_reg
+                .remotes
+                .get_mut(&addr_d)
+                .expect("D endpoint")
+                .disconnect();
+
+            let cf_before = session.confirmed_frame();
+
+            // Flip via endpoint C + local detection at 20.
+            session
+                .player_reg
+                .remotes
+                .get_mut(&addr_c)
+                .expect("C endpoint")
+                .set_peer_connect_status_for_tests(
+                    d,
+                    ConnectionStatus {
+                        disconnected: true,
+                        last_frame: Frame::new(18),
+                    },
+                );
+            session.local_connect_status[d.as_usize()] = ConnectionStatus {
+                disconnected: true,
+                last_frame: Frame::new(20),
+            };
+            session.update_player_disconnects();
+            let mined = session.local_connect_status[d.as_usize()].last_frame;
+            (cf_before, mined)
+        }
+
+        let (cf_stale, mined_stale) = run(true);
+        let (cf_fresh, mined_fresh) = run(false);
+
+        // Stale-low B drives both the bound and the freeze down to 3.
+        assert_eq!(cf_stale, Frame::new(3), "stale-low B pins the bound at 3");
+        assert_eq!(
+            mined_stale,
+            Frame::new(3),
+            "stale-low B's term mines the freeze frame to 3"
+        );
+        // Fresh-high B leaves C's 18 as the binding low term (D connected at C's
+        // 18 before the flip), so the bound is 18 and the freeze converges to 18.
+        assert_eq!(
+            cf_fresh,
+            Frame::new(18),
+            "without the stale-low term the bound rises to the next-lowest term (C's 18)"
+        );
+        assert_eq!(
+            mined_fresh,
+            Frame::new(18),
+            "the freeze frame follows the same term up to 18"
+        );
+        // The stale-low term is the SOLE cause of the lower freeze (non-vacuity).
+        assert_ne!(
+            mined_stale, mined_fresh,
+            "the stale-low term must be the sole cause of the differing freeze frame"
+        );
+        // In BOTH runs the barrier tracked the term: confirmation never overran.
+        assert!(
+            mined_stale >= cf_stale && mined_fresh >= cf_fresh,
+            "the freeze frame must never land below the previously-confirmed frame in either run"
+        );
+    }
+
+    /// Closes the most plausible INTRA-SNAPSHOT escape: a stale-low term that is
+    /// already DISCONNECTED (not connected). One might hope a disconnected
+    /// stale-low cache excludes the slot from the BOUND (via `any_reports_connected`)
+    /// while still mining the OVERRIDE down — the bound-vs-freeze asymmetry that
+    /// would let the freeze land below the bound. It does not: for a non-hot-join
+    /// fold `folded_frame = status.last_frame` UNCONDITIONALLY, so a disconnected
+    /// stale-low term still contributes to `gossip_min` and pins the bound. The
+    /// slot is only excluded once EVERY running endpoint reports it disconnected
+    /// (mesh agreement) — at which point the override has nothing left to mine
+    /// below what is already converged. This pins the intra-snapshot bound (it
+    /// asserts `remote_slot_confirmed_bound` / `confirmed_frame` directly); the
+    /// temporal/reachability argument lives in the rustdoc and the
+    /// `p2p_n4_stale_echo_freeze_*` integration test.
+    #[test]
+    fn stale_echo_disconnected_stale_low_term_still_pins_bound() {
+        let (mut session, addr_b, addr_c, addr_d) = build_abcd_live_session();
+        let d = PlayerHandle::new(3);
+        for h in [0, 1, 2] {
+            session.local_connect_status[h] = ConnectionStatus {
+                disconnected: false,
+                last_frame: Frame::new(20),
+            };
+        }
+        // A received D through 20 and still believes D connected (A has NOT
+        // detected its own drop yet — the pre-detection window).
+        session.local_connect_status[d.as_usize()] = ConnectionStatus {
+            disconnected: false,
+            last_frame: Frame::new(20),
+        };
+        // Endpoint B: DISCONNECTED stale-low cache of D at frame 3.
+        {
+            let b = session
+                .player_reg
+                .remotes
+                .get_mut(&addr_b)
+                .expect("B endpoint");
+            for h in [0, 1, 2] {
+                b.set_peer_connect_status_for_tests(
+                    PlayerHandle::new(h),
+                    ConnectionStatus {
+                        disconnected: false,
+                        last_frame: Frame::new(20),
+                    },
+                );
+            }
+            b.set_peer_connect_status_for_tests(
+                d,
+                ConnectionStatus {
+                    disconnected: true,
+                    last_frame: Frame::new(3),
+                },
+            );
+        }
+        // Endpoint C: still reports D CONNECTED at a high frame (so the slot is
+        // NOT yet mesh-agreed — at least one running endpoint says connected).
+        {
+            let c_ep = session
+                .player_reg
+                .remotes
+                .get_mut(&addr_c)
+                .expect("C endpoint");
+            for h in [0, 1, 2, 3] {
+                c_ep.set_peer_connect_status_for_tests(
+                    PlayerHandle::new(h),
+                    ConnectionStatus {
+                        disconnected: false,
+                        last_frame: Frame::new(20),
+                    },
+                );
+            }
+        }
+        session
+            .player_reg
+            .remotes
+            .get_mut(&addr_d)
+            .expect("D endpoint")
+            .disconnect();
+
+        // The disconnected stale-low term (3) still pins the bound at 3, NOT the
+        // slot being excluded. A connected slot bounded by a disconnected
+        // endpoint's stale-low gossip — the barrier folds it regardless.
+        let status = session.local_connect_status[d.as_usize()];
+        assert_eq!(
+            session.remote_slot_confirmed_bound(d, &status),
+            Some(Frame::new(3)),
+            "a DISCONNECTED stale-low cache (3) must still pin the connected slot's bound at 3 \
+             — it is not excluded until EVERY running endpoint agrees on the disconnect"
+        );
+        assert_eq!(
+            session.confirmed_frame(),
+            Frame::new(3),
+            "confirmed_frame must be pinned at the disconnected stale-low term, not race past it"
         );
     }
 

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -7916,19 +7916,27 @@ impl<T: Config> P2PSession<T> {
     ///   `tests/sessions/peer_drop.rs`.
     ///
     /// **Deferred fix (S41 — needs its own red-green + adversarial cycle; a
-    /// partial fix would regress liveness, so none is shipped):** close the
-    /// fold-membership asymmetry by one of (a) a per-slot DROP-EPOCH carried on
-    /// connect-status gossip so a relayed low `F` is recognized as authoritative
-    /// even after its origin dies and confirmation is held back (the wire-epoch
-    /// direction, shared with the host->spectator reactivation/epoch signal);
-    /// (b) a dead-survivor TOMBSTONE fold that retains a pruned survivor's last
-    /// gossiped term for a not-yet-mesh-agreed dropped slot until agreement
-    /// (non-wire, but must be reconciled with the S25 completeness-critic-#3
-    /// arbitration that the `is_running()` filter is correct — the tombstone is
-    /// a snapshot captured at death, distinct from folding a rearm-reset live
-    /// cache, and must `NULL`-guard the min); or (c) full
-    /// mesh-agreement-before-freeze (an ack round before discarding below a
-    /// freeze). Byzantine peers are out of scope entirely.
+    /// partial fix would regress liveness, so none is shipped).** The fix
+    /// direction is now machine-arbitrated in `specs/tla/DoubleFailureRelay.tla`
+    /// (S42/S44): close the fold-membership asymmetry by **(a)** a per-slot
+    /// DROP-EPOCH carried on connect-status gossip PLUS a `FRESH-ACK ROUND` that
+    /// holds confirmation of a not-yet-mesh-agreed dropped slot until a *fresh*
+    /// ack (one that postdates our intent to advance) from every reachable-alive
+    /// peer corroborates the floor — the epoch makes that ack a commitment under
+    /// latency (the wire-epoch direction, shared with the host->spectator
+    /// reactivation/epoch signal); this is the verified-SOUND `MeshAgree` policy.
+    /// **The cheaper alternatives are MACHINE-DISPROVEN:** (b) a dead-survivor
+    /// TOMBSTONE fold regresses liveness (a dead laggard's retained low term pins
+    /// a still-live slot forever — `Tombstone` cfg, conflicting with the S25
+    /// `is_running()`-filter arbitration); and the tempting NO-WIRE / cache-only
+    /// "inherited floor" (snapshot a departed source's low term, release on fresh
+    /// gossip corroboration) is UNSOUND via the *corroborate-then-drop race* — a
+    /// peer corroborates connected-above-floor and then drops the slot low with
+    /// its disconnect gossip still in flight, so we confirm+lock real inputs
+    /// above the freeze (`InheritedFloor` cfg). The obstruction is intrinsic: a
+    /// cache lags the corroborator's own in-flight drop, so PASSIVE gossip alone
+    /// cannot be the commitment — the fresh-ack *round* (not just a wire field)
+    /// is necessary. Byzantine peers are out of scope entirely.
     ///
     /// # `N == 2` identity (normal operation)
     ///

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -57,6 +57,33 @@ const MIN_RECOMMENDATION: u32 = 3;
 #[cfg(test)]
 const DEFAULT_MAX_EVENT_QUEUE_SIZE: usize = 100;
 
+/// Number of mismatching confirmed-frame checksums from a single peer at which
+/// the library emits a one-time advisory trust-downgrade WARNING (B3 Byzantine
+/// hardening).
+///
+/// Checksums are compared only on *confirmed* frames, whose inputs are
+/// byte-identical across honest peers, so in the default trusted-peer model a
+/// mismatch is a **genuine, permanent** state divergence (not a transient — the
+/// historic false-positive cases were bugs that were fixed). In an *untrusted*
+/// deployment a single mismatch may instead be a malicious or buggy peer
+/// emitting one bad checksum, which is the case this threshold disambiguates:
+/// once a peer's per-peer mismatch count (see
+/// [`UdpProtocol::checksum_mismatch_count`]) reaches it, the divergence is
+/// *persistent* and the library logs a richer diagnostic so an operator /
+/// application can downgrade trust. It is deliberately advisory: the library
+/// never auto-ejects — with only two endpoints it cannot tell which side is
+/// wrong, and ejecting may remove the honest peer. Applications wanting a
+/// different policy read the raw count via
+/// [`P2PSession::peer_checksum_mismatch_count`].
+///
+/// The count is per *confirmed frame*, so a single logical divergence at frame
+/// `F` increments once for every confirmed frame `>= F` it is compared against
+/// (a rollback / catch-up can confirm and compare many at once). The threshold
+/// can therefore be crossed by one divergence spanning many frames, not only by
+/// repeated independent episodes — which is the intent: a divergence that
+/// persists across this many confirmed frames has demonstrably not self-corrected.
+pub(crate) const CHECKSUM_MISMATCH_TRUST_DOWNGRADE_THRESHOLD: u32 = 10;
+
 /// Default for the hot-join serve timeout: the maximum number of
 /// [`poll_remote_clients`](P2PSession::poll_remote_clients) calls a host will
 /// keep a single hot-join serve open (re-sending the cached snapshot each poll)
@@ -6633,6 +6660,53 @@ impl<T: Config> P2PSession<T> {
         Some(SyncHealth::Pending)
     }
 
+    /// Returns how many confirmed-frame checksums received from `player_handle`
+    /// have **failed** to match our local checksum history — the per-peer
+    /// persistence signal behind the library's B3 trust-downgrade hardening.
+    ///
+    /// Returns `None` for a local player, a spectator, an invalid handle, or a
+    /// remote whose endpoint is gone; `Some(0)` for a connected remote that has
+    /// never mismatched. The count is per-peer (verification or mismatch against
+    /// one remote never leaks into another's) and monotonic for the life of the
+    /// endpoint. It is counted per confirmed frame, so one logical divergence
+    /// spanning many frames increments it many times.
+    ///
+    /// # Why this exists (and what it is *not*)
+    ///
+    /// A [`SyncHealth::DesyncDetected`] should be handled gracefully, not by
+    /// crashing the process: it is a recoverable library event. On a *confirmed*
+    /// frame in the default trusted-peer model it is a genuine, permanent state
+    /// divergence — end the affected session cleanly and surface diagnostics, do
+    /// not `panic!`. In an *untrusted* deployment a *single* mismatch may instead
+    /// be a malicious or buggy peer emitting one bad checksum, and a count that
+    /// **climbs** is what marks a peer whose state *persistently* disagrees with
+    /// ours. The library logs one advisory WARNING when the count crosses an
+    /// internal threshold but **never auto-ejects**: with only two endpoints it
+    /// cannot tell which side is wrong, so dropping a peer risks removing the
+    /// honest one. Use this to apply your own trust policy (e.g. surface a richer
+    /// diagnostic, or — only in a deployment with independent
+    /// identity/corroboration — quarantine a peer that mismatches far past the
+    /// honest-desync range).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Persistent mismatches from one peer: downgrade trust, do not crash.
+    /// if let Some(n) = session.peer_checksum_mismatch_count(handle) {
+    ///     if n >= 10 {
+    ///         log::warn!("peer {handle:?} has {n} checksum mismatches");
+    ///     }
+    /// }
+    /// ```
+    #[must_use]
+    pub fn peer_checksum_mismatch_count(&self, player_handle: PlayerHandle) -> Option<u32> {
+        let PlayerType::Remote(addr) = self.player_reg.handles.get(&player_handle)? else {
+            return None;
+        };
+        let remote = self.player_reg.remotes.get(addr)?;
+        Some(remote.checksum_mismatch_count)
+    }
+
     /// Returns `true` if every currently-**connected** remote peer shows
     /// [`SyncHealth::InSync`].
     ///
@@ -8946,6 +9020,46 @@ impl<T: Config> P2PSession<T> {
                                     remote_checksum,
                                     addr: remote.peer_addr(),
                                 });
+                                // B3 (Byzantine hardening): track per-peer
+                                // mismatch persistence. On a confirmed frame a
+                                // mismatch is a genuine divergence in the
+                                // trusted model; in an untrusted deployment a
+                                // lone one may be an adversarial checksum, so a
+                                // count that climbs is what marks a peer that
+                                // persistently disagrees with us. We surface it
+                                // (one advisory WARNING at the threshold) but
+                                // never auto-eject — with two endpoints we
+                                // cannot tell which side is wrong, and a
+                                // persistent honest desync should be ended
+                                // gracefully, not by silently dropping a peer.
+                                // `saturating_add` is deliberate: a count pegged
+                                // at u32::MAX still means "persistent" (the
+                                // threshold was crossed long before), and it
+                                // keeps the counter overflow-safe.
+                                remote.checksum_mismatch_count =
+                                    remote.checksum_mismatch_count.saturating_add(1);
+                                // The `== THRESHOLD` equality fires the WARNING
+                                // exactly once: the count passes through every
+                                // integer (this `+1` is in the same loop body as
+                                // the check, no early exit between), so even a
+                                // catch-up batch that drives it from below to
+                                // above the threshold still hits the `==` frame.
+                                if remote.checksum_mismatch_count
+                                    == CHECKSUM_MISMATCH_TRUST_DOWNGRADE_THRESHOLD
+                                {
+                                    report_violation!(
+                                        ViolationSeverity::Warning,
+                                        ViolationKind::ChecksumMismatch,
+                                        "Peer {:?} produced {} mismatching checksums (>= \
+                                         trust-downgrade threshold {}): persistent state \
+                                         divergence. Downgrade trust / surface to the \
+                                         application; the library does not auto-eject (it \
+                                         cannot tell which endpoint is wrong).",
+                                        remote.peer_addr(),
+                                        remote.checksum_mismatch_count,
+                                        CHECKSUM_MISMATCH_TRUST_DOWNGRADE_THRESHOLD
+                                    );
+                                }
                             } else {
                                 // Checksums match - update this peer's verified frame.
                                 // Per-peer (not session-global) so verification against one
@@ -10481,6 +10595,211 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, FortressEvent::DesyncDetected { .. })),
             "no false-positive DesyncDetected after stale checksum invalidation"
+        );
+    }
+
+    /// Thread-local tracing capture for tests asserting whether (and how often)
+    /// a `report_violation!` WARNING fired. `report_violation!` routes to the
+    /// global `TracingObserver` (a `warn!`/`error!` event), so capturing the
+    /// tracing events is the only way to observe it. Returns every WARN-level
+    /// message emitted while `body` ran. Thread-local, so it is parallel-safe
+    /// under both nextest and threaded `cargo test`.
+    fn capture_warn_messages(body: impl FnOnce()) -> Vec<String> {
+        use std::sync::{Arc, Mutex};
+
+        struct CapSub {
+            events: Arc<Mutex<Vec<(bool, String)>>>,
+        }
+        impl tracing::Subscriber for CapSub {
+            fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+                true
+            }
+            fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+                tracing::span::Id::from_u64(1)
+            }
+            fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+            fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+            fn event(&self, event: &tracing::Event<'_>) {
+                struct V<'a>(&'a mut String);
+                impl tracing::field::Visit for V<'_> {
+                    fn record_debug(
+                        &mut self,
+                        field: &tracing::field::Field,
+                        value: &dyn std::fmt::Debug,
+                    ) {
+                        if field.name() == "message" {
+                            use std::fmt::Write as _;
+                            let _ = write!(self.0, "{value:?}");
+                        }
+                    }
+                }
+                let mut message = String::new();
+                event.record(&mut V(&mut message));
+                self.events
+                    .lock()
+                    .expect("capture mutex")
+                    .push((*event.metadata().level() == tracing::Level::WARN, message));
+            }
+            fn enter(&self, _: &tracing::span::Id) {}
+            fn exit(&self, _: &tracing::span::Id) {}
+        }
+
+        let events = Arc::new(Mutex::new(Vec::new()));
+        tracing::subscriber::with_default(
+            CapSub {
+                events: Arc::clone(&events),
+            },
+            body,
+        );
+        let captured = std::mem::take(&mut *events.lock().expect("capture mutex"));
+        captured
+            .into_iter()
+            .filter_map(|(is_warn, message)| is_warn.then_some(message))
+            .collect()
+    }
+
+    /// B3 (Byzantine hardening): a peer that sends persistently mismatching
+    /// checksums must (1) accumulate a per-peer mismatch count queryable via
+    /// [`P2PSession::peer_checksum_mismatch_count`], (2) be surfaced by exactly
+    /// ONE advisory trust-downgrade WARNING once the count reaches the threshold
+    /// (NOT on the first mismatch), and (3) NEVER be auto-ejected by the library
+    /// — with two endpoints we cannot tell which side is wrong, so dropping a
+    /// peer risks removing the honest one. The count is per-peer, so a
+    /// misbehaving peer does not taint a well-behaved one.
+    #[test]
+    fn persistent_checksum_mismatch_counts_warns_once_and_never_ejects() {
+        let threshold = CHECKSUM_MISMATCH_TRUST_DOWNGRADE_THRESHOLD;
+        let handle_b = PlayerHandle::new(1);
+        let handle_d = PlayerHandle::new(2);
+        let addr_b = test_addr(8080);
+
+        let warns = capture_warn_messages(|| {
+            let mut session = create_three_player_desync_session();
+
+            // Advance + confirm a wide window so every test frame compares
+            // (the comparison skips frames >= last_confirmed_frame).
+            for _ in 0..(threshold as i32 + 4) {
+                session.sync_layer.advance_frame();
+            }
+            session
+                .sync_layer
+                .set_last_confirmed_frame(Frame::new(threshold as i32 + 3), session.save_mode);
+
+            // Feed B `count` mismatching checksums starting at frame `base`,
+            // then run the production comparison (which consumes them).
+            let feed_mismatches = |session: &mut P2PSession<TestConfig>, base: i32, count: i32| {
+                for f in base..(base + count) {
+                    let frame = Frame::new(f);
+                    session.local_checksum_history.insert(frame, 0xAAAA_AAAA);
+                    session
+                        .player_reg
+                        .remotes
+                        .get_mut(&addr_b)
+                        .expect("B endpoint exists")
+                        .pending_checksums
+                        .insert(frame, 0xBBBB_BBBB); // differs from local => mismatch
+                }
+                session.compare_local_checksums_against_peers();
+            };
+
+            // A single mismatch must NOT trip the threshold.
+            feed_mismatches(&mut session, 0, 1);
+            assert_eq!(
+                session.peer_checksum_mismatch_count(handle_b),
+                Some(1),
+                "one mismatch must yield a per-peer count of 1"
+            );
+
+            // Drive the count up to exactly the threshold.
+            feed_mismatches(&mut session, 1, threshold as i32 - 1);
+            assert_eq!(
+                session.peer_checksum_mismatch_count(handle_b),
+                Some(threshold),
+                "the per-peer mismatch count must reach the trust-downgrade threshold"
+            );
+
+            // (3) The misbehaving peer is NEVER auto-ejected by the library.
+            assert!(
+                session.player_reg.remotes.contains_key(&addr_b),
+                "B's endpoint must still exist — the library must not auto-eject on mismatch"
+            );
+            assert!(
+                !session.local_connect_status[handle_b.as_usize()].disconnected,
+                "B must not be marked disconnected by the library on checksum mismatch"
+            );
+
+            // Per-peer isolation: D (sent nothing) stays at 0 — no cross-peer taint.
+            assert_eq!(
+                session.peer_checksum_mismatch_count(handle_d),
+                Some(0),
+                "a well-behaved peer's mismatch count must stay 0 (per-peer)"
+            );
+        });
+
+        // (2) Exactly ONE advisory trust-downgrade WARNING fired — at the
+        // threshold, not on the first mismatch and not repeated afterwards.
+        let trust_warns = warns
+            .iter()
+            .filter(|m| m.contains("trust-downgrade threshold"))
+            .count();
+        assert_eq!(
+            trust_warns, 1,
+            "exactly one advisory trust-downgrade WARNING must fire at the threshold; got {trust_warns} in {warns:?}"
+        );
+    }
+
+    /// B3: the advisory WARNING fires exactly ONCE even when a single catch-up
+    /// batch drives the per-peer mismatch count from BELOW the threshold to
+    /// ABOVE it in one `compare_local_checksums_against_peers` call. This is the
+    /// adversarial case for the `== THRESHOLD` equality: because the count is
+    /// incremented by one and checked in the same loop body, it passes through
+    /// the exact threshold value even on an overshooting batch, so the equality
+    /// can never be skipped. (A future refactor to `+= n` would silently break
+    /// this; the test locks it in.)
+    #[test]
+    fn checksum_mismatch_warning_fires_once_on_batch_overshooting_threshold() {
+        let threshold = CHECKSUM_MISMATCH_TRUST_DOWNGRADE_THRESHOLD;
+        let handle_b = PlayerHandle::new(1);
+        let addr_b = test_addr(8080);
+        let overshoot = threshold as i32 + 5; // jump well past the threshold in one batch
+
+        let warns = capture_warn_messages(|| {
+            let mut session = create_three_player_desync_session();
+            for _ in 0..(overshoot + 4) {
+                session.sync_layer.advance_frame();
+            }
+            session
+                .sync_layer
+                .set_last_confirmed_frame(Frame::new(overshoot + 3), session.save_mode);
+
+            // One batch of `threshold + 5` mismatching checksums to a fresh peer.
+            for f in 0..overshoot {
+                let frame = Frame::new(f);
+                session.local_checksum_history.insert(frame, 0xAAAA_AAAA);
+                session
+                    .player_reg
+                    .remotes
+                    .get_mut(&addr_b)
+                    .expect("B endpoint exists")
+                    .pending_checksums
+                    .insert(frame, 0xBBBB_BBBB);
+            }
+            session.compare_local_checksums_against_peers();
+
+            assert_eq!(
+                session.peer_checksum_mismatch_count(handle_b),
+                Some(u32::try_from(overshoot).expect("non-negative")),
+                "every mismatch in the overshooting batch must be counted"
+            );
+        });
+
+        let trust_warns = warns
+            .iter()
+            .filter(|m| m.contains("trust-downgrade threshold"))
+            .count();
+        assert_eq!(
+            trust_warns, 1,
+            "WARNING must fire exactly once even when one batch overshoots the threshold; got {trust_warns} in {warns:?}"
         );
     }
 

--- a/src/sessions/p2p_spectator_session.rs
+++ b/src/sessions/p2p_spectator_session.rs
@@ -3291,7 +3291,7 @@ mod tests {
     // freeze frame) is never reconciled. If divergence is silently missed, this is
     // the spectator analog of the c25fc1f asymmetric-loss desync.
     #[test]
-    fn spectator_asymmetric_freeze_frame_nonoverlapping_region_divergence() {
+    fn spectator_asymmetric_freeze_frame_nonoverlapping_region_converges_to_global_min() {
         let mut session: SpectatorSession<TestConfig> = SessionBuilder::new()
             .with_num_players(2)
             .unwrap()
@@ -3431,7 +3431,7 @@ mod tests {
     }
 
     // Completeness-Critic #2 coverage (commit-time path). Same asymmetric-loss
-    // mesh as `spectator_asymmetric_freeze_frame_nonoverlapping_region_divergence`,
+    // mesh as `spectator_asymmetric_freeze_frame_nonoverlapping_region_converges_to_global_min`,
     // but the distinguishing ORDERING exercises `converged_drop_status` (the
     // commit-time fold), NOT `converge_latched_drop_status` (the late-arrival fold).
     // Here the non-canonical lower-`F` host (host 1, F_B = 1) has its snapshots for

--- a/src/sessions/sync_health.rs
+++ b/src/sessions/sync_health.rs
@@ -50,10 +50,22 @@ pub enum SyncHealth {
     /// - When the peer hasn't sent checksum data yet
     Pending,
 
-    /// Checksums differ - game state has diverged.
+    /// Checksums differ at the compared frame — the peers' game state for that
+    /// frame does not match.
     ///
-    /// This is a critical error indicating non-determinism or a bug.
-    /// The session should typically be terminated when this occurs.
+    /// Treat this as a **signal to handle gracefully, not a reason to
+    /// hard-panic.** `DesyncDetected` is a normal, recoverable library event;
+    /// crashing the process on a single one is fragile. In the default
+    /// trusted-peer model a mismatch indicates genuine non-determinism — end
+    /// the affected session and surface diagnostics. In an untrusted deployment
+    /// a *single* mismatch may instead be a malicious or buggy peer emitting one
+    /// bad checksum, so weight a *persistent* mismatch with the same peer (see
+    /// [`P2PSession::peer_checksum_mismatch_count`]) more heavily than a one-off,
+    /// and prefer downgrading trust over auto-ejecting — with only two endpoints
+    /// you cannot tell which side is wrong, so ejecting may remove the honest
+    /// peer.
+    ///
+    /// [`P2PSession::peer_checksum_mismatch_count`]: crate::P2PSession::peer_checksum_mismatch_count
     DesyncDetected {
         /// The frame at which the desync was detected.
         frame: Frame,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1347,11 +1347,26 @@ macro_rules! debug_check_invariants {
 }
 
 /// No-op version for release builds without `paranoid` feature.
+///
+/// The arguments are referenced inside a statically-dead `if false` block so a
+/// caller binding used *only* by this macro is not flagged `unused_variables`
+/// under the crate's `#![deny(warnings)]` (see `src/lib.rs`). The dead block is
+/// removed by codegen, so the release no-op stays truly zero-cost: `$expr` is
+/// referenced for the lint but never evaluated, preserving the macro's contract
+/// of doing no work in release.
 #[macro_export]
 #[cfg(not(any(debug_assertions, feature = "paranoid")))]
 macro_rules! debug_check_invariants {
-    ($expr:expr) => {{}};
-    ($expr:expr, $context:expr) => {{}};
+    ($expr:expr) => {{
+        if false {
+            let _ = &$expr;
+        }
+    }};
+    ($expr:expr, $context:expr) => {{
+        if false {
+            let _ = (&$expr, &$context);
+        }
+    }};
 }
 
 /// Macro for checking invariants and panicking if violated (debug only).
@@ -1398,8 +1413,20 @@ macro_rules! assert_invariants {
 #[macro_export]
 #[cfg(not(any(debug_assertions, feature = "paranoid")))]
 macro_rules! assert_invariants {
-    ($expr:expr) => {{}};
-    ($expr:expr, $context:expr) => {{}};
+    // See the release `debug_check_invariants!` no-op above: the `if false`
+    // block references the arguments for the `unused_variables` lint without
+    // evaluating them, keeping the release no-op zero-cost under
+    // `#![deny(warnings)]`.
+    ($expr:expr) => {{
+        if false {
+            let _ = &$expr;
+        }
+    }};
+    ($expr:expr, $context:expr) => {{
+        if false {
+            let _ = (&$expr, &$context);
+        }
+    }};
 }
 
 /// Macro for checking invariants and returning a Result.

--- a/tests/common/channel_socket.rs
+++ b/tests/common/channel_socket.rs
@@ -296,6 +296,116 @@ pub fn create_channel_quad() -> (
     )
 }
 
+/// Creates a fully-meshed set of `n` connected in-memory sockets for N-player
+/// P2P testing.
+///
+/// This is the general-N companion to [`create_channel_pair`] /
+/// [`create_channel_triple`] / [`create_channel_quad`]: every socket can send
+/// to every other socket, and messages are delivered instantly through channels
+/// — no real network I/O occurs. The fixed-N helpers above are retained for
+/// readability; this one is used by the N≥3 deterministic chaos harness.
+///
+/// # Arguments
+///
+/// * `n` - The number of peers in the mesh (must be `>= 2`).
+///
+/// # Returns
+///
+/// `(sockets, addrs)` where `sockets[i]` is at `addrs[i]` and can send to every
+/// `addrs[j]` for `j != i`. Address `i` is `127.0.0.1:(10001 + i)`.
+///
+/// # Panics
+///
+/// Panics if `n < 2` (a mesh needs at least two peers).
+#[allow(dead_code, clippy::expect_used)] // Test infrastructure.
+#[must_use]
+pub fn create_channel_mesh(n: usize) -> (Vec<ChannelSocket>, Vec<SocketAddr>) {
+    assert!(
+        (2..=1000).contains(&n),
+        "a channel mesh needs at least 2 peers and at most 1000 (got {n})"
+    );
+
+    let addrs: Vec<SocketAddr> = (0..n)
+        .map(|i| {
+            // `n <= 1000` (asserted above) keeps the port within `u16`.
+            let port = 10001 + u16::try_from(i).expect("peer index fits in u16");
+            ([127, 0, 0, 1], port).into()
+        })
+        .collect();
+
+    // One receiver per peer; senders are cloned so every other peer can write
+    // into it.
+    let mut senders: Vec<Sender<(SocketAddr, Message)>> = Vec::with_capacity(n);
+    let mut receivers: Vec<mpsc::Receiver<(SocketAddr, Message)>> = Vec::with_capacity(n);
+    for _ in 0..n {
+        let (tx, rx) = mpsc::channel();
+        senders.push(tx);
+        receivers.push(rx);
+    }
+
+    let sockets: Vec<ChannelSocket> = receivers
+        .into_iter()
+        .enumerate()
+        .map(|(i, rx)| {
+            // Peer `i` gets a cloned sender to every other peer `j`.
+            let peer_senders: HashMap<SocketAddr, Sender<(SocketAddr, Message)>> = (0..n)
+                .filter(|&j| j != i)
+                .map(|j| (addrs[j], senders[j].clone()))
+                .collect();
+            ChannelSocket {
+                local_addr: addrs[i],
+                senders: peer_senders,
+                receiver: Mutex::new(rx),
+            }
+        })
+        .collect();
+
+    (sockets, addrs)
+}
+
+/// Creates a fully-meshed set of `n`
+/// [`ChaosSocket`](fortress_rollback::ChaosSocket)-wrapped `ChannelSocket`s for
+/// deterministic N-player network chaos testing.
+///
+/// This is the general-N companion to [`create_chaos_channel_pair`]. Each peer
+/// `i` wraps its mesh socket in a `ChaosSocket` configured by `configs[i]`,
+/// sharing the same virtual `clock` so the whole simulation is deterministic.
+///
+/// # Arguments
+///
+/// * `configs` - Per-peer chaos configuration; `configs.len()` is the mesh size.
+///   Callers **must** use a distinct seed per peer (identical seeds produce
+///   correlated drop sequences that deadlock synchronization — see the
+///   seed-correlation warning in the chaos test modules).
+/// * `clock` - Shared test clock for deterministic time control.
+///
+/// # Returns
+///
+/// `(chaos_sockets, addrs)` where `chaos_sockets[i]` is at `addrs[i]`.
+///
+/// # Panics
+///
+/// Panics if `configs.len() < 2`.
+#[allow(dead_code)]
+#[must_use]
+pub fn create_chaos_channel_mesh(
+    configs: Vec<fortress_rollback::ChaosConfig>,
+    clock: &super::test_clock::TestClock,
+) -> (
+    Vec<fortress_rollback::ChaosSocket<SocketAddr, ChannelSocket>>,
+    Vec<SocketAddr>,
+) {
+    use fortress_rollback::ChaosSocket;
+
+    let (sockets, addrs) = create_channel_mesh(configs.len());
+    let chaos_sockets = sockets
+        .into_iter()
+        .zip(configs)
+        .map(|(socket, config)| ChaosSocket::new(socket, config).with_clock(clock.as_chaos_clock()))
+        .collect();
+    (chaos_sockets, addrs)
+}
+
 /// Creates a connected pair of [`ChaosSocket`](fortress_rollback::ChaosSocket)-wrapped
 /// `ChannelSocket`s for deterministic network chaos testing.
 ///
@@ -374,6 +484,49 @@ mod tests {
         let (s1, s2, addr1, addr2) = create_channel_pair();
         assert_eq!(s1.local_addr(), addr1);
         assert_eq!(s2.local_addr(), addr2);
+    }
+
+    #[test]
+    fn create_channel_mesh_returns_distinct_addresses_and_matching_locals() {
+        for n in [2usize, 3, 5, 8] {
+            let (sockets, addrs) = create_channel_mesh(n);
+            assert_eq!(sockets.len(), n, "mesh must have n sockets");
+            assert_eq!(addrs.len(), n, "mesh must have n addresses");
+
+            // Every address is distinct.
+            let unique: std::collections::HashSet<_> = addrs.iter().collect();
+            assert_eq!(unique.len(), n, "mesh addresses must be distinct (n={n})");
+
+            // Each socket's local address matches its slot, and it has a sender
+            // to every OTHER peer (and none to itself).
+            for (i, socket) in sockets.iter().enumerate() {
+                assert_eq!(socket.local_addr(), addrs[i], "local_addr matches slot");
+                assert_eq!(
+                    socket.senders.len(),
+                    n - 1,
+                    "peer {i} must reach the other {} peers",
+                    n - 1
+                );
+                assert!(
+                    !socket.senders.contains_key(&addrs[i]),
+                    "peer {i} must not have a sender to itself"
+                );
+                for (j, addr) in addrs.iter().enumerate() {
+                    if j != i {
+                        assert!(
+                            socket.senders.contains_key(addr),
+                            "peer {i} must have a sender to peer {j}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "at least 2 peers")]
+    fn create_channel_mesh_rejects_too_few_peers() {
+        let _ = create_channel_mesh(1);
     }
 
     #[test]

--- a/tests/common/channel_socket.rs
+++ b/tests/common/channel_socket.rs
@@ -307,7 +307,7 @@ pub fn create_channel_quad() -> (
 ///
 /// # Arguments
 ///
-/// * `n` - The number of peers in the mesh (must be `>= 2`).
+/// * `n` - The number of peers in the mesh (must be in `2..=1000`).
 ///
 /// # Returns
 ///
@@ -316,7 +316,7 @@ pub fn create_channel_quad() -> (
 ///
 /// # Panics
 ///
-/// Panics if `n < 2` (a mesh needs at least two peers).
+/// Panics if `n < 2` or `n > 1000`.
 #[allow(dead_code, clippy::expect_used)] // Test infrastructure.
 #[must_use]
 pub fn create_channel_mesh(n: usize) -> (Vec<ChannelSocket>, Vec<SocketAddr>) {
@@ -373,7 +373,8 @@ pub fn create_channel_mesh(n: usize) -> (Vec<ChannelSocket>, Vec<SocketAddr>) {
 ///
 /// # Arguments
 ///
-/// * `configs` - Per-peer chaos configuration; `configs.len()` is the mesh size.
+/// * `configs` - Per-peer chaos configuration; `configs.len()` is the mesh size
+///   and must be in `2..=1000`.
 ///   Callers **must** use a distinct seed per peer (identical seeds produce
 ///   correlated drop sequences that deadlock synchronization — see the
 ///   seed-correlation warning in the chaos test modules).
@@ -385,7 +386,7 @@ pub fn create_channel_mesh(n: usize) -> (Vec<ChannelSocket>, Vec<SocketAddr>) {
 ///
 /// # Panics
 ///
-/// Panics if `configs.len() < 2`.
+/// Panics if `configs.len() < 2` or `configs.len() > 1000`.
 #[allow(dead_code)]
 #[must_use]
 pub fn create_chaos_channel_mesh(
@@ -527,6 +528,12 @@ mod tests {
     #[should_panic(expected = "at least 2 peers")]
     fn create_channel_mesh_rejects_too_few_peers() {
         let _ = create_channel_mesh(1);
+    }
+
+    #[test]
+    #[should_panic(expected = "at most 1000")]
+    fn create_channel_mesh_rejects_too_many_peers() {
+        let _ = create_channel_mesh(1001);
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -31,8 +31,8 @@ pub mod test_utils;
 pub use bus_socket::{BusSocket, RoutingBus};
 #[allow(unused_imports)]
 pub use channel_socket::{
-    create_channel_pair, create_channel_quad, create_channel_triple, create_chaos_channel_pair,
-    create_unconnected_socket, ChannelSocket,
+    create_channel_mesh, create_channel_pair, create_channel_quad, create_channel_triple,
+    create_chaos_channel_mesh, create_chaos_channel_pair, create_unconnected_socket, ChannelSocket,
 };
 #[allow(unused_imports)]
 pub use filter_socket::{

--- a/tests/common/test_clock.rs
+++ b/tests/common/test_clock.rs
@@ -94,6 +94,10 @@ impl TestClock {
     /// The returned closure captures a reference to this clock's shared state,
     /// so advancing the clock affects all protocols using this clock function.
     ///
+    /// # Panics
+    ///
+    /// The returned closure panics if the internal mutex is poisoned.
+    ///
     /// # Example
     ///
     /// ```ignore
@@ -115,6 +119,10 @@ impl TestClock {
     /// On non-WASM targets, `web_time::Instant` is the same type as
     /// `std::time::Instant`, so this returns the same underlying clock
     /// as [`as_protocol_clock()`](TestClock::as_protocol_clock).
+    ///
+    /// # Panics
+    ///
+    /// The returned closure panics if the internal mutex is poisoned.
     ///
     /// # Example
     ///

--- a/tests/common/test_utils.rs
+++ b/tests/common/test_utils.rs
@@ -192,8 +192,8 @@ impl PortAllocator {
     ///
     /// # Panics
     ///
-    /// Panics if the port counter would overflow (after many allocations
-    /// from the starting point). This should never happen in practice.
+    /// Panics if the allocator is exhausted and the next port would be
+    /// `>= 60000`. This should never happen in practice.
     #[allow(dead_code)]
     #[must_use]
     pub fn next_port() -> u16 {
@@ -211,6 +211,10 @@ impl PortAllocator {
     /// Allocates N consecutive ports.
     ///
     /// This is useful for multi-peer tests that need a known set of ports.
+    ///
+    /// # Panics
+    ///
+    /// Panics if allocating any requested port would exhaust the allocator.
     ///
     /// # Example
     ///
@@ -256,6 +260,10 @@ impl PortAllocator {
     /// let (mock_port1, mock_port2) = PortAllocator::next_pair();
     /// let mock_remote = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), mock_port1);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if allocating either port would exhaust the allocator.
     ///
     /// [`bind_socket_ephemeral`]: crate::common::test_utils::bind_socket_ephemeral
     #[allow(dead_code)]
@@ -1403,9 +1411,24 @@ mod tests {
 
     mod port_allocator_tests {
         use super::*;
+        use serial_test::serial;
+
+        fn set_port_allocator_state(next_port: u16) {
+            PORT_COUNTER.store(next_port, Ordering::SeqCst);
+            PORT_COUNTER_INITIALIZED.store(true, Ordering::SeqCst);
+        }
+
+        fn assert_allocator_exhaustion_panics<T>(
+            operation: impl FnOnce() -> T + std::panic::UnwindSafe,
+        ) {
+            let result = std::panic::catch_unwind(operation);
+            PortAllocator::reset();
+            assert!(result.is_err(), "allocator exhaustion should panic");
+        }
 
         /// Tests that PortAllocator provides unique ports.
         #[test]
+        #[serial]
         fn port_allocator_provides_unique_ports() {
             // Reset to ensure clean state
             PortAllocator::reset();
@@ -1421,6 +1444,7 @@ mod tests {
 
         /// Tests that next_ports returns the correct number of ports.
         #[test]
+        #[serial]
         fn port_allocator_next_ports_returns_correct_count() {
             PortAllocator::reset();
 
@@ -1442,6 +1466,7 @@ mod tests {
         /// Tests that next_pair returns two unique ports.
         /// Note: This tests the deprecated function to ensure it still works correctly.
         #[test]
+        #[serial]
         #[allow(deprecated)]
         fn port_allocator_next_pair_returns_unique_ports() {
             PortAllocator::reset();
@@ -1452,6 +1477,7 @@ mod tests {
 
         /// Tests that ports are within the expected range.
         #[test]
+        #[serial]
         fn port_allocator_ports_in_valid_range() {
             PortAllocator::reset();
 
@@ -1465,6 +1491,31 @@ mod tests {
                 );
                 assert!(port < 60000, "Port {} should be < 60000", port);
             }
+        }
+
+        #[test]
+        #[serial]
+        fn port_allocator_next_port_panics_when_exhausted() {
+            set_port_allocator_state(60000);
+
+            assert_allocator_exhaustion_panics(PortAllocator::next_port);
+        }
+
+        #[test]
+        #[serial]
+        fn port_allocator_next_ports_panics_when_exhausted_mid_batch() {
+            set_port_allocator_state(59999);
+
+            assert_allocator_exhaustion_panics(PortAllocator::next_ports::<2>);
+        }
+
+        #[test]
+        #[serial]
+        #[allow(deprecated)]
+        fn port_allocator_next_pair_panics_when_exhausted_mid_pair() {
+            set_port_allocator_state(59999);
+
+            assert_allocator_exhaustion_panics(PortAllocator::next_pair);
         }
     }
 

--- a/tests/network/in_process_chaos.rs
+++ b/tests/network/in_process_chaos.rs
@@ -51,13 +51,36 @@
 )]
 
 use crate::common::stubs::{GameStub, StubConfig, StubInput};
-use crate::common::{create_chaos_channel_pair, TestClock};
+use crate::common::{create_chaos_channel_mesh, create_chaos_channel_pair, TestClock};
 use fortress_rollback::hash::fnv1a_hash;
 use fortress_rollback::{
-    ChaosConfig, Frame, P2PSession, PlayerHandle, PlayerType, ProtocolConfig, SessionBuilder,
-    SessionState, SyncConfig, TimeSyncConfig,
+    ChaosConfig, FortressError, Frame, P2PSession, PlayerHandle, PlayerType, ProtocolConfig,
+    RequestVec, SessionBuilder, SessionState, SyncConfig, TimeSyncConfig,
 };
 use std::time::Duration;
+
+/// Folds an `advance_frame()` result into the stub, panicking on ANY error.
+///
+/// `P2PSession::advance_frame` surfaces the prediction-window throttle (a peer
+/// racing ahead under chaos) as `Ok(<empty requests>)` — a no-op — **not** as an
+/// `Err`, so it needs no special-casing here. The chaos harness also disables
+/// disconnect detection (a disconnect timeout provably larger than the whole
+/// virtual-time budget), so under correct operation `advance_frame` cannot
+/// legitimately error. Any `Err` is therefore a genuine failure (a spurious
+/// disconnect, a missing local input, an internal invariant break) and must
+/// turn the test RED rather than be silently absorbed.
+///
+/// This is strictly stronger than the historical `if let Ok(..)` swallow-all
+/// (which would hide such an error as silent non-progress) and satisfies the
+/// agent-preflight `advance-frame-error-handling` rule (mirroring
+/// `handle_advance_frame_allowing` in `resilience.rs`, which likewise panics on
+/// an unexpected error).
+fn fold_advance_frame(result: Result<RequestVec<StubConfig>, FortressError>, stub: &mut GameStub) {
+    match result {
+        Ok(requests) => stub.handle_requests(requests),
+        Err(err) => panic!("unexpected advance_frame error under chaos: {err:?}"),
+    }
+}
 
 /// Helper: creates a `ProtocolConfig` with the given test clock.
 ///
@@ -646,21 +669,19 @@ fn execute_scenario_once(s: &ChaosScenario) -> ScenarioRun {
                 inp: frame_input.wrapping_mul(11).wrapping_add(3),
             };
 
-            // add_local_input can transiently reject when the prediction
-            // window is full; that is expected under chaos. Only advance the
-            // frame when both inputs were accepted this tick.
+            // add_local_input only rejects a non-local handle (the prediction
+            // throttle is applied by advance_frame, which returns Ok(<empty>)
+            // when the window is full), so under correct wiring these always
+            // succeed; the `added*` guard is defensive. Only advance when both
+            // inputs were accepted this tick.
             let added1 = sess1.add_local_input(PlayerHandle::new(0), input1).is_ok();
             let added2 = sess2.add_local_input(PlayerHandle::new(1), input2).is_ok();
             if !(added1 && added2) {
                 continue;
             }
 
-            if let Ok(requests1) = sess1.advance_frame() {
-                stub1.handle_requests(requests1);
-            }
-            if let Ok(requests2) = sess2.advance_frame() {
-                stub2.handle_requests(requests2);
-            }
+            fold_advance_frame(sess1.advance_frame(), &mut stub1);
+            fold_advance_frame(sess2.advance_frame(), &mut stub2);
             frame_input = frame_input.wrapping_add(1);
         }
     }
@@ -923,4 +944,766 @@ fn in_process_chaos_perfect_link_determinism() {
     if let Err(report) = run_chaos_scenario(&scenario) {
         panic!("perfect-link determinism failed:\n{report}");
     }
+}
+
+// ===========================================================================
+// N≥3 deterministic chaos mesh
+// ===========================================================================
+//
+// The 2-peer table above is the original deterministic chaos coverage. This
+// section generalizes the exact same methodology — seeded `ChaosSocket`s over
+// `ChannelSocket`s on a shared virtual `TestClock`, a cross-peer confirmed-input
+// determinism + checksum assertion, and a bit-for-bit reproducibility re-run —
+// to a **fully-meshed N-peer session** (N ∈ {3, 4}). It is the deterministic,
+// in-process companion to the nightly real-UDP N≥3 multi-process driver
+// (`tests/network/multi_process.rs`): same determinism oracle, but every run is
+// reproducible and completes in milliseconds of virtual time, so it can run in
+// the default (non-nightly) suite and pin regressions exactly.
+//
+// # Why N≥3 is a distinct test, not just a bigger number
+//
+// Confirmed-input agreement across **three or more** peers exercises the
+// disconnect-gossip relay, per-(local, remote) checksum keying, and the
+// freeze-barrier `confirmed_frame()` bound — machinery that is structurally
+// inert at N=2 (where every peer is the other's sole remote). A 2-peer chaos
+// run cannot diverge the way the N-player audit's findings (F4/F7/F9/F11/F12/
+// F17) require, because those mechanisms only have N-1 ≥ 2 remotes to
+// reconcile. This harness puts the steady-state (no-disconnect) N≥3 confirmed
+// stream under sustained loss/latency/reorder/duplication and asserts it stays
+// byte-identical across the whole mesh.
+//
+// # Seed correlation (N-peer form)
+//
+// The 2-peer seed-correlation warning generalizes: every peer in the mesh must
+// use a **distinct** chaos seed, or correlated drop sequences systematically
+// block synchronization. Peer `i` uses `seed + i`.
+
+/// One row of the N-peer data-driven scenario table.
+#[derive(Debug, Clone)]
+struct NPeerChaosScenario {
+    /// Human-readable scenario name (used in diagnostics).
+    name: &'static str,
+    /// Per-peer chaos profiles; `profiles.len()` is the mesh size `N`.
+    profiles: Vec<ChaosProfile>,
+    /// Base seed; peer `i` uses `seed + i` (never identical across peers).
+    seed: u64,
+    /// Target confirmed frame every peer must reach.
+    target_confirmed: i32,
+    /// Per-player input delay frames.
+    input_delay: usize,
+    /// Sync configuration preset to use for all peers.
+    preset: SyncPreset,
+}
+
+impl NPeerChaosScenario {
+    /// The mesh size `N`.
+    fn num_players(&self) -> usize {
+        self.profiles.len()
+    }
+}
+
+/// The result of running a single N-peer scenario once.
+struct NPeerScenarioRun {
+    /// Per-peer confirmed frame reached.
+    confirmed: Vec<i32>,
+    /// Per-peer current frame.
+    current: Vec<i32>,
+    /// Per-peer final `GameStub` frame.
+    stub_frame: Vec<i32>,
+    /// Per-peer checksum over the shared confirmed-input range.
+    checksum: Vec<u64>,
+    /// The shared confirmed frame (the min confirmed frame across the mesh) over
+    /// which the checksum was actually computed.
+    shared: i32,
+    /// Per-peer length of the flattened confirmed-input stream actually folded
+    /// into the checksum. Used to assert the checksum is non-vacuous (it covers
+    /// the full `[0, shared]` range and was not truncated by an unavailable
+    /// confirmed frame) — see `check_npeer_run`.
+    stream_len: Vec<usize>,
+    /// First `(peer, flattened-input-index)` at which a peer's confirmed-input
+    /// stream diverged from peer 0's, if any. The index is into the
+    /// all-players-per-frame flattened `u32` stream (index = frame * N + player
+    /// for N players), NOT a frame number.
+    first_divergence: Option<(usize, i32)>,
+    /// Per-peer final session state for diagnostics.
+    state: Vec<SessionState>,
+    /// Whether every peer reached the target confirmed frame.
+    reached_target: bool,
+}
+
+/// Deterministic, frame-and-peer-derived local input for peer `peer` on input
+/// tick `tick`. Independent of any wall clock. Distinct per peer at the small
+/// `(N, tick)` ranges this harness exercises — the negative-control test
+/// (`in_process_chaos_npeer_oracle_detects_divergence`) independently proves a
+/// cross-peer mix-up is caught, so exact all-tick injectivity is not relied on.
+fn npeer_input(tick: u32, peer: usize) -> u32 {
+    let peer = u32::try_from(peer).unwrap_or(0);
+    tick.wrapping_mul(7u32.wrapping_add(peer.wrapping_mul(4)))
+        .wrapping_add(1u32.wrapping_add(peer.wrapping_mul(2)))
+}
+
+/// Builds a fully-meshed N-peer session set for the scenario, runs the
+/// simulation to the target confirmed frame, and computes the cross-peer
+/// determinism checksum. This is the single source of truth used by both the
+/// initial run and the reproducibility re-run.
+fn execute_npeer_scenario_once(s: &NPeerChaosScenario) -> NPeerScenarioRun {
+    let n = s.num_players();
+    let clock = TestClock::new();
+
+    // Distinct seed per peer (see the seed-correlation note above).
+    let configs: Vec<_> = s
+        .profiles
+        .iter()
+        .enumerate()
+        .map(|(i, profile)| profile.to_chaos_config(s.seed + i as u64))
+        .collect();
+
+    let (sockets, addrs) = create_chaos_channel_mesh(configs, &clock);
+
+    // As in the 2-peer harness, set a disconnect timeout provably larger than
+    // the whole virtual-time budget: there is no peer that died here, only chaos
+    // sockets dropping packets, so any spurious disconnect would be a false
+    // positive that breaks the confirmed-input invariant. Virtual time is free.
+    let disconnect_timeout = Duration::from_secs(100_000);
+    let disconnect_notify = Duration::from_secs(50_000);
+
+    let mut sessions: Vec<P2PSession<StubConfig>> = Vec::with_capacity(n);
+    for (i, socket) in sockets.into_iter().enumerate() {
+        let mut builder = SessionBuilder::<StubConfig>::new()
+            .with_num_players(n)
+            .expect("valid player count")
+            .with_protocol_config(protocol_config(&clock, s.preset))
+            .with_sync_config(s.preset.sync_config())
+            .with_time_sync_config(time_sync_config(s.preset))
+            .with_disconnect_timeout(disconnect_timeout)
+            .with_disconnect_notify_delay(disconnect_notify)
+            .with_input_delay(s.input_delay)
+            .expect("valid input delay");
+        for (h, &addr) in addrs.iter().enumerate() {
+            let player = if h == i {
+                PlayerType::Local
+            } else {
+                PlayerType::Remote(addr)
+            };
+            builder = builder
+                .add_player(player, PlayerHandle::new(h))
+                .expect("add player");
+        }
+        sessions.push(
+            builder
+                .start_p2p_session(socket)
+                .expect("start p2p session"),
+        );
+    }
+
+    // --- Synchronize the whole mesh (bounded, virtual-time iteration cap) ----
+    // An N-peer mesh must sync every pair, so the cap is more generous than the
+    // 2-peer harness. Poll several times per tick to drain chaos buffers.
+    for _ in 0..8000 {
+        for _ in 0..4 {
+            for sess in &mut sessions {
+                sess.poll_remote_clients();
+            }
+        }
+        if sessions
+            .iter()
+            .all(|sess| sess.current_state() == SessionState::Running)
+        {
+            break;
+        }
+        clock.advance(Duration::from_millis(20));
+    }
+
+    let mut stubs: Vec<GameStub> = (0..n).map(|_| GameStub::new()).collect();
+
+    // --- Advance until every peer reaches the target confirmed frame --------
+    if sessions
+        .iter()
+        .all(|sess| sess.current_state() == SessionState::Running)
+    {
+        let mut tick: u32 = 0;
+        for _ in 0..8000 {
+            if sessions
+                .iter()
+                .all(|sess| sess.confirmed_frame().as_i32() >= s.target_confirmed)
+            {
+                break;
+            }
+
+            for _ in 0..10 {
+                for sess in &mut sessions {
+                    sess.poll_remote_clients();
+                }
+            }
+            clock.advance(Duration::from_millis(16));
+
+            // Every peer offers its (deterministic, distinct) local input.
+            // add_local_input only fails on a wrong handle, so under correct
+            // wiring this always succeeds; the prediction-window throttle is
+            // applied by advance_frame (handled below), not here.
+            let mut all_added = true;
+            for (i, sess) in sessions.iter_mut().enumerate() {
+                let input = StubInput {
+                    inp: npeer_input(tick, i),
+                };
+                if sess.add_local_input(PlayerHandle::new(i), input).is_err() {
+                    all_added = false;
+                }
+            }
+            if !all_added {
+                continue;
+            }
+
+            for (i, sess) in sessions.iter_mut().enumerate() {
+                fold_advance_frame(sess.advance_frame(), &mut stubs[i]);
+            }
+            tick = tick.wrapping_add(1);
+        }
+    }
+
+    // --- Drain any in-flight packets so confirmations settle ----------------
+    for _ in 0..400 {
+        for sess in &mut sessions {
+            sess.poll_remote_clients();
+        }
+        clock.advance(Duration::from_millis(16));
+    }
+
+    let confirmed: Vec<i32> = sessions
+        .iter()
+        .map(|sess| sess.confirmed_frame().as_i32())
+        .collect();
+    let current: Vec<i32> = sessions
+        .iter()
+        .map(|sess| sess.current_frame().as_i32())
+        .collect();
+    let state: Vec<SessionState> = sessions.iter().map(P2PSession::current_state).collect();
+    let stub_frame: Vec<i32> = stubs.iter().map(|stub| stub.gs.frame).collect();
+
+    // --- The core cross-peer determinism + checksum assertion ---------------
+    // Compare confirmed inputs frame-by-frame over the shared confirmed range
+    // (the min confirmed frame across the whole mesh).
+    let shared = confirmed.iter().copied().min().unwrap_or(-1);
+    let streams = collect_mesh_streams(&sessions, shared);
+    let stream_len: Vec<usize> = streams.iter().map(Vec::len).collect();
+    let (checksum, first_divergence) = mesh_input_checksums(&streams);
+
+    let reached_target = confirmed.iter().all(|&c| c >= s.target_confirmed);
+
+    NPeerScenarioRun {
+        confirmed,
+        current,
+        stub_frame,
+        checksum,
+        shared,
+        stream_len,
+        first_divergence,
+        state,
+        reached_target,
+    }
+}
+
+/// Collects each peer's confirmed-input `u32` stream over `0..=shared` (all
+/// players' inputs flattened per frame, in handle order). If a peer cannot
+/// produce confirmed inputs for some frame in range, that peer's stream is
+/// truncated there — `mesh_input_checksums` then surfaces the truncation as a
+/// divergence relative to peer 0.
+fn collect_mesh_streams(sessions: &[P2PSession<StubConfig>], shared: i32) -> Vec<Vec<u32>> {
+    sessions
+        .iter()
+        .map(|sess| {
+            let mut acc: Vec<u32> = Vec::new();
+            let mut f = 0;
+            while f <= shared {
+                match sess.confirmed_inputs_for_frame(Frame::new(f)) {
+                    Ok(inputs) => acc.extend(inputs.iter().map(|input| input.inp)),
+                    Err(_) => break,
+                }
+                f += 1;
+            }
+            acc
+        })
+        .collect()
+}
+
+/// Folds each peer's flattened confirmed-input stream into an FNV-1a checksum
+/// and reports the first `(peer, element_index)` at which any peer's stream
+/// differs from peer 0's (a shorter stream counts as a divergence at its end).
+///
+/// Pure and self-contained so the negative-control test
+/// (`npeer_oracle_detects_divergence`) can prove it actually catches a
+/// divergence — i.e. that the green assertions below are non-vacuous.
+fn mesh_input_checksums(streams: &[Vec<u32>]) -> (Vec<u64>, Option<(usize, i32)>) {
+    let checksums: Vec<u64> = streams.iter().map(fnv1a_hash).collect();
+
+    let mut first_divergence: Option<(usize, i32)> = None;
+    if let Some(reference) = streams.first() {
+        for (peer, stream) in streams.iter().enumerate().skip(1) {
+            let common = reference.len().min(stream.len());
+            let mut diverged = false;
+            for idx in 0..common {
+                if reference[idx] != stream[idx] {
+                    first_divergence = Some((peer, idx as i32));
+                    diverged = true;
+                    break;
+                }
+            }
+            if !diverged && reference.len() != stream.len() {
+                // Streams agree on the common prefix but differ in length: one
+                // peer produced fewer confirmed inputs over the shared range.
+                first_divergence = Some((peer, common as i32));
+                diverged = true;
+            }
+            if diverged {
+                break;
+            }
+        }
+    }
+
+    (checksums, first_divergence)
+}
+
+/// Renders a rich, self-explanatory diagnostic block for a failing N-peer
+/// scenario.
+fn npeer_diagnostics(s: &NPeerChaosScenario, run: &NPeerScenarioRun) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = format!(
+        "N-peer scenario '{name}' FAILED\n  \
+         N={n}, base_seed={seed} (peer i uses seed+i)\n  \
+         preset: {preset:?}, input_delay={delay}, target_confirmed={target}\n  \
+         reached_target={reached}, first_confirmed_input_divergence={div:?}\n",
+        name = s.name,
+        n = s.num_players(),
+        seed = s.seed,
+        preset = s.preset,
+        delay = s.input_delay,
+        target = s.target_confirmed,
+        reached = run.reached_target,
+        div = run.first_divergence,
+    );
+    for i in 0..s.num_players() {
+        let _ = write!(
+            out,
+            "  peer{i}: profile={profile:?}\n         \
+             state={state:?} current={cur} confirmed={conf} stub_frame={stub} checksum={cs:#018x}\n",
+            i = i,
+            profile = s.profiles[i],
+            state = run.state[i],
+            cur = run.current[i],
+            conf = run.confirmed[i],
+            stub = run.stub_frame[i],
+            cs = run.checksum[i],
+        );
+    }
+    out
+}
+
+/// Checks every per-run invariant for a single completed N-peer run:
+///   1. a non-vacuous confirmed range AND a non-vacuous, fully-collected
+///      checksummed stream on EVERY peer (so the checksum is meaningful, and
+///      `confirmed >= MIN_CONFIRMED_FLOOR > 0` also proves no peer suffered a
+///      spurious disconnect downgrade to `Synchronizing`),
+///   2. no confirmed-input divergence anywhere in the mesh,
+///   3. all peers' determinism checksums identical,
+///   4. every `GameStub` advanced,
+///   5. every peer reached the target confirmed frame (progress/liveness).
+fn check_npeer_run(s: &NPeerChaosScenario, run: &NPeerScenarioRun) -> Result<(), String> {
+    // Non-vacuous floor FIRST, on every peer.
+    if let Some((peer, conf)) = run
+        .confirmed
+        .iter()
+        .copied()
+        .enumerate()
+        .find(|&(_, c)| c < MIN_CONFIRMED_FLOOR)
+    {
+        return Err(format!(
+            "peer{peer} confirmed range {conf} below floor {MIN_CONFIRMED_FLOOR}; \
+             determinism checksum would be vacuous\n{}",
+            npeer_diagnostics(s, run)
+        ));
+    }
+    // The checksum is folded over `collect_mesh_streams(.., shared)`, which
+    // truncates a peer's stream if any confirmed frame in `[0, shared]` is
+    // unavailable (e.g. evicted from the input ring). `confirmed_frame()` being
+    // high does NOT, by itself, prove the stream was retrievable — so assert the
+    // checksummed streams are themselves non-vacuous and complete: `shared`
+    // clears the floor AND every peer folded the full `(shared + 1) * N`
+    // elements. This keeps the determinism assertion honest even if a future
+    // target/queue-length change pushes frame 0 out of the ring.
+    if run.shared < MIN_CONFIRMED_FLOOR {
+        return Err(format!(
+            "shared confirmed range {} below floor {MIN_CONFIRMED_FLOOR}; \
+             determinism checksum would be vacuous\n{}",
+            run.shared,
+            npeer_diagnostics(s, run)
+        ));
+    }
+    let expected_len = usize::try_from((run.shared + 1).max(0)).unwrap_or(0) * s.num_players();
+    if let Some((peer, len)) = run
+        .stream_len
+        .iter()
+        .copied()
+        .enumerate()
+        .find(|&(_, len)| len != expected_len)
+    {
+        return Err(format!(
+            "peer{peer} folded {len} confirmed-input elements but the full shared range \
+             [0, {}] over {} players needs {expected_len} (stream truncated — an in-range \
+             confirmed frame was unavailable); determinism checksum would be vacuous\n{}",
+            run.shared,
+            s.num_players(),
+            npeer_diagnostics(s, run)
+        ));
+    }
+    if let Some((peer, index)) = run.first_divergence {
+        return Err(format!(
+            "confirmed inputs diverged: peer{peer} differs from peer0 at flattened index {index}\n{}",
+            npeer_diagnostics(s, run)
+        ));
+    }
+    // All checksums must equal peer 0's.
+    if let Some(reference) = run.checksum.first() {
+        if let Some((peer, _)) = run
+            .checksum
+            .iter()
+            .enumerate()
+            .find(|&(_, cs)| cs != reference)
+        {
+            return Err(format!(
+                "confirmed-input checksums differ: peer{peer} != peer0\n{}",
+                npeer_diagnostics(s, run)
+            ));
+        }
+    }
+    if let Some((peer, _)) = run.stub_frame.iter().enumerate().find(|&(_, f)| *f <= 0) {
+        return Err(format!(
+            "peer{peer}'s GameStub did not advance\n{}",
+            npeer_diagnostics(s, run)
+        ));
+    }
+    if !run.reached_target {
+        return Err(format!(
+            "not every peer reached the target confirmed frame\n{}",
+            npeer_diagnostics(s, run)
+        ));
+    }
+    Ok(())
+}
+
+/// Runs a single N-peer scenario on its FIXED per-peer seeds and returns
+/// `Ok(())` if all invariants hold, or `Err(diagnostic)`. After the invariants
+/// pass, reproducibility is proven by re-running the identical scenario from
+/// scratch and asserting bit-identical confirmed frames AND checksums.
+fn run_npeer_chaos_scenario(s: &NPeerChaosScenario) -> Result<(), String> {
+    let run = execute_npeer_scenario_once(s);
+    check_npeer_run(s, &run)?;
+
+    let rerun = execute_npeer_scenario_once(s);
+    let repro_ok = rerun.first_divergence.is_none()
+        && rerun.confirmed == run.confirmed
+        && rerun.checksum == run.checksum;
+    if !repro_ok {
+        return Err(format!(
+            "reproducibility mismatch:\n  run    confirmed={:?} checksum={:?}\n  \
+             rerun  confirmed={:?} checksum={:?}\n{}",
+            run.confirmed,
+            run.checksum,
+            rerun.confirmed,
+            rerun.checksum,
+            npeer_diagnostics(s, &rerun)
+        ));
+    }
+    Ok(())
+}
+
+/// The N-peer data-driven scenario table (N ∈ {3, 4}).
+///
+/// Profiles are drawn from the same `ChaosProfile` palette as the 2-peer table.
+/// Targets are deliberately conservative for the larger meshes: an N-peer mesh
+/// must synchronize every pair and reconcile every remote's confirmed stream,
+/// so sustained heavy loss converges more slowly than the 2-peer case. Each row
+/// is pinned to a single seed family (no seed search), so a pass reflects a
+/// genuinely robust deterministic run, and reproducibility is asserted on top.
+fn npeer_scenarios() -> Vec<NPeerChaosScenario> {
+    use SyncPreset::{Competitive, Default, Lan, Mobile};
+    vec![
+        // --- N = 3 (symmetric) ----------------------------------------------
+        NPeerChaosScenario {
+            name: "n3_local",
+            profiles: vec![ChaosProfile::local(); 3],
+            seed: 2_100,
+            target_confirmed: 40,
+            input_delay: 2,
+            preset: Lan,
+        },
+        NPeerChaosScenario {
+            name: "n3_lan",
+            profiles: vec![ChaosProfile::lan(); 3],
+            seed: 2_200,
+            target_confirmed: 35,
+            input_delay: 2,
+            preset: Lan,
+        },
+        NPeerChaosScenario {
+            name: "n3_wifi_good",
+            profiles: vec![ChaosProfile::wifi_good(); 3],
+            seed: 2_300,
+            target_confirmed: 35,
+            input_delay: 2,
+            preset: Competitive,
+        },
+        NPeerChaosScenario {
+            name: "n3_wifi_average",
+            profiles: vec![ChaosProfile::wifi_average(); 3],
+            seed: 2_400,
+            target_confirmed: 30,
+            input_delay: 2,
+            preset: Default,
+        },
+        // mobile_4g (~8% loss) is the heaviest symmetric profile that still
+        // confirms a meaningful (non-vacuous) range across a 3-peer mesh in the
+        // virtual-time budget. The 15%-loss `wifi_congested` / `mobile_3g`
+        // profiles — which the 2-peer table tolerates — near-deadlock at N≥3
+        // (the per-frame confirmation needs EVERY peer's input, so the combined
+        // effective loss compounds with mesh size), so they are deliberately
+        // omitted here for the same reason the 2-peer table omits `terrible`:
+        // "does it survive catastrophic loss at all" is the nightly real-UDP
+        // suite's job, not this determinism table's.
+        NPeerChaosScenario {
+            name: "n3_mobile_4g",
+            profiles: vec![ChaosProfile::mobile_4g(); 3],
+            seed: 3_400,
+            target_confirmed: 25,
+            input_delay: 2,
+            preset: Mobile,
+        },
+        // --- N = 3 (asymmetric: one lossy peer) -----------------------------
+        NPeerChaosScenario {
+            name: "n3_asymmetric_one_wifi_average",
+            profiles: vec![
+                ChaosProfile::lan(),
+                ChaosProfile::lan(),
+                ChaosProfile::wifi_average(),
+            ],
+            seed: 2_500,
+            target_confirmed: 30,
+            input_delay: 2,
+            preset: Default,
+        },
+        // --- N = 4 (symmetric) ----------------------------------------------
+        NPeerChaosScenario {
+            name: "n4_local",
+            profiles: vec![ChaosProfile::local(); 4],
+            seed: 2_600,
+            target_confirmed: 35,
+            input_delay: 2,
+            preset: Lan,
+        },
+        NPeerChaosScenario {
+            name: "n4_lan",
+            profiles: vec![ChaosProfile::lan(); 4],
+            seed: 2_700,
+            target_confirmed: 30,
+            input_delay: 2,
+            preset: Lan,
+        },
+        NPeerChaosScenario {
+            name: "n4_wifi_good",
+            profiles: vec![ChaosProfile::wifi_good(); 4],
+            seed: 2_800,
+            target_confirmed: 30,
+            input_delay: 2,
+            preset: Competitive,
+        },
+        // --- N = 4 (asymmetric: mixed quality) ------------------------------
+        NPeerChaosScenario {
+            name: "n4_asymmetric_mixed",
+            profiles: vec![
+                ChaosProfile::lan(),
+                ChaosProfile::wifi_good(),
+                ChaosProfile::lan(),
+                ChaosProfile::wifi_average(),
+            ],
+            seed: 2_900,
+            target_confirmed: 25,
+            input_delay: 2,
+            preset: Mobile,
+        },
+    ]
+}
+
+/// The primary N≥3 data-driven chaos test: iterates the whole N-peer scenario
+/// table, aggregates failures into a single clear report, and asserts at the
+/// end. Fully deterministic and virtual-time, so it completes in a few seconds.
+#[test]
+fn in_process_chaos_npeer_table() {
+    let scenarios = npeer_scenarios();
+    let mut failures: Vec<String> = Vec::new();
+    let mut passed = 0usize;
+
+    for scenario in &scenarios {
+        match run_npeer_chaos_scenario(scenario) {
+            Ok(()) => passed += 1,
+            Err(report) => {
+                eprintln!("\n=== N-PEER CHAOS SCENARIO FAILURE ===\n{report}\n");
+                failures.push(scenario.name.to_string());
+            },
+        }
+    }
+
+    eprintln!(
+        "in_process_chaos_npeer_table: {passed}/{} scenarios passed",
+        scenarios.len()
+    );
+
+    assert!(
+        failures.is_empty(),
+        "{} N-peer chaos scenario(s) failed: {:?}",
+        failures.len(),
+        failures
+    );
+}
+
+/// A focused sanity check on the N-peer determinism harness itself using a
+/// perfect 3-peer link: confirmed inputs must match exactly across all peers
+/// and reproduce bit-for-bit. If this fails while the table passes, the bug is
+/// in the harness, not chaos handling.
+#[test]
+fn in_process_chaos_npeer_perfect_link_determinism() {
+    let scenario = NPeerChaosScenario {
+        name: "n3_perfect_link",
+        profiles: vec![ChaosProfile::local(); 3],
+        seed: 11,
+        target_confirmed: 50,
+        input_delay: 2,
+        preset: SyncPreset::Lan,
+    };
+
+    if let Err(report) = run_npeer_chaos_scenario(&scenario) {
+        panic!("N-peer perfect-link determinism failed:\n{report}");
+    }
+}
+
+/// Negative control: proves the cross-peer determinism oracle is **non-vacuous**
+/// — i.e. it genuinely detects a divergence rather than passing trivially.
+///
+/// `mesh_input_checksums` is the exact comparator the table test asserts on, so
+/// confirming it (a) reports identical checksums and no divergence for agreeing
+/// streams and (b) reports unequal checksums and the precise `(peer, index)`
+/// for a single corrupted element guarantees that a real N-peer desync would
+/// turn the table test RED.
+#[test]
+fn in_process_chaos_npeer_oracle_detects_divergence() {
+    // Agreeing streams: no divergence, all checksums equal.
+    let agree = vec![vec![1u32, 2, 3, 4], vec![1, 2, 3, 4], vec![1, 2, 3, 4]];
+    let (checksums, divergence) = mesh_input_checksums(&agree);
+    assert_eq!(divergence, None, "agreeing streams must not diverge");
+    assert!(
+        checksums.iter().all(|&c| c == checksums[0]),
+        "agreeing streams must share one checksum"
+    );
+
+    // One element corrupted on peer 2: divergence at (2, 2), checksum differs.
+    let diverge = vec![vec![1u32, 2, 3, 4], vec![1, 2, 3, 4], vec![1, 2, 99, 4]];
+    let (checksums, divergence) = mesh_input_checksums(&diverge);
+    assert_eq!(
+        divergence,
+        Some((2, 2)),
+        "a corrupted element must be reported at its exact (peer, index)"
+    );
+    assert_ne!(
+        checksums[2], checksums[0],
+        "a divergent peer's checksum must differ from peer 0's"
+    );
+
+    // Two peers BOTH differing from peer 0: keying off peer 0 still flags the
+    // first such peer (lowest index), proving the transitive-equality approach
+    // catches multi-peer divergence.
+    let multi = vec![vec![1u32, 2, 3, 4], vec![1, 9, 3, 4], vec![1, 2, 9, 4]];
+    let (_checksums, divergence) = mesh_input_checksums(&multi);
+    assert_eq!(
+        divergence,
+        Some((1, 1)),
+        "when multiple peers differ from peer 0, the lowest-index one is reported first"
+    );
+
+    // A short stream (a peer that produced fewer confirmed inputs) also counts
+    // as a divergence at the truncation point.
+    let truncated = vec![vec![1u32, 2, 3, 4], vec![1, 2], vec![1, 2, 3, 4]];
+    let (_checksums, divergence) = mesh_input_checksums(&truncated);
+    assert_eq!(
+        divergence,
+        Some((1, 2)),
+        "a truncated stream must be reported as a divergence at its end"
+    );
+
+    // The full run-checker rejects a run whose checksums disagree, so the
+    // table-level green assertion is itself non-vacuous. The stream lengths are
+    // set to the complete `(shared + 1) * N` so the run clears the vacuity gates
+    // and actually reaches the checksum-equality check.
+    let s = NPeerChaosScenario {
+        name: "synthetic_divergent",
+        profiles: vec![ChaosProfile::local(); 3],
+        seed: 0,
+        target_confirmed: 20,
+        input_delay: 2,
+        preset: SyncPreset::Lan,
+    };
+    let full_len = (30 + 1) * 3; // shared = 30, N = 3
+    let good_lens = vec![full_len; 3];
+    let bad_run = NPeerScenarioRun {
+        confirmed: vec![30, 30, 30],
+        current: vec![32, 32, 32],
+        stub_frame: vec![30, 30, 30],
+        checksum: vec![0xAAAA, 0xAAAA, 0xBBBB],
+        shared: 30,
+        stream_len: good_lens.clone(),
+        first_divergence: None,
+        state: vec![SessionState::Running; 3],
+        reached_target: true,
+    };
+    assert!(
+        check_npeer_run(&s, &bad_run).is_err(),
+        "check_npeer_run must reject a run whose checksums disagree"
+    );
+
+    // And the run-checker rejects a VACUOUS run: a peer whose checksummed stream
+    // was truncated (an in-range confirmed frame was unavailable) must fail even
+    // though confirmed_frame() and the checksums look fine — this pins the
+    // stream-length non-vacuity guard.
+    let vacuous_run = NPeerScenarioRun {
+        confirmed: vec![30, 30, 30],
+        current: vec![32, 32, 32],
+        stub_frame: vec![30, 30, 30],
+        checksum: vec![0xAAAA; 3],
+        shared: 30,
+        // Peer 1 folded too few elements (frame 0 evicted from its ring).
+        stream_len: vec![full_len, full_len - 3, full_len],
+        first_divergence: None,
+        state: vec![SessionState::Running; 3],
+        reached_target: true,
+    };
+    assert!(
+        check_npeer_run(&s, &vacuous_run).is_err(),
+        "check_npeer_run must reject a run whose checksummed stream was truncated"
+    );
+
+    // A fully non-vacuous, agreeing run passes the checker (positive control, so
+    // the rejections above aren't trivially always-Err).
+    let good_run = NPeerScenarioRun {
+        confirmed: vec![30, 30, 30],
+        current: vec![32, 32, 32],
+        stub_frame: vec![30, 30, 30],
+        checksum: vec![0xAAAA; 3],
+        shared: 30,
+        stream_len: good_lens,
+        first_divergence: None,
+        state: vec![SessionState::Running; 3],
+        reached_target: true,
+    };
+    assert!(
+        check_npeer_run(&s, &good_run).is_ok(),
+        "check_npeer_run must accept a complete, agreeing, non-vacuous run"
+    );
 }

--- a/tests/network/multi_process.rs
+++ b/tests/network/multi_process.rs
@@ -1399,9 +1399,30 @@ fn verify_determinism(result1: &TestResult, result2: &TestResult, context: &str)
                 eprintln!("  Check network conditions and sync preset configuration.");
             },
             (false, false) => {
-                // Both advanced frames but still failed - different issue
-                eprintln!("DIAGNOSIS: Both peers advanced frames but test still failed.");
-                eprintln!("  This may indicate a timeout or desync during gameplay.");
+                let both_timed_out = result1.error_kind.as_deref() == Some("timeout")
+                    && result2.error_kind.as_deref() == Some("timeout");
+                if both_timed_out {
+                    // Both peers exhausted their real-time budget before reaching
+                    // the target. These multi-process tests are governed by real
+                    // wall-clock time (real UDP latency/jitter/loss + timer-based
+                    // retransmission), so a timeout here is almost always CI host
+                    // starvation on a slow/loaded runner, NOT a protocol livelock:
+                    // the prediction-window throttle + retransmission guarantee
+                    // progress under mere delay/loss, the same scenario completes
+                    // in seconds on an unloaded machine, and progress-under-loss
+                    // is proven deterministically in tests/network/in_process_chaos.rs.
+                    eprintln!("DIAGNOSIS: Both peers timed out before reaching the target frame.");
+                    eprintln!("  Real-UDP multi-process tests are real-time, so a timeout is");
+                    eprintln!("  usually CI host starvation, not a logic deadlock. Determinism");
+                    eprintln!("  and progress-under-loss are covered deterministically in");
+                    eprintln!("  tests/network/in_process_chaos.rs. If a scenario is consistently");
+                    eprintln!("  too heavy for per-PR CI, move it to the nightly suite with");
+                    eprintln!("  #[ignore] (see .github/workflows/ci-network-nightly.yml).");
+                } else {
+                    // Both advanced frames but still failed - different issue
+                    eprintln!("DIAGNOSIS: Both peers advanced frames but test still failed.");
+                    eprintln!("  This may indicate a timeout or desync during gameplay.");
+                }
             },
         }
         eprintln!("============================================");
@@ -2199,6 +2220,7 @@ fn test_zero_latency_high_loss() {
 /// Test medium-length session (300 frames) with moderate conditions.
 #[test]
 #[serial]
+#[ignore = "long-running endurance or high-latency real-UDP session; runs in the nightly network suite (ci-network-nightly.yml), not per-PR CI"]
 fn test_medium_session_300_frames() {
     skip_if_no_peer_binary!();
     let peer1_config = PeerConfig {

--- a/tests/network/multi_process.rs
+++ b/tests/network/multi_process.rs
@@ -1188,9 +1188,17 @@ fn wait_for_peer(child: Child, name: &str) -> TestResult {
 /// Returns one `TestResult` per input config, in the same order.
 ///
 /// # Panics
-/// Panics if the network_test_peer binary is not available.
+/// Panics if fewer than two peer configs are provided, if the
+/// network_test_peer binary is not available, if a peer cannot be spawned, or
+/// if a peer wait thread panics.
 /// Use [`skip_if_no_peer_binary!`] at the start of tests to skip gracefully.
 fn run_n_peer_test(configs: Vec<PeerConfig>) -> Vec<TestResult> {
+    assert!(
+        configs.len() >= 2,
+        "run_n_peer_test requires at least 2 peers, got {}",
+        configs.len()
+    );
+
     // Check if the binary exists - fail fast with a clear message
     assert!(
         is_peer_binary_available(),
@@ -1201,12 +1209,6 @@ fn run_n_peer_test(configs: Vec<PeerConfig>) -> Vec<TestResult> {
          This is not a test failure - the test requires the peer binary to be built first.",
         PEER_BINARY_NAME
     );
-    assert!(
-        configs.len() >= 2,
-        "run_n_peer_test requires at least 2 peers, got {}",
-        configs.len()
-    );
-
     let test_start = std::time::Instant::now();
 
     // Calculate timeout: use the max of peer timeouts + 30s buffer for process
@@ -1289,7 +1291,9 @@ fn run_n_peer_test(configs: Vec<PeerConfig>) -> Vec<TestResult> {
 /// keep working unchanged.
 ///
 /// # Panics
-/// Panics if the network_test_peer binary is not available.
+/// Panics if the network_test_peer binary is not available, if a peer cannot
+/// be spawned, if a peer wait thread panics, or if the shared N-peer helper
+/// returns fewer than two results.
 /// Use [`skip_if_no_peer_binary!`] at the start of tests to skip gracefully.
 fn run_two_peer_test(
     peer1_config: PeerConfig,
@@ -3658,6 +3662,18 @@ mod infrastructure_tests {
             found.is_some(),
             "is_peer_binary_available should match find_peer_binary().is_some()"
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "requires at least 2 peers")]
+    fn run_n_peer_test_rejects_empty_configs_before_binary_check() {
+        let _ = run_n_peer_test(Vec::new());
+    }
+
+    #[test]
+    #[should_panic(expected = "requires at least 2 peers")]
+    fn run_n_peer_test_rejects_single_config_before_binary_check() {
+        let _ = run_n_peer_test(vec![PeerConfig::default()]);
     }
 
     /// Test PeerConfig default values.

--- a/tests/sessions/peer_drop.rs
+++ b/tests/sessions/peer_drop.rs
@@ -2860,6 +2860,691 @@ fn p2p_n4_relay_clobber_dropped_slot_freeze_frame_converges_across_survivors(
 }
 
 // ============================================================================
+// ARBITRATION (N=4 residual): "stale-echo freeze" — VERDICT: NOTABUG
+// (arbitrated S41). Documented at `p2p_session.rs`
+// `remote_slot_confirmed_bound`'s rustdoc ("# Documented residuals").
+// ============================================================================
+//
+// Claim once feared: a third survivor X freezes the dropped slot D using its
+// STALE-LOW cache of survivor U's old gossip about D. The moment ANOTHER peer's
+// (B's) disconnect report flips X's `queue_connected` for D, X's
+// endpoint-terms override (`update_player_disconnects`' min over running
+// endpoints) mins that stale-low cached term and converges a freeze frame BELOW
+// X's current confirmed bound — which (the fear was) X's confirmation may
+// already have passed, re-exposing the window-floor mechanism: X silently
+// overwrites confirmed history for D in `(stale_low, X_confirmed]` while U
+// (whose own bound stayed high) keeps D's real inputs there.
+//
+// VERDICT (S41): NOTABUG. The stale-low term is held by a STILL-RUNNING endpoint,
+// so the SAME term is folded into X's confirmed BOUND (`remote_slot_confirmed_bound`)
+// that the override later mins — bound == applied freeze within a snapshot, so X is
+// pinned AT the stale-low value and never confirms past it (no window-floor
+// re-exposure). The only cross-call escape is UNREACHABLE in a full mesh
+// (see the assertion-site comment below and the rustdoc); the genuine escape needs
+// fold-membership asymmetry, which is the sibling `p2p_n4_double_failure_relay_*`
+// (REAL) corner.
+//
+// This test is the IN-MESH REACHABILITY evidence for that NOTABUG: it drives the
+// full choreography and the F4 byte oracle (over the shared confirmed-frame range,
+// A's and C's recorded confirmed StateStub must be byte-equal) shows the victim C
+// pinned low with byte-IDENTICAL confirmed state — confirmation never outran the
+// freeze in process. The byte-compare is the oracle; a NON-EMPTY divergence list
+// (or a survivor stalling / `advance_frame` erroring) would be a RED reproduction.
+//
+// Assignment (natural mapping onto the F4 harness): U = A (high-receipt peer
+// whose own bound stays high), X = C (stale-holding survivor), flip-trigger =
+// B. A->C is severed (as in F4) so C never hears A's NEWER, higher gossip about
+// D — C's `endpoint_A.peer_connect_status(D)` is frozen at A's early, low view.
+//
+// The non-vacuity assertion guards that some confirmed frames were compared; the
+// `divergences.is_empty()` assertion pins the NOTABUG outcome so the file stays a
+// regression guard (it flips RED if the corner ever reproduces).
+
+/// Stale-echo arbitration (VERDICT: NOTABUG, S41). Engineers C to hold a
+/// stale-low cache of A's early gossip about D (A->C severed after A's low gossip
+/// lands), then has B drop D and gossip the disconnect to C, flipping C's
+/// `queue_connected(D)` while C still holds A's stale-low term. Records confirmed
+/// states per survivor and runs the F4 byte oracle, which shows C pinned low with
+/// byte-identical confirmed state — confirmation never outran the freeze. Asserts
+/// non-vacuity (some confirmed frames compared) and that the survivors' confirmed
+/// state did NOT diverge.
+#[test]
+fn p2p_n4_stale_echo_freeze_dropped_slot_diverges_across_survivors() -> Result<(), FortressError> {
+    // Long symmetric timeouts: every drop here is driven by explicit
+    // `remove_player` + gossip propagation, never by an auto-timeout (so a
+    // blocked LINK never collapses an endpoint to non-running on its own and
+    // changes the fold membership out from under the choreography).
+    let (
+        mut sess_a,
+        mut sess_b,
+        mut sess_c,
+        mut sess_d,
+        blocked,
+        a_addr,
+        b_addr,
+        c_addr,
+        d_addr,
+        clock,
+    ) = build_filtered_four_player_sessions(Duration::from_secs(5))?;
+
+    let mut stub_a = GameStub::new();
+    let mut stub_b = GameStub::new();
+    let mut stub_c = GameStub::new();
+    let mut stub_d = GameStub::new();
+
+    let mut states_a: BTreeMap<i32, StateStub> = BTreeMap::new();
+    let mut states_b: BTreeMap<i32, StateStub> = BTreeMap::new();
+    let mut states_c: BTreeMap<i32, StateStub> = BTreeMap::new();
+    let mut sink: BTreeMap<i32, StateStub> = BTreeMap::new();
+
+    let h_a = PlayerHandle::new(0);
+    let h_b = PlayerHandle::new(1);
+    let h_c = PlayerHandle::new(2);
+    let h_d = PlayerHandle::new(3);
+
+    // --- Phase 1: tiny warmup (all links open) so A's gossip about D reaches C
+    // at a LOW frame and all four mutually confirm a couple of frames. D's
+    // stream (i + 3000) is non-constant so a frozen D value is frame-sensitive
+    // and divergence is byte-detectable. ---
+    let warmup_frames = 3_u32;
+    for i in 0..warmup_frames {
+        poll_four(
+            &mut sess_a,
+            &mut sess_b,
+            &mut sess_c,
+            &mut sess_d,
+            &clock,
+            3,
+        );
+        try_advance_recording(&mut sess_a, &mut stub_a, h_a, i, &mut states_a)?;
+        try_advance_recording(&mut sess_b, &mut stub_b, h_b, i + 1000, &mut states_b)?;
+        try_advance_recording(&mut sess_c, &mut stub_c, h_c, i + 2000, &mut states_c)?;
+        try_advance_recording(&mut sess_d, &mut stub_d, h_d, i + 3000, &mut sink)?;
+    }
+    poll_four(
+        &mut sess_a,
+        &mut sess_b,
+        &mut sess_c,
+        &mut sess_d,
+        &clock,
+        4,
+    );
+
+    // --- Phase 2: SEVER A->C now (early), freezing C's cache of A's view of D
+    // at A's CURRENT (low) gossip. From here C never hears A's newer, higher
+    // gossip about D — C's `endpoint_A.peer_connect_status(D)` is stuck low. We
+    // keep D->A, D->B, D->C open and advance several frames so A's and B's REAL
+    // receipt of D climbs well ABOVE the frozen value C holds for A. ---
+    blocked.block(a_addr, c_addr);
+    blocked.block(c_addr, a_addr); // sever both directions, as in F4
+
+    // Advance a wider window so A's (and B's) D receipt climbs above the stale
+    // value frozen in C's A-cache. C still receives D directly, so C's OWN
+    // local receipt of D also climbs — but C's confirmed_frame is BOUNDED by
+    // the gossip fold, which includes A's frozen-low cache.
+    let climb_window = 6_u32;
+    for i in 0..climb_window {
+        poll_four(
+            &mut sess_a,
+            &mut sess_b,
+            &mut sess_c,
+            &mut sess_d,
+            &clock,
+            2,
+        );
+        try_advance_recording(&mut sess_a, &mut stub_a, h_a, 100 + i, &mut states_a)?;
+        try_advance_recording(&mut sess_b, &mut stub_b, h_b, 1100 + i, &mut states_b)?;
+        try_advance_recording(&mut sess_c, &mut stub_c, h_c, 2100 + i, &mut states_c)?;
+        try_advance_recording(&mut sess_d, &mut stub_d, h_d, 3100 + i, &mut sink)?;
+    }
+    poll_four(
+        &mut sess_a,
+        &mut sess_b,
+        &mut sess_c,
+        &mut sess_d,
+        &clock,
+        4,
+    );
+
+    // --- Phase 3: D goes silent to EVERYONE. B drops D first (direct
+    // `remove_player`) at B's HIGH receipt, then gossips D-disconnected to C
+    // (B->C open), flipping C's `queue_connected(D)`. C still holds A's
+    // stale-low cache (A->C severed), so C's override mins down to A's stale-low
+    // term. A, meanwhile, dropped D at its OWN high receipt and (A<->C severed)
+    // never hears C's lowering directly. ---
+    blocked.block(d_addr, a_addr);
+    blocked.block(d_addr, b_addr);
+    blocked.block(d_addr, c_addr);
+
+    // B drops D at its high receipt and re-gossips the disconnect to C.
+    sess_b.remove_player(h_d).unwrap();
+    // A drops D at its high receipt; A's own bound for D stays HIGH (A folds its
+    // own receipt, not C's lowering — A<->C severed).
+    sess_a.remove_player(h_d).unwrap();
+    // C does NOT explicitly remove D: we want C to learn D is disconnected via
+    // B's GOSSIP (the queue_connected flip), so the stale-low A-cache term is
+    // what mines C's freeze frame down — not C's own (higher) receipt.
+
+    let mut c_stall_error: Option<FortressError> = None;
+    for _ in 0..200 {
+        sess_a.poll_remote_clients();
+        sess_b.poll_remote_clients();
+        sess_c.poll_remote_clients();
+        clock.advance(POLL_INTERVAL_DETERMINISTIC);
+
+        try_advance_recording(&mut sess_a, &mut stub_a, h_a, 500, &mut states_a)?;
+        try_advance_recording(&mut sess_b, &mut stub_b, h_b, 1500, &mut states_b)?;
+        // C may stall or error if the mine-down targets confirmed/discarded
+        // history (the window-floor re-exposure the claim predicts). Capture
+        // (not `?`-propagate) any non-throttle error so the test can report it.
+        match try_advance_recording(&mut sess_c, &mut stub_c, h_c, 2500, &mut states_c) {
+            Ok(_) => {},
+            Err(e) => {
+                if c_stall_error.is_none() {
+                    c_stall_error = Some(e);
+                }
+            },
+        }
+    }
+
+    // --- Byte oracle (F4 pattern): over the shared confirmed range, A vs C is
+    // the stale-echo pair (A's bound stayed high; C's was mined down by A's
+    // stale-low cached term). A vs B catches residual divergence. ---
+    let confirmed_bound = sess_a
+        .confirmed_frame()
+        .as_i32()
+        .min(sess_b.confirmed_frame().as_i32())
+        .min(sess_c.confirmed_frame().as_i32());
+    let mut compared = 0_u32;
+    let mut divergences: Vec<(i32, &'static str, StateStub, StateStub)> = Vec::new();
+    for (&frame, &state_a) in &states_a {
+        if frame > confirmed_bound {
+            continue;
+        }
+        if let Some(&state_c) = states_c.get(&frame) {
+            compared += 1;
+            if state_a != state_c {
+                divergences.push((frame, "A!=C", state_a, state_c));
+            }
+        }
+        if let Some(&state_b) = states_b.get(&frame) {
+            if state_a != state_b {
+                divergences.push((frame, "A!=B", state_a, state_b));
+            }
+        }
+    }
+
+    // Non-vacuity: the choreography must actually have exercised confirmed
+    // frames across survivors, or the arbitration proves nothing.
+    assert!(
+        compared > 0,
+        "no confirmed frames were compared across survivors (bound={confirmed_bound}); \
+         the stale-echo choreography did not produce overlapping confirmed history"
+    );
+
+    // NOTABUG (arbitrated S41), two-part rationale (matches the
+    // `remote_slot_confirmed_bound` rustdoc "# Documented residuals"):
+    //
+    // (1) INTRA-SNAPSHOT (bound == applied freeze). C's stale-low term is held by
+    //     a STILL-RUNNING endpoint (A's cache), so it is folded into C's confirmed
+    //     BOUND (`remote_slot_confirmed_bound`) AND into the override
+    //     (`update_player_disconnects`) IDENTICALLY — both folds iterate the same
+    //     `is_running()` endpoint set. C is therefore pinned AT the stale-low value
+    //     the whole window: it never confirms PAST it, and the mine-down rewrites
+    //     only PREDICTED frames (no window-floor re-exposure, no divergence, no stall).
+    //
+    // (2) REACHABILITY (no cross-call escape). The one cross-call escape — a
+    //     still-running endpoint adopting a LOWER freeze on its disconnect-flip
+    //     (`merge_peer_connect_status`'s first-disconnect `last_frame = remote.last_frame`)
+    //     below an already-confirmed frame — is UNREACHABLE in a full mesh: for any
+    //     endpoint to gossip a low `{disconnected, F}` that we adopt, some running
+    //     endpoint must have gossiped that low `F`, and broadcast gossip (every input
+    //     packet carries the full connect-status vector) delivers the same low `F` to
+    //     US, pinning our bound at `F` BEFORE we can confirm past it. The genuine
+    //     escape requires that source endpoint to be ABSENT from our fold
+    //     (fold-membership asymmetry) — i.e. the sibling `p2p_n4_double_failure_relay_*`
+    //     (REAL) corner, where the low term's origin dies and is pruned.
+    //
+    // If this assertion ever fails (divergences non-empty, or C errored), the
+    // stale-echo corner has gone RED and this guard must be revisited.
+    assert!(
+        divergences.is_empty() && c_stall_error.is_none(),
+        "stale-echo went RED: the corner reproduced in-process \
+         (bound={confirmed_bound}, compared={compared}, divergences={divergences:?}, \
+         c_stall_error={c_stall_error:?})"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// ARBITRATION (N=4 residual): "double-failure relay" — VERDICT: REAL
+// (arbitrated S41; the genuine residual). Documented at `p2p_session.rs`
+// `remote_slot_confirmed_bound`'s rustdoc ("# Documented residuals").
+// ============================================================================
+//
+// Documented quote (p2p_session.rs, remote_slot_confirmed_bound rustdoc):
+// "an origin survivor that dies AFTER relaying its low freeze value to a third
+// peer but BEFORE delivering it to us leaves a window where our bound (no longer
+// folding the dead origin's endpoint) exceeds the override later relayed through
+// the third peer."
+//
+// VERDICT (this test): REAL — arbitrated AND adversarially verified faithful /
+// non-vacuous in S41. The corner REPRODUCES in-process as a REAL, deterministic,
+// cross-survivor CONFIRMED-STATE divergence with FIRST divergence at `F + 1`; it
+// VANISHES if the origin stays in the fold or the relay is prompt (so the
+// choreography is load-bearing, not an artifact). The test asserts the divergence
+// IS present as a CI-safe characterization guard that FLIPS when a future fix
+// closes the residual.
+//
+// Mechanism, as actually driven below (A = "us", B = dying origin, C = relay,
+// D = the dropped peer; num_players=4, ContinueWithout, max_prediction=4):
+//   - Phase 2 builds a D-receipt gradient by blocking D->B: B's view of D freezes
+//     at the global-min `F` while A and C keep receiving D up to a higher `M`.
+//     While B still runs and gossips {connected, F}, every survivor folds B's low
+//     term, so the freeze barrier PINS confirmed_frame at `F` even though A's and
+//     C's receipt of D has climbed to M. C keeps gossiping {connected, M} to A, so
+//     A's cached C-view of D (`endpoint_C.peer_connect_status(D)`) reaches M.
+//   - Phase 3 arms the DOUBLE FAILURE via explicit removals (no timeout, so fold
+//     membership is fully controlled): block D->C (C frozen at M); sever C->A while
+//     A's cached C-view of D is still {connected, M} (A's long timeout keeps C's
+//     endpoint RUNNING, so A keeps folding C at M); `B.remove_player(D)` (B freezes
+//     D at F and gossips {disconnected, F} to C, which ADOPTS F via
+//     `merge_peer_connect_status:1847` even though C's own receipt is M); and
+//     `A.remove_player(B)` so B's endpoint on A goes non-running and is PRUNED from
+//     A's D fold (`remote_slot_confirmed_bound`/`update_player_disconnects` skip
+//     `!endpoint.is_running()`) — the "origin dies after relaying to C but before
+//     delivering to us" leg. A's D fold is now min(A receipt, C-cache) = M.
+//   - Phase 4: A records frames ABOVE `F` with D's REAL inputs (A does not yet know
+//     D dropped) and its small window DISCARDS the frames below `current - 4`.
+//   - Phase 5 re-opens C->A: C's relayed {disconnected, F} finally lands, A lowers
+//     its D term to F and arms a disconnect rollback to F+1 — BELOW A's window
+//     floor. The S20 out-of-window clamp (adjust_gamestate:7478,
+//     `frame_to_load.max(window_floor)`) keeps A LIVE (Ok, no stall) and
+//     re-simulates only the in-window frames with D frozen at F. The already
+//     -discarded frames in `(F, floor]` keep A's real-input state, which no longer
+//     matches C's frozen-at-F state -> a permanent divergence the relay cannot fix.
+//
+// This is the N>=4 instance of the discard-before-convergence residual the S32
+// barrier closed at N=3 but only NARROWED at N>=4. The "double failure" is: the
+// origin B is pruned from A's fold (its low view never reaches A directly) AND
+// C->A is delayed past A's record+discard of the high frames.
+//
+// Oracle (F4 byte pattern): over the shared confirmed-frame range, A's and C's
+// recorded confirmed StateStub must be byte-equal; a NON-EMPTY divergence list is
+// the RED signal. The decisive SIGNATURE of this corner (vs a plain input split)
+// is that D's confirmed *inputs* CONVERGE across A and C (both frozen at F, so the
+// library's own input-checksum desync detector stays silent) while the recorded
+// *state* silently diverges. The assertions pin the empirically-observed
+// reproduction (first divergence at `F + 1`) as a CI-safe characterization guard.
+
+/// Double-failure-relay arbitration (VERDICT: REAL, S41). Builds a D-receipt
+/// gradient (B low = `F`, A/C high = `M`), then prunes the origin B from A's fold
+/// via `A.remove_player(B)` while A's direct link to C is severed and B has already
+/// relayed its low freeze to C — so A records D's slot above `F` with real inputs
+/// and discards those frames before C's relayed `{disconnected, F}` reaches A. The
+/// late relay lowers A's D term below A's discarded window; the S20 clamp keeps A
+/// live but cannot repair the discarded frames, leaving A and C with divergent
+/// confirmed state. Records confirmed states per survivor, runs the F4 byte oracle,
+/// and probes (on genuinely-queryable in-window frames) that D's confirmed inputs
+/// nonetheless converged — so an input-checksum desync detector stays blind.
+#[test]
+fn p2p_n4_double_failure_relay_dropped_slot_diverges_across_survivors() -> Result<(), FortressError>
+{
+    // LONG symmetric timeouts so NO auto-timeout fires: every endpoint pruning
+    // here is driven by an explicit `remove_player`, so the choreography fully
+    // controls fold membership (a blocked LINK never collapses an endpoint to
+    // non-running out from under us). SMALL prediction window (4) so A can burn
+    // its whole window and DISCARD frames below `F` before C's relayed low lands.
+    let long = Duration::from_secs(20);
+    let (
+        mut sess_a,
+        mut sess_b,
+        mut sess_c,
+        mut sess_d,
+        blocked,
+        a_addr,
+        b_addr,
+        c_addr,
+        d_addr,
+        clock,
+    ) = build_filtered_four_player_sessions_with_timeouts_and_prediction([long; 4], 4)?;
+
+    let mut stub_a = GameStub::new();
+    let mut stub_b = GameStub::new();
+    let mut stub_c = GameStub::new();
+    let mut stub_d = GameStub::new();
+
+    let mut states_a: BTreeMap<i32, StateStub> = BTreeMap::new();
+    let mut states_b: BTreeMap<i32, StateStub> = BTreeMap::new();
+    let mut states_c: BTreeMap<i32, StateStub> = BTreeMap::new();
+    let mut sink: BTreeMap<i32, StateStub> = BTreeMap::new();
+
+    let h_a = PlayerHandle::new(0);
+    let h_b = PlayerHandle::new(1);
+    let h_c = PlayerHandle::new(2);
+    let h_d = PlayerHandle::new(3);
+
+    // --- Phase 1: warmup, all links open so all four confirm together. D's stream
+    // (i + 3000) is non-constant so a frozen D value is frame-sensitive and a
+    // divergence is byte-detectable. ---
+    let warmup_frames = 6_u32;
+    for i in 0..warmup_frames {
+        poll_four(
+            &mut sess_a,
+            &mut sess_b,
+            &mut sess_c,
+            &mut sess_d,
+            &clock,
+            3,
+        );
+        try_advance_recording(&mut sess_a, &mut stub_a, h_a, i, &mut states_a)?;
+        try_advance_recording(&mut sess_b, &mut stub_b, h_b, i + 1000, &mut states_b)?;
+        try_advance_recording(&mut sess_c, &mut stub_c, h_c, i + 2000, &mut states_c)?;
+        try_advance_recording(&mut sess_d, &mut stub_d, h_d, i + 3000, &mut sink)?;
+    }
+    poll_four(
+        &mut sess_a,
+        &mut sess_b,
+        &mut sess_c,
+        &mut sess_d,
+        &clock,
+        8,
+    );
+
+    // --- Phase 2: build the D-receipt gradient B(low=F) < C,A(high=M). Block
+    // D -> B so B's receipt of D freezes at the global-min `F`. Keep D -> A and
+    // D -> C (and C -> A) OPEN and advance a WIDE window so A's and C's receipt of
+    // D climb to `M`. While B still runs and gossips {connected, F}, every
+    // survivor folds B's low term, so confirmed_frame is PINNED at `F` (the
+    // barrier working) even as A's and C's *receipt* of D climbs to M. Crucially
+    // C keeps gossiping {connected, M} to A, so A's cached view of C's D term
+    // (`endpoint_C.peer_connect_status(D)`) reaches M. ---
+    blocked.block(d_addr, b_addr);
+    let climb = 14_u32;
+    for i in 0..climb {
+        poll_four(
+            &mut sess_a,
+            &mut sess_b,
+            &mut sess_c,
+            &mut sess_d,
+            &clock,
+            2,
+        );
+        try_advance_recording(&mut sess_a, &mut stub_a, h_a, 100 + i, &mut states_a)?;
+        try_advance_recording(&mut sess_b, &mut stub_b, h_b, 1100 + i, &mut states_b)?;
+        try_advance_recording(&mut sess_c, &mut stub_c, h_c, 2100 + i, &mut states_c)?;
+        try_advance_recording(&mut sess_d, &mut stub_d, h_d, 3100 + i, &mut sink)?;
+    }
+    poll_four(
+        &mut sess_a,
+        &mut sess_b,
+        &mut sess_c,
+        &mut sess_d,
+        &clock,
+        4,
+    );
+
+    // --- Phase 3: arm the DOUBLE FAILURE (all via explicit removals; no timeout).
+    //   (a) Block D -> C so C's receipt of D freezes at M (D keeps reaching A).
+    //   (b) Sever C -> A and A -> C while A's cached view of C's D term is still
+    //       the HIGH {connected, M}. A's LONG timeout keeps C's endpoint RUNNING
+    //       on A (a blocked link alone never prunes it), so A keeps folding C at M
+    //       — A never hears C lower its D view until we re-open the link.
+    //   (c) B `remove_player(D)`: B freezes D at F and gossips {disconnected, F}.
+    //       B -> C is OPEN, so C receives it and on first learning D disconnected
+    //       ADOPTS F (merge_peer_connect_status:1847) even though C's own receipt
+    //       is M -> C is now frozen at the global-min F, BELOW its own receipt.
+    //       B -> A is CUT first so A does NOT adopt F here (A's cached B view of D
+    //       freezes at its last {connected, F}).
+    //   (d) A `remove_player(B)`: B's endpoint on A goes terminal (non-running),
+    //       so it is PRUNED from A's D fold (`remote_slot_confirmed_bound` and
+    //       `update_player_disconnects` skip `!endpoint.is_running()`). B's low
+    //       view is now gone from A's fold; A's D bound = min(A receipt, C-cache)
+    //       = M. This is the "origin dies AFTER relaying to the third peer but
+    //       BEFORE delivering to us" leg.
+    // D stays reachable to A (D -> A open) so A keeps confirming D with REAL
+    // inputs. A NEVER removes D — it must learn the drop only via C's late relay. ---
+    blocked.block(d_addr, c_addr);
+    blocked.block(c_addr, a_addr);
+    blocked.block(a_addr, c_addr);
+    blocked.block(b_addr, a_addr);
+    blocked.block(a_addr, b_addr);
+
+    sess_b.remove_player(h_d).unwrap();
+    sess_a.remove_player(h_b).unwrap();
+
+    // --- Phase 4: A confirms/records D HIGH and DISCARDS past F. With B pruned and
+    // C frozen-high in A's fold, A advances and records frames above F using D's
+    // REAL (connected, then predicted-high) inputs — A does NOT yet know D dropped
+    // (`a_dropped_d_p4` stays false) — while its small window discards every frame
+    // below `current - max_prediction`. C, meanwhile, receives B's relayed
+    // {disconnected, F}, freezes D at F, and (with D mesh-excluded) advances PAST
+    // F recording frozen-at-F D values. C -> A is severed so C's lowered view
+    // cannot reach A yet. ---
+    let mut a_dropped_b = false;
+    let mut a_dropped_d_p4 = false;
+    let mut a_stall_error: Option<FortressError> = None;
+    for _ in 0..120 {
+        sess_a.poll_remote_clients();
+        sess_b.poll_remote_clients();
+        sess_c.poll_remote_clients();
+        clock.advance(POLL_INTERVAL_DETERMINISTIC);
+
+        match try_advance_recording(&mut sess_a, &mut stub_a, h_a, 500, &mut states_a) {
+            Ok(_) => {},
+            Err(e) => {
+                if a_stall_error.is_none() {
+                    a_stall_error = Some(e);
+                }
+            },
+        }
+        try_advance_recording(&mut sess_b, &mut stub_b, h_b, 1500, &mut states_b)?;
+        try_advance_recording(&mut sess_c, &mut stub_c, h_c, 2500, &mut states_c)?;
+
+        for e in sess_a.events() {
+            if let FortressEvent::PeerDropped { handle, .. } = e {
+                if handle == h_b {
+                    a_dropped_b = true;
+                }
+                if handle == h_d {
+                    a_dropped_d_p4 = true;
+                }
+            }
+        }
+    }
+
+    // --- Phase 5: the LATE RELAY. Re-open C -> A so C's {disconnected, F} finally
+    // reaches A AFTER A recorded + discarded past F. A's `update_player_disconnects`
+    // now folds C (running, reporting D disconnected at F) and lowers A's D term to
+    // F, arming a disconnect rollback to F+1. F+1 is BELOW A's window floor; the
+    // S20 out-of-window clamp (adjust_gamestate:7478, `frame_to_load.max(window_floor)`)
+    // keeps A LIVE (returns Ok, no stall) and re-simulates only the in-window
+    // frames with D frozen at F. The frames in `(F, floor]` were already discarded
+    // and KEEP A's real-input state, which no longer matches C's frozen-at-F state
+    // -> a permanent cross-survivor confirmed-state DIVERGENCE the relay cannot
+    // repair. ---
+    blocked.unblock(c_addr, a_addr);
+    blocked.unblock(a_addr, c_addr);
+
+    let mut a_dropped_d_p5 = false;
+    for _ in 0..160 {
+        sess_a.poll_remote_clients();
+        sess_c.poll_remote_clients();
+        clock.advance(POLL_INTERVAL_DETERMINISTIC);
+
+        match try_advance_recording(&mut sess_a, &mut stub_a, h_a, 700, &mut states_a) {
+            Ok(_) => {},
+            Err(e) => {
+                if a_stall_error.is_none() {
+                    a_stall_error = Some(e);
+                }
+            },
+        }
+        try_advance_recording(&mut sess_c, &mut stub_c, h_c, 2700, &mut states_c)?;
+
+        if sess_a
+            .events()
+            .any(|e| matches!(e, FortressEvent::PeerDropped { handle, .. } if handle == h_d))
+        {
+            a_dropped_d_p5 = true;
+        }
+    }
+
+    // A "learned D disconnected" if it emitted PeerDropped for D in either phase.
+    // The interesting (and documented) ordering is p4=false, p5=true: A confirmed
+    // past F BEFORE it knew D had dropped, then learned the low freeze via the relay.
+    let a_dropped_d = a_dropped_d_p4 || a_dropped_d_p5;
+
+    // --- Byte oracle (F4 pattern): over the shared confirmed range A vs C is the
+    // double-failure pair (A's D bound stayed high while B was pruned + C severed;
+    // C froze D at the relayed low F). ---
+    let confirmed_bound = sess_a
+        .confirmed_frame()
+        .as_i32()
+        .min(sess_c.confirmed_frame().as_i32());
+    let mut compared = 0_u32;
+    let mut divergences: Vec<(i32, &'static str, StateStub, StateStub)> = Vec::new();
+    for (&frame, &state_a) in &states_a {
+        if frame > confirmed_bound {
+            continue;
+        }
+        if let Some(&state_c) = states_c.get(&frame) {
+            compared += 1;
+            if state_a != state_c {
+                divergences.push((frame, "A!=C", state_a, state_c));
+            }
+        }
+    }
+
+    // PROBE (the decisive signature of THIS corner vs a plain input split): read
+    // D's confirmed INPUT (handle 3) on A vs C at sample in-window frames. The
+    // public contract (`confirmed_inputs_for_frame`) says these are identical
+    // across peers for any confirmed frame. They DO match here — both peers
+    // converged D's frozen input to the global-min `F` — yet the recorded game
+    // STATE for those same frames diverges, because A computed/recorded that state
+    // with D's REAL inputs BEFORE the freeze converged and the frames were already
+    // discarded (below the window floor) when the relay lowered the term. So the
+    // library's own input-based desync detector would see NO divergence while the
+    // actual confirmed STATE silently disagrees: the documented residual exactly.
+    //
+    // We sample frames in the QUERYABLE range at end of test (`confirmed_bound`
+    // climbs to ~167, and the input ring retains roughly the last
+    // `INPUT_QUEUE_LENGTH` == 128 confirmed frames). The EARLY diverging-onset
+    // frames (`F + 1` .. the early window) are by now FULLY DISCARDED from the
+    // input ring — `confirmed_inputs_for_frame` returns `Err`/`None` for them —
+    // which STRENGTHENS the detector-blind claim: the divergence lives in discarded
+    // history the input-checksum detector cannot inspect. So we filter to the frames
+    // that ARE queryable (both peers return `Ok`) and assert NON-VACUOUSLY that D's
+    // converged input matches across A and C on at least one genuine frame (a plain
+    // `None == None` on a discarded frame must not count as a match).
+    let mut input_probe: Vec<(i32, Option<u32>, Option<u32>)> = Vec::new();
+    let mut queryable_matches = 0_u32;
+    let mut queryable_mismatch = false;
+    for &pf in &[50_i32, 100, 150] {
+        if pf > confirmed_bound {
+            continue;
+        }
+        let da = sess_a
+            .confirmed_inputs_for_frame(Frame::new(pf))
+            .ok()
+            .and_then(|v| v.get(3).map(|i| i.inp));
+        let dc = sess_c
+            .confirmed_inputs_for_frame(Frame::new(pf))
+            .ok()
+            .and_then(|v| v.get(3).map(|i| i.inp));
+        // Only frames queryable on BOTH peers count toward the non-vacuous match
+        // (a discarded frame yields `None` on both and proves nothing).
+        if da.is_some() && dc.is_some() {
+            if da == dc {
+                queryable_matches += 1;
+            } else {
+                queryable_mismatch = true;
+            }
+        }
+        input_probe.push((pf, da, dc));
+    }
+
+    // Non-vacuity: the choreography must actually have exercised confirmed frames
+    // across survivors, or the arbitration proves nothing.
+    assert!(
+        compared > 0,
+        "no confirmed frames were compared across survivors (bound={confirmed_bound}); \
+         the double-failure-relay choreography did not produce overlapping confirmed history"
+    );
+
+    // A must have actually LEARNED D's disconnect (emitted PeerDropped for D),
+    // and via the LATE relay (p5), not before it confirmed past F (p4). Otherwise
+    // a divergence would be the trivial "A never converged the drop" rather than
+    // the documented "A converged the disconnect FLAG but the freeze frame relayed
+    // below A's already-discarded confirmed window, so the S20 clamp could not
+    // re-simulate the diverged frames".
+    assert!(
+        a_dropped_d_p5 && !a_dropped_d_p4,
+        "expected A to learn D's disconnect ONLY via the late relay (p4={a_dropped_d_p4}, \
+         p5={a_dropped_d_p5}); the documented double-failure ordering did not hold \
+         (bound={confirmed_bound}, a_dropped_b={a_dropped_b})"
+    );
+
+    // A must have stayed LIVE through the late relay: the documented mechanism is
+    // the S20 out-of-window CLAMP (Ok, no stall), not a hard error. A stall/error
+    // would be a different (more benign) failure mode.
+    assert!(
+        a_stall_error.is_none(),
+        "expected A to stay live via the S20 clamp, but advance_frame errored: \
+         {a_stall_error:?} (bound={confirmed_bound})"
+    );
+
+    // ARBITRATION VERDICT — pinned to the empirically-observed CURRENT-code
+    // behavior: the "double-failure relay" residual (documented as REAL, the
+    // genuine N>=4 residual, in `remote_slot_confirmed_bound`'s rustdoc) REPRODUCES
+    // in-process as a REAL, deterministic, cross-survivor CONFIRMED-STATE
+    // divergence. A confirmed and recorded frames above the global-min freeze `F`
+    // with D's real inputs while its only low-view sources were out of fold (origin
+    // B pruned, relay C severed); the late relay then lowered A's D term below A's
+    // already-discarded window, and the S20 clamp kept A live but could not repair
+    // the discarded frames. This is the N>=4 instance of the discard-before
+    // -convergence residual the S32 barrier narrowed but did not close. The queryable
+    // input probe above shows the insidious part: D's confirmed *inputs* converged
+    // across peers (so an input-checksum desync detector stays silent) while the
+    // recorded *state* diverged.
+    //
+    // This assertion CHARACTERIZES that reproduction: it PASSES while the corner
+    // remains open. If a future fix closes the residual (a stale-aware override
+    // fold, or full mesh-agreement-before-freeze convergence), `divergences` goes
+    // empty and this assertion flips — at which point convert this test into a
+    // positive convergence guard (assert `divergences.is_empty()`), mirroring the
+    // F4 `..._converges_across_survivors` test.
+    assert!(
+        !divergences.is_empty(),
+        "double-failure-relay did NOT reproduce: confirmed state converged across \
+         survivors (bound={confirmed_bound}, compared={compared}, a_dropped_d={a_dropped_d}, \
+         a_stall_error={a_stall_error:?}). If a fix landed, convert this to a positive \
+         convergence guard (assert divergences.is_empty())."
+    );
+
+    // And the decisive signature: D's confirmed INPUTS converged across A and C
+    // even though their recorded STATE diverged (input-based desync detection is
+    // blind to this residual). This must rest on GENUINELY-QUERYABLE frames — at
+    // least one frame queryable on both peers (else the "match" is a vacuous
+    // `None == None` on discarded history), and no queryable mismatch.
+    assert!(
+        queryable_matches > 0,
+        "input probe was vacuous: no sampled frame was queryable on BOTH A and C \
+         (all discarded from the input ring) — pick frames in the queryable window; \
+         got {input_probe:?} (bound={confirmed_bound})"
+    );
+    assert!(
+        !queryable_mismatch,
+        "expected D's confirmed inputs to MATCH across A and C on every queryable \
+         frame (the freeze frame converged) despite the state divergence; \
+         got {input_probe:?}"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
 // Regression (direct-detection path): `remove_player` under asymmetric loss
 // ============================================================================
 //
@@ -4383,9 +5068,12 @@ fn staggered_two_drops_opposite_order_survivors_converge_no_desync() -> Result<(
 // and the packet that delivers a third party's flip refreshes that party's
 // term before any fold runs), so the confirmed frame can never race past `F`:
 // nothing at/above `F` is lost and the throttle keeps the `F+1` rollback
-// target inside the window. At N>=4 the bound strictly NARROWS the race but
-// two corners remain open (the stale-echo freeze and the double-failure
-// relay) — documented as residuals in `remote_slot_confirmed_bound`.
+// target inside the window. At N>=4 the bound strictly NARROWS the race;
+// S41 arbitrated the two named corners (stale-echo freeze; double-failure
+// relay) red-test-first to ONE genuine residual — the double-failure relay
+// (stale-echo is NOTABUG: its low term's source endpoint stays in the fold,
+// so bound == override). See `remote_slot_confirmed_bound`'s
+// "# Documented residuals".
 //
 // Three orderings ("flavors") are pinned below. All FAIL before the barrier
 // (byte divergence at frames > F) and PASS after:

--- a/tests/sessions/peer_drop.rs
+++ b/tests/sessions/peer_drop.rs
@@ -2909,7 +2909,7 @@ fn p2p_n4_relay_clobber_dropped_slot_freeze_frame_converges_across_survivors(
 /// non-vacuity (some confirmed frames compared) and that the survivors' confirmed
 /// state did NOT diverge.
 #[test]
-fn p2p_n4_stale_echo_freeze_dropped_slot_diverges_across_survivors() -> Result<(), FortressError> {
+fn p2p_n4_stale_echo_freeze_dropped_slot_converges_across_survivors() -> Result<(), FortressError> {
     // Long symmetric timeouts: every drop here is driven by explicit
     // `remove_player` + gossip propagation, never by an auto-timeout (so a
     // blocked LINK never collapses an endpoint to non-running on its own and

--- a/tests/verification/z3.rs
+++ b/tests/verification/z3.rs
@@ -1209,10 +1209,14 @@ fn z3_proof_mesh_agreed_dropped_players_excluded_from_confirmed_min() {
 ///   party's `queue_connected` for the slot comes from the very endpoint
 ///   whose cached term the override would min, and the connect-status merge
 ///   refreshes that term BEFORE any fold runs.
-/// - **The `N >= 4` residuals.** The stale-echo freeze (a third survivor
-///   converging on its stale cache of OUR old, lower claim) and the
-///   double-failure relay corner are out-of-model and remain open; they are
-///   documented as residuals in `remote_slot_confirmed_bound`'s rustdoc.
+/// - **The `N >= 4` residual.** This same-instant subset-min lemma is exactly
+///   the intra-snapshot invariant by which Session 41 arbitrated the
+///   stale-echo freeze **NOTABUG** (the low term's source endpoint stays in
+///   the fold, so bound == override at every instant). The one genuine
+///   residual — the double-failure relay — needs fold-membership asymmetry
+///   (the origin survivor leaves the fold before its relayed low value lands)
+///   and is out-of-model here; it is documented as a residual in
+///   `remote_slot_confirmed_bound`'s rustdoc.
 #[test]
 fn z3_proof_confirmed_bound_below_same_instant_subset_overrides() {
     /// Asserts, on a fresh solver, that `min(terms)` (the bound) cannot


### PR DESCRIPTION
## Description

This branch hardens peer-controlled decode paths and improves multi-peer rollback diagnostics.
It adds a per-peer checksum mismatch counter for `P2PSession`, emits a one-time advisory warning when a peer shows persistent checksum divergence, and keeps that signal advisory rather than auto-ejecting a peer.

It also makes hot-join snapshot decoding reject deeply nested recursive state payloads with a recoverable error instead of risking a stack overflow, while keeping the existing bounded-allocation protections.

Beyond the runtime changes, this branch expands N>=3/N>=4 chaos and peer-drop coverage and adds a new `DoubleFailureRelay` TLA+ spec plus documentation that formalize the remaining multi-peer freeze-barrier residual. That spec work proves the mesh-acked-floor fix design and documents why cheaper cache-only alternatives are unsound; it does not ship that protocol change yet.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation (changes to documentation only)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [x] 🔧 CI/Build (changes to CI configuration or build process)

## Checklist

<!-- Please review and check all applicable items -->

### Required

- [ ] I have read the [CONTRIBUTING guide](../docs/contributing.md)
- [ ] I have followed the **zero-panic policy**:
  - No `unwrap()` in production code
  - No `expect()` in production code
  - No `panic!()` or `todo!()`
  - All fallible operations return `Result`
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have run `cargo fmt && cargo clippy --workspace --all-targets --features tokio,json` with no warnings
- [ ] I have run `cargo nextest run` and all tests pass

### If Applicable

- [x] I have updated the documentation accordingly
- [x] I have added an entry to `CHANGELOG.md` for user-facing changes
- [ ] I have updated relevant examples in the `examples/` directory
- [ ] My changes generate no new compiler warnings

## Testing

**Tests added/modified:**

- Added bounded-recursion decode coverage for hot-join snapshot decoding.
- Expanded in-process chaos coverage for N>=3 multi-peer topologies.
- Added/expanded peer-drop regressions for checksum-mismatch persistence and the N=4 double-failure relay scenario.
- Added `DoubleFailureRelay` to the TLA+ verification suite and refreshed the verification docs.

**Manual testing performed:**

- None documented in this PR draft.

## Related Issues

- None referenced.

---

<!-- Thank you for contributing to Fortress Rollback! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches P2P desync/checksum behavior, peer-controlled hot-join deserialization, and formalizes a deferred multi-peer freeze-barrier fix—runtime changes affect session safety paths and hostile-input handling.
> 
> **Overview**
> **P2P diagnostics:** Tracks per-remote **checksum mismatch counts** on confirmed frames, exposes them via **`P2PSession::peer_checksum_mismatch_count`**, and logs a **one-time advisory WARNING** when a peer crosses an internal threshold—**no auto-eject**; apps choose policy from the raw count. Changelog/docs clarify **`SyncHealth::DesyncDetected`** handling.
> 
> **Hot-join decode hardening:** **`codec::decode_bounded`** for **`Config::State`** now uses a new **`codec_depth`** serde wrapper so peer snapshots nested past **`MAX_DECODE_DEPTH`** fail with **`Err`** instead of risking stack overflow, while keeping the existing byte cap; input decode stays on the fast path.
> 
> **Zero-panic / lint:** **`#![cfg_attr(not(test))]`** denies panic-prone clippy lints on library **`src/`**; **`rle`** and protocol paths replace slicing with **`get`**-based access.
> 
> **Formal methods:** Adds **`DoubleFailureRelay.tla`** (Baseline / Tombstone / MeshAgree / InheritedFloor configs), registers the passing **MeshAgree** model in **`verify-tla.sh`**, and documents why cheaper cache-only fixes are unsound—the **mesh-acked-floor** protocol change is **spec-only**, not implemented in production.
> 
> **CI & docs quality:** Workflow **`run`** steps that pipe to **`tee`** use **`set -o pipefail`**; **`check-rust-semantic-claims.py`** is wired through **`check-doc-claims.sh`**, **agent preflight**, and **ci-docs** path filters, with pytest coverage for semantic claims and tee pipelines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cccba67525283bb192581f249aa81244e680afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->