### PR TITLE
bugfix: Stability in 3+ Player Sessions + Docs Overhaul

### DIFF
--- a/.llm/skills/rust-language/concurrency.md
+++ b/.llm/skills/rust-language/concurrency.md
@@ -30,6 +30,7 @@ Is data accessed from multiple threads?
 ## Key Patterns
 
 ### Mutex -- Minimize Hold Time
+
 ```rust
 // Use parking_lot::Mutex -- no poisoning, so .lock() returns the guard directly
 let value = {
@@ -40,6 +41,7 @@ expensive_operation(); // other threads can proceed
 ```
 
 ### RwLock -- Drop Read Before Write
+
 ```rust
 // Use parking_lot::RwLock -- no poisoning, no .unwrap() needed
 let needs_write = {
@@ -53,6 +55,7 @@ if needs_write {
 ```
 
 ### Atomic State Machine
+
 ```rust
 fn try_connect(&self) -> bool {
     self.state.compare_exchange(
@@ -63,6 +66,7 @@ fn try_connect(&self) -> bool {
 ```
 
 ### Message Passing
+
 ```rust
 enum Command { Process(Data), Shutdown }
 fn worker(rx: mpsc::Receiver<Command>) {
@@ -74,6 +78,16 @@ fn worker(rx: mpsc::Receiver<Command>) {
     }
 }
 ```
+
+### Same-Thread RAII Guards
+
+If a `Drop` guard mutates thread-local state, make it explicitly `!Send` and `!Sync`
+with a private `PhantomData<Rc<()>>` marker. Add `compile_fail` doctests that try
+to move and borrow the guard across threads so the thread-affinity contract is
+checked by doctest CI. If removing owned resources from a `RefCell`-backed
+thread-local stack, return the removed value and drop it after releasing the
+borrow so destructors can safely re-enter telemetry/logging. In guard `Drop`,
+use `LocalKey::try_with` rather than `with` so TLS teardown cannot panic.
 
 ## Memory Ordering
 

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -59,7 +59,7 @@ exclude = [
     "^https://github\\.com/wallstop/fortress-rollback/releases/tag/v",
     "^https://github\\.com/wallstop/fortress-rollback/issues/new\\?.*template=",
     # Shell-script examples interpolate this at runtime; the literal URL is intentionally invalid.
-    "^https://github\\.com/tlaplus/tlaplus/releases/download/v(\\$\\{|%24%7B)TLA_TOOLS_VERSION(\\}|%7D)/tla2tools\\.jar$",
+    "^https://github\\.com/tlaplus/tlaplus/releases/download/v(\\$|%24)(\\{|%7[Bb])TLA_TOOLS_VERSION(\\}|%7[Dd])/tla2tools\\.jar$",
 
     # Rate-limited sites
     "^https://twitter\\.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `push_violation_observer(observer)` installs `observer` as the current thread's violation observer for as
   long as the returned guard lives; while installed, the `report_violation!` macro routes to it (installs
   nest; the innermost wins; the guard restores the previous observer on drop). This is the mechanism that
-  makes `with_violation_observer` work for `P2PSession`/`SyncTestSession` (see *Fixed*), and is also usable
+  makes `with_violation_observer` work for `P2PSession`/`SyncTestSession`/`SpectatorSession` (see *Fixed*), and is also usable
   directly to scope violation routing around arbitrary code. `report_to_current_observer` is the macro's
   dispatch target (it falls back to the `tracing` observer when none is installed).
 - **`P2PSession::peer_checksum_mismatch_count(handle)` and an advisory per-peer checksum trust-downgrade
@@ -101,17 +101,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Pre-existing:** `SessionBuilder::with_violation_observer` now works for `P2PSession` and
-  `SyncTestSession`, not only `SpectatorSession`. Previously those two session types emitted every
-  specification violation through the global `tracing`-backed observer only, so a `ViolationObserver`
-  (e.g. `CollectingObserver`) attached via `with_violation_observer` never received them — the released
-  API promise was silently false for the two most common session types. Each session now installs its
+- **Pre-existing:** `SessionBuilder::with_violation_observer` now routes specification violations to the
+  configured observer for **every** session type — `P2PSession`, `SyncTestSession`, and `SpectatorSession`.
+  Previously `P2PSession` and `SyncTestSession` emitted every specification violation through the global
+  `tracing`-backed observer only, so a `ViolationObserver` (e.g. `CollectingObserver`) attached via
+  `with_violation_observer` never received them — the released API promise was silently false for the two
+  most common session types. `SpectatorSession` already routed the violations raised on its direct paths,
+  but a residual set of `report_violation!` sites (the `frames_behind_host`, `inputs_at_frame`, and
+  host-input validation guards) bypassed the per-session observer too. Each session now installs its
   configured observer as a thread-local scope for the duration of every public, state-driving entry point
-  (`advance_frame`, `poll_remote_clients`, `add_local_input`, `disconnect_player`, `remove_player`,
-  `set_input_delay`) and during construction, so all `report_violation!` calls beneath — including those
-  raised by the low-level input-queue, sync-layer, and protocol components — route to the per-session
-  observer. When no observer is configured, violations fall back to the `tracing` observer exactly as
-  before, so there is no behavior change for sessions that do not opt in.
+  and during construction (`P2PSession`: `advance_frame`, `poll_remote_clients`, `add_local_input`,
+  `disconnect_player`, `remove_player`, `set_input_delay`; `SpectatorSession`: `advance_frame`,
+  `poll_remote_clients`, `seek_to_frame`, `frames_behind_host`), so all `report_violation!` calls beneath —
+  including those raised by the low-level input-queue, sync-layer, and protocol components — route to the
+  per-session observer. When no observer is configured, violations fall back to the `tracing` observer
+  exactly as before, so there is no behavior change for sessions that do not opt in.
 - **Pre-existing:** A prediction episode in the input queue now always begins at the queue's **first
   missing frame** rather than at the frame the simulation happened to request. Previously, a rollback re-simulation
   whose first input request landed **above** a remote queue's missing window — ordinary cross-endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`telemetry::push_violation_observer` / `telemetry::ScopedObserverGuard` /
+  `telemetry::report_to_current_observer` — a thread-local *scoped* violation-observer primitive.**
+  `push_violation_observer(observer)` installs `observer` as the current thread's violation observer for as
+  long as the returned guard lives; while installed, the `report_violation!` macro routes to it (installs
+  nest; the innermost wins; the guard restores the previous observer on drop). This is the mechanism that
+  makes `with_violation_observer` work for `P2PSession`/`SyncTestSession` (see *Fixed*), and is also usable
+  directly to scope violation routing around arbitrary code. `report_to_current_observer` is the macro's
+  dispatch target (it falls back to the `tracing` observer when none is installed).
 - **`P2PSession::peer_checksum_mismatch_count(handle)` and an advisory per-peer checksum trust-downgrade
   signal (Byzantine-peer hardening).** With desync detection enabled, the session now tracks, per remote
   peer, how many confirmed-frame checksums failed to match the local history, exposes that count via the
@@ -93,6 +101,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pre-existing:** `SessionBuilder::with_violation_observer` now works for `P2PSession` and
+  `SyncTestSession`, not only `SpectatorSession`. Previously those two session types emitted every
+  specification violation through the global `tracing`-backed observer only, so a `ViolationObserver`
+  (e.g. `CollectingObserver`) attached via `with_violation_observer` never received them — the released
+  API promise was silently false for the two most common session types. Each session now installs its
+  configured observer as a thread-local scope for the duration of every public, state-driving entry point
+  (`advance_frame`, `poll_remote_clients`, `add_local_input`, `disconnect_player`, `remove_player`,
+  `set_input_delay`) and during construction, so all `report_violation!` calls beneath — including those
+  raised by the low-level input-queue, sync-layer, and protocol components — route to the per-session
+  observer. When no observer is configured, violations fall back to the `tracing` observer exactly as
+  before, so there is no behavior change for sessions that do not opt in.
 - **Pre-existing:** A prediction episode in the input queue now always begins at the queue's **first
   missing frame** rather than at the frame the simulation happened to request. Previously, a rollback re-simulation
   whose first input request landed **above** a remote queue's missing window — ordinary cross-endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`telemetry::push_violation_observer` / `telemetry::ScopedObserverGuard` /
   `telemetry::report_to_current_observer` — a thread-local *scoped* violation-observer primitive.**
-  `push_violation_observer(observer)` installs `observer` as the current thread's violation observer for as
+  `push_violation_observer(observer)` installs `observer` as the current thread's violation observer as
   long as the returned guard lives; while installed, the `report_violation!` macro routes to it (installs
-  nest; the innermost wins; the guard restores the previous observer on drop). This is the mechanism that
+  nest; the innermost wins; the guard removes its own observer on drop, restoring the previous observer
+  for normal LIFO scopes). This is the mechanism that
   makes `with_violation_observer` work for `P2PSession`/`SyncTestSession`/`SpectatorSession` (see *Fixed*), and is also usable
   directly to scope violation routing around arbitrary code. `report_to_current_observer` is the macro's
   dispatch target (it falls back to the `tracing` observer when none is installed).

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Fortress Rollback includes interactive game examples built with [macroquad](http
 
 ```shell
 # P2P session (run in two terminals with different ports)
-cargo run --example ex_game_p2p --features graphical-examples -- --local-port 7000 --remote-addr 127.0.0.1:7001
-cargo run --example ex_game_p2p --features graphical-examples -- --local-port 7001 --remote-addr 127.0.0.1:7000
+cargo run --example ex_game_p2p --features graphical-examples -- --local-port 7000 --players localhost 127.0.0.1:7001
+cargo run --example ex_game_p2p --features graphical-examples -- --local-port 7001 --players 127.0.0.1:7000 localhost
 
 # Sync test (determinism verification)
-cargo run --example ex_game_synctest --features graphical-examples
+cargo run --example ex_game_synctest --features graphical-examples -- --num-players 2 --check-distance 7
 ```
 
 See the [examples README](./examples/README.md) for system dependencies and more options.
@@ -118,6 +118,7 @@ For detailed configuration guidance, see the [User Guide](./docs/user-guide.md#n
 | Feature | Description |
 |---------|-------------|
 | `sync-send` | Adds `Send + Sync` bounds for multi-threaded game engines (e.g., Bevy) |
+| `hot-join` | Allows a peer to join/rejoin a running session by filling a reserved or gracefully-dropped slot via a state snapshot (requires `Config::State: Serialize + DeserializeOwned`; player count stays fixed) |
 | `tokio` | Enables `TokioUdpSocket` for async Tokio applications |
 | `paranoid` | Runtime invariant checking in release builds |
 | `graphical-examples` | Enables ex_game graphical examples (requires macroquad deps) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,6 +134,8 @@ pub enum PlayerType<A> {
 pub enum SessionState {
     Synchronizing, // Establishing connection with remotes
     Running,       // Synchronized and accepting input
+    #[cfg(feature = "hot-join")]
+    HotJoining,    // Applying a state snapshot to (re)join a running session
 }
 ```
 
@@ -638,7 +640,7 @@ Before dropping a session, verify:
 
 **Important:** There are two distinct state types in Fortress Rollback:
 
-- **`SessionState`** (2 states): The high-level session state visible to users
+- **`SessionState`** (2 states by default; a third `HotJoining` state exists with the `hot-join` feature): The high-level session state visible to users
   - `Synchronizing` — Establishing connection with remotes
   - `Running` — Synchronized and accepting input
 
@@ -742,6 +744,9 @@ graph TD
     QUALITY["QualityReport<br/>(Frame advantage)"]
     QREPLY["QualityReply<br/>(Response to report)"]
     CHECKSUM["ChecksumReport<br/>(Desync detection)"]
+    FLOORREQ["FloorRequest<br/>(N&ge;4 relay floor round)"]
+    FLOORREP["FloorReply<br/>(Per-slot pessimistic floors)"]
+    KEEPALIVE["KeepAlive<br/>(Idle connection upkeep)"]
 
     MSG --> HEADER
     MSG --> BODY
@@ -751,7 +756,12 @@ graph TD
     BODY --> QUALITY
     BODY --> QREPLY
     BODY --> CHECKSUM
+    BODY --> FLOORREQ
+    BODY --> FLOORREP
+    BODY --> KEEPALIVE
 ```
+
+Hot-join builds (the `hot-join` feature) additionally carry join-lifecycle bodies (`JoinRequest`, `StateSnapshot`, `StateSnapshotAck`, `ReactivateSlot`, `ReactivateSlotAck`, `JoinCommitted`, `JoinAborted`).
 
 ### Time Synchronization
 
@@ -863,6 +873,7 @@ use fortress_rollback::Frame;
 pub struct ConnectionStatus {
     pub disconnected: bool,  // Is the player disconnected?
     pub last_frame: Frame,   // Last frame we received input for
+    pub epoch: u16,          // Per-slot generation; bumped on each connect<->disconnect transition
 }
 ```
 
@@ -982,8 +993,8 @@ The protocol is UDP-based (unreliable) but handles:
 
 Regular packets maintain connection:
 
-- `running_retry_interval` (configurable, default 200ms): interval for resending inputs and quality reports
-- `QualityReport` sent every `running_retry_interval`
+- `running_retry_interval` (configurable, default 200ms): interval for resending unacknowledged inputs
+- `QualityReport` sent every `quality_report_interval` (configurable, default 200ms)
 - Disconnect after `disconnect_timeout` (configurable, default 2000ms)
 
 ---

--- a/docs/fortress-vs-ggrs.md
+++ b/docs/fortress-vs-ggrs.md
@@ -116,7 +116,7 @@ InvalidFrame { frame: Frame(0), reason: "must load frame in the past" }
 **Fix:**
 
 - Created new `fortress_rollback::hash` module with FNV-1a deterministic hashing
-- Window-based checksum computation using last 64 frames ensures frames are always available for both peers
+- Checksums are tracked per frame in a bounded history (`max_checksum_history`, default 32) and compared at the desync-detection interval (default `interval: 60`), so the compared frame is available on both peers
 
 ---
 
@@ -133,7 +133,7 @@ InvalidFrame { frame: Frame(0), reason: "must load frame in the past" }
 ```rust
 // Explicit spectator validation
 impl PlayerHandle {
-    pub fn is_spectator_for(&self, num_players: usize) -> bool {
+    pub const fn is_spectator_for(self, num_players: usize) -> bool {
         self.0 >= num_players
     }
 }
@@ -280,13 +280,15 @@ let range_value: u32 = rng.gen_range(1..100);
 
 ```rust
 use fortress_rollback::hash::{fnv1a_hash, DeterministicHasher};
+use std::hash::Hasher; // brings write()/finish() into scope
 
 // Hash any hashable data deterministically
 let checksum = fnv1a_hash(&game_state);
 
 // Or use the hasher directly
+let data: &[u8] = b"some bytes";
 let mut hasher = DeterministicHasher::new();
-hasher.write(&data);
+hasher.write(data);
 let hash = hasher.finish();
 ```
 
@@ -470,9 +472,9 @@ ChaosConfig::intercontinental() // High-latency stable connection
 
 ### Formal Verification
 
-- **7 TLA+ specifications** covering core protocols (Rollback, InputQueue, NetworkProtocol, TimeSync, ChecksumExchange, SpectatorSession, Concurrency)
-- **115 Kani proofs** for bounded model checking
-- **54 Z3 SMT proofs** for algorithmic correctness
+- **15 TLA+ specifications** covering core protocols (Rollback, InputQueue, NetworkProtocol, TimeSync, ChecksumExchange, SpectatorSession, Concurrency) as well as N-peer/freeze/failover protocols (DoubleFailureRelay, FrameAdvantageAggregation, FreezeConvergence, NPeerReactivation, NPeerServeFreezeConvergence, PeerDrop, SpectatorFailover, SpectatorReactivationEpoch)
+- **130 Kani proofs** for bounded model checking
+- **65 Z3 SMT proofs** for algorithmic correctness
 
 ### Testing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -183,7 +183,7 @@ Get up and running with Fortress Rollback in minutes.
 
     - :material-shield-check: All `panic!` and `assert!` converted to recoverable errors
     - :material-sort-variant: Deterministic `BTreeMap`/`BTreeSet` instead of `HashMap`/`HashSet`
-    - :material-test-tube: ~1600 tests with ~92% code coverage
+    - :material-test-tube: ~2200 tests with ~92% code coverage
     - :material-file-certificate: TLA+, Z3, and Kani formal verification
 
     [:octicons-arrow-right-24: Full comparison](fortress-vs-ggrs.md)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -14,7 +14,7 @@ Fortress Rollback is the correctness-first, verified fork of the original `ggrs`
 - Ensure your `Config::Address` type implements `Ord` + `PartialOrd` (in addition to `Clone + Eq + Hash`).
 - Rename types: `GgrsError` → `FortressError`, `GgrsEvent` → `FortressEvent`, `GgrsRequest` → `FortressRequest`.
 - All examples/tests now import `fortress_rollback`; mirror that pattern in your code.
-- **New in Unreleased:** runtime input-delay adjustment (`set_input_delay`/`input_delay`), opt-in graceful peer drop (`DisconnectBehavior::ContinueWithout`, `with_disconnect_behavior`), explicit graceful removal (`remove_player`), and fail-closed redundant spectator divergence; exhaustive matches on `FortressEvent`, `FortressError`, `InvalidRequestKind`, and `InternalErrorKind` need new arms — see [Unreleased section](#unreleased-runtime-input-delay-disconnect-behavior-graceful-peer-removal-and-spectator-divergence).
+- **New in Unreleased:** runtime input-delay adjustment (`set_input_delay`/`input_delay`), opt-in graceful peer drop (`DisconnectBehavior::ContinueWithout`, `with_disconnect_behavior`), explicit graceful removal (`remove_player`), and fail-closed redundant spectator divergence; exhaustive matches on `FortressEvent`, `FortressError`, `InvalidRequestKind`, `InternalErrorKind`, `SerializationErrorKind`, `RleDecodeReason`, and `DeltaDecodeReason` need new arms — see [Unreleased section](#unreleased-runtime-input-delay-disconnect-behavior-graceful-peer-removal-and-spectator-divergence).
 
 ## Dependency Changes
 
@@ -194,6 +194,8 @@ The `sync-send` feature flag remains compatible. Fortress Rollback adds several 
 | `loom`               | Concurrency testing                    | ✅               |
 | `z3-verification`    | Formal verification tests              | ✅               |
 | `graphical-examples` | Interactive demos                      | ✅               |
+| `hot-join`           | Peers can join/rejoin a running session via a state snapshot (requires `Config::State: Serialize + DeserializeOwned`) | ✅               |
+| `z3-verification-bundled` | `z3-verification` with a bundled Z3 build (no system Z3 needed) | ✅               |
 
 > **Note:** The `json` feature enables `to_json()` and `to_json_pretty()` methods on telemetry types.
 > Without this feature, the `serde_json` dependency is not included, reducing the default dependency count.

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -209,7 +209,7 @@ while !session.is_complete() {
 | `num_players` | Number of players in the recorded match |
 | `frames` | `Vec<Vec<I>>` -- inputs per frame, one entry per player |
 | `checksums` | `Vec<Option<u128>>` -- per-frame checksums for validation |
-| `metadata` | `ReplayMetadata` -- version, player count, frame count |
+| `metadata` | `ReplayMetadata` -- library version, player count, total frame count, and skipped-frame count |
 | `to_bytes()` | Serialize to bytes (deterministic bincode codec) |
 | `from_bytes(&[u8])` | Deserialize from bytes and validate the result |
 | `from_bytes_with_config(&[u8], ReplayDecodeConfig)` | Deserialize with a caller-defined byte limit or validation setting |

--- a/docs/specs/api-contracts.md
+++ b/docs/specs/api-contracts.md
@@ -107,9 +107,9 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidRequest("Player handle already in use")` - handle duplicate
-- `InvalidRequest("...handle should be between 0 and num_players")` - invalid player handle
-- `InvalidRequest("...handle should be num_players or higher")` - invalid spectator handle
+- `InvalidRequestStructured { kind: PlayerHandleInUse { handle } }` - handle duplicate
+- `InvalidRequestStructured { kind: InvalidLocalPlayerHandle { handle, num_players } }` / `InvalidRequestStructured { kind: InvalidRemotePlayerHandle { handle, num_players } }` - invalid Local/Remote handle (`handle.0 >= num_players`)
+- `InvalidRequestStructured { kind: InvalidSpectatorHandle { handle, num_players } }` - invalid spectator handle (`handle.0 < num_players`)
 
 **Panics:** Never
 
@@ -164,7 +164,7 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidRequest("FPS should be higher than 0")` - if `fps = 0`
+- `InvalidRequestStructured { kind: ZeroFps }` - if `fps = 0`
 
 **Panics:** Never
 
@@ -246,7 +246,7 @@ Each API is documented with:
 
 ---
 
-### `start_p2p_session(self, socket: impl NonBlockingSocket<T::Address>) -> Result<P2PSession<T>, FortressError>`
+### `start_p2p_session(self, socket: impl NonBlockingSocket<T::Address> + 'static) -> Result<P2PSession<T>, FortressError>`
 
 ```rust
 /// Consume builder and create a P2P session.
@@ -265,7 +265,7 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidRequest("Not enough players have been added...")` - missing players
+- `InvalidRequestStructured { kind: NotEnoughPlayers { expected, actual } }` - not all player handles `0..num_players` have been registered
 
 **Panics:** Never
 
@@ -277,7 +277,7 @@ Each API is documented with:
 
 ---
 
-### `start_spectator_session(self, host_addr: T::Address, socket: impl NonBlockingSocket<T::Address>) -> Option<SpectatorSession<T>>`
+### `start_spectator_session(self, host_addr: T::Address, socket: impl NonBlockingSocket<T::Address> + 'static) -> Option<SpectatorSession<T>>`
 
 ```rust
 /// Create a spectator session connected to a host.
@@ -321,7 +321,7 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidRequest("Check distance too big")` - if `check_distance >= max_prediction`
+- `InvalidRequestStructured { kind: CheckDistanceTooLarge { check_dist, max_prediction } }` - if `check_distance >= max_prediction`
 
 **Panics:** Never
 
@@ -406,8 +406,7 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidPlayerHandle` - handle not registered or not local
-- `InvalidRequest("Prediction threshold reached")` - too far ahead
+- `InvalidRequestStructured { kind: NotLocalPlayer { handle } }` - handle is not a registered local player
 
 **Panics:** Never
 
@@ -504,13 +503,13 @@ Each API is documented with:
 /// Get network statistics for a remote player.
 ```
 
-**Pre:** `handle` is a remote player
+**Pre:** `handle` is a remote player or spectator
 
 **Post:** Returns stats (ping, bandwidth, etc.)
 
 **Errors:**
 
-- `InvalidPlayerHandle` - not a remote player
+- `InvalidRequestStructured { kind: NotRemotePlayerOrSpectator { handle } }` - handle is neither a remote player nor a spectator
 - `NotSynchronized` - stats not yet available
 
 **Panics:** Never
@@ -571,7 +570,7 @@ Each API is documented with:
 - `InvalidRequestStructured { kind: DisconnectInvalidHandle { handle } }` - handle not registered, or refers to a spectator
 - `InvalidRequestStructured { kind: DisconnectLocalPlayer { handle } }` - handle refers to a local player
 - `InvalidRequestStructured { kind: PlayerAlreadyRemoved { handle } }` - handle is already marked disconnected (either via a prior `remove_player` call, via auto-removal under `DisconnectBehavior::ContinueWithout`, or via a previous explicit `disconnect_player` call)
-- `InternalErrorStructured { kind: DisconnectStatusNotFound { handle } | IndexOutOfBounds { .. } }` - internal-invariant violation (a registered handle has no corresponding input queue or connection-status entry); should not occur in correct code, treat as a library bug
+- `InternalErrorStructured { kind: DisconnectStatusNotFound { handle } | IndexOutOfBounds(..) }` - internal-invariant violation (a registered handle has no corresponding input queue or connection-status entry); should not occur in correct code, treat as a library bug
 
 **Panics:** Never
 
@@ -717,7 +716,8 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidRequest` on checksum mismatch (desync detected)
+- `MismatchedChecksum { current_frame, mismatched_frames }` on checksum mismatch (desync detected during resimulation)
+- `InvalidRequestStructured { kind: MissingLocalInput }` - not all players provided input
 
 **Panics:** Never
 

--- a/docs/specs/determinism-model.md
+++ b/docs/specs/determinism-model.md
@@ -131,7 +131,7 @@ fn spawn_enemy(state: &mut GameState, rng: &mut SeededRng) {
 
 **Implementation:**
 
-- ✅ `bincode` with default configuration (little-endian, fixed-size integers)
+- ✅ `bincode` configured with `standard().with_little_endian().with_fixed_int_encoding()` (fixed-size integers are an explicit override of bincode's variable-int default, ensuring identical serialized bytes across platforms)
 - ✅ Input types require `Serialize + Deserialize`
 - ✅ No platform-specific serialization
 
@@ -154,7 +154,7 @@ pub trait Config: 'static {
 
 - ✅ `#![forbid(unsafe_code)]` prevents uninitialized memory access
 - ✅ All arrays initialized with default values
-- ✅ Input queues initialized with `BLANK_INPUT`
+- ✅ Input queues initialized with blank inputs via `PlayerInput::blank_input(Frame::NULL)`
 
 ### DETER-6: Integer Arithmetic Consistency
 

--- a/docs/specs/formal-spec.md
+++ b/docs/specs/formal-spec.md
@@ -116,7 +116,10 @@ InputStatus = Confirmed | Predicted | Disconnected
 ```
 ConnectionStatus = {
     disconnected: Bool,
-    last_frame: Frame
+    last_frame: Frame,
+    epoch: ℕ            -- u16 monotonic per-slot generation, bumped on each
+                       -- connected<->disconnected transition; rides the
+                       -- connect-status gossip on every Input packet
 }
 ```
 
@@ -197,11 +200,11 @@ less than the current frame. When `first_incorrect_frame >= current_frame`,
 This invariant captures the guard in `adjust_gamestate()`:
 
 ```rust
-if frame_to_load >= current_frame {
+if load_target >= current_frame {
     // skip_rollback path
     return Ok(());
 }
-// Only reach load_frame if frame_to_load < current_frame
+// Only reach load_frame if load_target < current_frame
 ```
 
 ### INV-9a: Message Causality
@@ -304,7 +307,7 @@ POST:
     RETURNS Ok(inputs[frame mod 128])
 
 ERROR:
-    frame > last_added_frame → MissingInput
+    frame mismatch (no confirmed input at slot) → NoConfirmedInput (FortressError::InvalidRequestStructured)
 ```
 
 #### reset_prediction()
@@ -357,7 +360,7 @@ POST:
     RETURNS input_queues[handle].add_input(input)
 ```
 
-#### synchronized_inputs(connect_status) → Vec&lt;(Input, InputStatus)&gt;
+#### synchronized_inputs(connect_status) → Option&lt;Vec&lt;(Input, InputStatus)&gt;&gt;
 
 ```
 POST:
@@ -400,8 +403,8 @@ POST:
     RETURNS Ok(LoadGameState { frame, cell })
 
 ERROR:
-    frame = NULL_FRAME → InvalidFrame("cannot load NULL_FRAME")
-    frame >= current_frame → InvalidFrame("must load frame in the past")
+    frame = NULL_FRAME → InvalidFrameStructured(NullFrame)        -- "cannot load NULL_FRAME"
+    frame >= current_frame → InvalidFrameStructured(NotInPast)    -- "must load frame in the past (current: …)"
 ```
 
 #### skip_rollback()
@@ -426,7 +429,8 @@ COMMENT:
         first_incorrect_frame = 0, current_frame = 0
 
     Production code (p2p_session.rs, adjust_gamestate):
-        if frame_to_load >= current_frame {
+        let load_target = frame_to_load.max(window_floor); // clamp UP to prediction-window floor
+        if load_target >= current_frame {
             self.sync_layer.reset_prediction();
             return Ok(());  // Skip rollback
         }
@@ -498,6 +502,17 @@ MessageBody =
     | QualityReport { frame_advantage: i16, ping: u128 }
     | QualityReply { pong: u128 }
     | ChecksumReport { checksum: u128, frame: Frame }
+    | KeepAlive
+    | FloorRequest { round_seq: u32 }                    -- floor-round protocol (N>=4 double-failure-relay convergence)
+    | FloorReply { round_seq: u32, floors: Vec<Frame> }  -- relay's per-slot pessimistic floors
+    -- The following are only present with cfg(feature = "hot-join"):
+    | JoinRequest { player_handle: usize }
+    | StateSnapshot { ... }
+    | StateSnapshotAck { ... }
+    | ReactivateSlot { ... }
+    | ReactivateSlotAck { ... }
+    | JoinCommitted { ... }
+    | JoinAborted { frame: Frame }
 ```
 
 ---
@@ -639,8 +654,8 @@ MessageBody =
 | Protocol state machine        | TLA+ | ✅ Implemented (`specs/tla/NetworkProtocol.tla`)  |
 | LIVE-1 (sync convergence)     | TLA+ | ✅ Implemented (`specs/tla/NetworkProtocol.tla`)  |
 | SAFE-4 (rollback consistency) | TLA+ | ✅ Implemented (`specs/tla/Rollback.tla`)         |
-| Frame arithmetic              | Z3   | ✅ Implemented (`tests/test_z3_verification.rs`)  |
-| Queue index math              | Z3   | ✅ Implemented (`tests/test_z3_verification.rs`)  |
+| Frame arithmetic              | Z3   | ✅ Implemented (`tests/verification/z3.rs`)       |
+| Queue index math              | Z3   | ✅ Implemented (`tests/verification/z3.rs`)       |
 | Concurrency (GameStateCell)   | Loom | ✅ Implemented (`loom-tests/`)                    |
 | Time synchronization          | TLA+ | ✅ Implemented (`specs/tla/TimeSync.tla`)         |
 | Checksum exchange             | TLA+ | ✅ Implemented (`specs/tla/ChecksumExchange.tla`) |

--- a/docs/specs/spec-divergences.md
+++ b/docs/specs/spec-divergences.md
@@ -32,9 +32,9 @@ This document lists intentional divergences between formal specifications and pr
 
 | Constant             | Kani Value | Production Value | Justification                                                                                                                                        |
 | -------------------- | ---------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `INPUT_QUEUE_LENGTH` | 8          | 128              | Kani's symbolic execution is exponential in array size. 8 elements is sufficient to prove circular buffer invariants (wrap-around, bounds checking). |
+| `INPUT_QUEUE_LENGTH` | 7          | 128              | Kani's symbolic execution is exponential in array size. 7 elements is sufficient to prove circular buffer invariants (wrap-around, bounds checking). |
 
-**Verification Strategy:** The invariants are size-independent; proving them for 8 elements implies they hold for 128.
+**Verification Strategy:** The invariants are size-independent; proving them for 7 elements implies they hold for 128.
 
 ### 3. Z3 SMT Constants
 
@@ -166,7 +166,7 @@ The invariants proven in TLA+, Kani, and Z3 are **size-independent**:
 1. **TLA+**: Uses small constants (e.g., `QUEUE_LENGTH=3`) for model checking tractability.
    The invariants (INV-4: length bounded, INV-5: valid indices) hold for ANY `QUEUE_LENGTH >= 2`.
 
-2. **Kani**: Uses `INPUT_QUEUE_LENGTH=8` for symbolic execution tractability.
+2. **Kani**: Uses `INPUT_QUEUE_LENGTH=7` for symbolic execution tractability.
    Circular buffer arithmetic and bounds checking are independent of actual size.
 
 3. **Z3**: Uses default values (128) but proves properties that hold for any valid size.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -302,8 +302,11 @@ sequenceDiagram
         Session->>Telemetry: on_frame_advance(frame)
     end
 
-    Game->>Session: network_stats(player)
-    Session->>Telemetry: on_network_stats(player, stats)
+    Game->>Session: poll_remote_clients()
+    loop For each running remote endpoint
+        Session->>Telemetry: on_network_stats(player, stats)
+    end
+    Note over Session: The public network_stats(player) getter<br/>returns stats to the caller and does not<br/>invoke the telemetry observer.
 ```
 
 ---

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -913,7 +913,7 @@ Rollback networking works best under certain network conditions. Understanding t
 - Frequent rollbacks
 - Noticeable input delay recommended (2-3 frames)
 - Use `SyncConfig::high_latency()` preset
-- Consider increasing `max_prediction_frames`
+- Consider increasing the prediction window via `with_max_prediction_window`
 
 **Very High Latency (>200ms RTT)**
 
@@ -1561,7 +1561,10 @@ use fortress_rollback::{network::codec, Message, NonBlockingSocket};
 
 const MAX_MESSAGES_PER_POLL: usize = 64;
 
-struct MyCustomSocket { /* ... */ }
+struct MyCustomSocket {
+    // Raw packets queued by your transport, drained in bounded batches below.
+    incoming: std::collections::VecDeque<(MyAddress, Vec<u8>)>,
+}
 
 impl NonBlockingSocket<MyAddress> for MyCustomSocket {
     fn send_to(&mut self, msg: &Message, addr: &MyAddress) {
@@ -1570,7 +1573,9 @@ impl NonBlockingSocket<MyAddress> for MyCustomSocket {
 
     fn receive_all_messages(&mut self) -> Vec<(MyAddress, Message)> {
         // Return a bounded batch and leave excess packets for a future poll
-        self.drain_received_messages_bounded(MAX_MESSAGES_PER_POLL)
+        let batch_len = self.incoming.len().min(MAX_MESSAGES_PER_POLL);
+        self.incoming
+            .drain(..batch_len)
             .filter_map(|(addr, bytes)| {
                 codec::decode_message(&bytes).ok().map(|(msg, _consumed)| (addr, msg))
             })
@@ -2353,6 +2358,8 @@ const MAX_MESSAGES_PER_POLL: usize = 64;
 
 struct MyWebSocketTransport {
     // Your WebSocket implementation
+    // Raw packets queued by your transport, drained in bounded batches below.
+    incoming: std::collections::VecDeque<(MyPeerId, Vec<u8>)>,
 }
 
 impl NonBlockingSocket<MyPeerId> for MyWebSocketTransport {
@@ -2364,7 +2371,9 @@ impl NonBlockingSocket<MyPeerId> for MyWebSocketTransport {
 
     fn receive_all_messages(&mut self) -> Vec<(MyPeerId, Message)> {
         // Return a bounded batch and leave excess packets for a future poll
-        self.drain_received_messages_bounded(MAX_MESSAGES_PER_POLL)
+        let batch_len = self.incoming.len().min(MAX_MESSAGES_PER_POLL);
+        self.incoming
+            .drain(..batch_len)
             .filter_map(|(peer, bytes)| {
                 codec::decode_message(&bytes).ok().map(|(msg, _consumed)| (peer, msg))
             })

--- a/examples/README.md
+++ b/examples/README.md
@@ -188,7 +188,7 @@ You can use the Arrow Keys in addition to WASD in order to move the second playe
 
 ### Launching ExGame SyncTest
 
-ExGame SyncTest is launched by a single command-line argument:
+ExGame SyncTest is launched by the following command-line arguments:
 
 - `--num-players / -n`: number of players that will participate in the game
 - `--check-distance / -d`: number of frames that will be rolled back and resimulated each frame

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Fortress Rollback
 
-> Fortress Rollback is a correctness-first fork of GGRS (Good Game Rollback System), providing peer-to-peer rollback networking for deterministic multiplayer games in 100% safe Rust. It features deterministic hashing, panic-free APIs, formal verification (TLA+, Z3), and ~1500 tests with ~92% coverage.
+> Fortress Rollback is a correctness-first fork of GGRS (Good Game Rollback System), providing peer-to-peer rollback networking for deterministic multiplayer games in 100% safe Rust. It features deterministic hashing, panic-free APIs, formal verification (TLA+, Z3), and ~2200 tests with ~92% coverage.
 
 Key information:
 
@@ -25,7 +25,7 @@ Key information:
 
 - [Configuration Example](https://github.com/wallstop/fortress-rollback/blob/main/examples/configuration.rs): Demonstrates session builder configuration options
 - [Error Handling Example](https://github.com/wallstop/fortress-rollback/blob/main/examples/error_handling.rs): Shows proper error handling patterns
-- [Example Game](https://github.com/wallstop/fortress-rollback/tree/main/examples/ex_game): Complete interactive game demo with macroquad/bevy and matchbox
+- [Example Game](https://github.com/wallstop/fortress-rollback/tree/main/examples/ex_game): Complete interactive game demo using macroquad (graphics/audio) and plain UDP sockets (P2P, spectator, and SyncTest variants)
 
 ## API Reference
 

--- a/scripts/tests/test_external_link_checker_config.py
+++ b/scripts/tests/test_external_link_checker_config.py
@@ -97,6 +97,8 @@ def test_lychee_literal_path_args_exist(
     [
         "https://github.com/tlaplus/tlaplus/releases/download/v${TLA_TOOLS_VERSION}/tla2tools.jar",
         "https://github.com/tlaplus/tlaplus/releases/download/v%24%7BTLA_TOOLS_VERSION%7D/tla2tools.jar",
+        "https://github.com/tlaplus/tlaplus/releases/download/v$%7BTLA_TOOLS_VERSION%7D/tla2tools.jar",
+        "https://github.com/tlaplus/tlaplus/releases/download/v$%7bTLA_TOOLS_VERSION%7d/tla2tools.jar",
     ],
 )
 def test_lychee_ignores_templated_runtime_urls(url: str) -> None:

--- a/scripts/tests/test_verify_markdown_code.py
+++ b/scripts/tests/test_verify_markdown_code.py
@@ -22,6 +22,7 @@ unavailable so this file can still be collected on minimal CI shards.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import textwrap
@@ -142,6 +143,12 @@ def _build_tree(tmp_path: Path) -> dict[str, Path]:
     }
 
 
+@pytest.fixture(scope="session")
+def cargo_target_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Share cargo build artifacts across subprocess cases."""
+    return tmp_path_factory.mktemp("verify-markdown-code-target")
+
+
 CASES: tuple[Case, ...] = (
     Case(
         name="single_good_file_passes",
@@ -190,13 +197,17 @@ CASES: tuple[Case, ...] = (
 def test_verify_markdown_code_behaviour(
     case: Case,
     tmp_path: Path,
+    cargo_target_dir: Path,
 ) -> None:
     """Drive verify-markdown-code.sh and assert exit code + key substrings."""
     paths = _build_tree(tmp_path)
     args = case.args_builder(paths)  # type: ignore[operator]
+    env = os.environ.copy()
+    env["CARGO_TARGET_DIR"] = str(cargo_target_dir)
     result = subprocess.run(
         ["bash", str(SCRIPT_PATH), *args],
         cwd=PROJECT_ROOT,
+        env=env,
         capture_output=True,
         text=True,
         check=False,

--- a/scripts/verification/verify-tla.sh
+++ b/scripts/verification/verify-tla.sh
@@ -72,6 +72,7 @@ SPECS=(
     "SpectatorReactivationEpoch"
     "PeerDrop"
     "NPeerReactivation"
+    "NPeerServeFreezeConvergence"
     "FreezeConvergence"
     "FrameAdvantageAggregation"
     "DoubleFailureRelay"

--- a/specs/tla/NPeerServeFreezeConvergence.cfg
+++ b/specs/tla/NPeerServeFreezeConvergence.cfg
@@ -1,0 +1,54 @@
+SPECIFICATION Spec
+
+\* Mesh: 2 remote SURVIVORS the coordinator folds over + 1 COORD (the serving
+\* coordinator), 1 returning joiner J' (implicit — modeled by the baked
+\* `joinerFreeze`), one dropped slot D, frames 0..MAX_FRAME. Two survivors are
+\* the minimum that exercises the gate's `min` fold over more than one remote
+\* claim AND both GlobalMin-holder placements (a survivor holds the true global
+\* min, or the coordinator does). SURVIVORS is genuinely parameterized, so a
+\* larger run is a config-only change.
+\*
+\* DEFAULT config — the landed gate (FIX_MODE = "Gate"): the coordinator serves
+\* the joiner only when no freeze-convergence re-adjust at or below the snapshot
+\* frame S is owed (`npeer_owed_freeze_readjust_at_or_below(S) == false`).
+\* Registered in verify-tla.sh; PASSES every safety invariant AND the liveness
+\* property. The companion negative config NPeerServeFreezeConvergence_GateBlind
+\* sets FIX_MODE = "GateBlind" to demonstrate that, WITHOUT the gate, a premature
+\* serve bakes a stale over-frozen view into the joiner and NoServeDivergence
+\* fails — i.e. the gate is load-bearing. NPeerServeFreezeConvergence_Witness
+\* proves the gate's coverage is non-vacuous (it genuinely defers an owed serve).
+\*
+\* Bounds rationale (this repo's devcontainer, single TLC worker as
+\* verify-tla.sh / CI runs it):
+\* - MAX_FRAME = 3 is the smallest bound that makes a staggered drop AND a
+\*   below-S re-adjust observable: peers can freeze D spread across {0,1,2,3}
+\*   so the global min sits strictly below some peer's freeze, and the snapshot
+\*   frame S can sit strictly above the global min (the `QueueMin + 1 <= S`
+\*   reach term non-trivially binds). Smaller bounds make the GateBlind
+\*   violation unreachable (vacuous).
+\* - InputValue is hardcoded to {0,1} in the .tla: two distinct values are
+\*   enough to make a divergent (stale-baked) snapshot observable.
+\* - streamValue, receivedThrough, and serveFrame are fixed-at-Init adversarial
+\*   choices (D's per-frame inputs, each peer's asymmetric received-through =
+\*   its f0, and the snapshot frame); they never change, so they enlarge only
+\*   the initial-state set, not the reachable depth.
+\* - No SYMMETRY: a liveness property (EventuallyServed) is checked, and TLC
+\*   symmetry reduction is unsound for liveness. The model is small enough to
+\*   run un-reduced.
+CONSTANT SURVIVORS = {s1, s2}
+CONSTANT COORD = k
+CONSTANT MAX_FRAME = 3
+CONSTANT NULL_FRAME = 999
+CONSTANT FIX_MODE = "Gate"
+
+\* Safety invariants
+INVARIANT TypeInvariant
+INVARIANT FreezeFrameInRange
+INVARIANT NoServeDivergence
+INVARIANT ServedMeshNoDesync
+INVARIANT SafetyInvariant
+
+\* Liveness: the gate never deadlocks the serve — every owed re-adjust is
+\* eventually applied, the gate opens, and the joiner is served (requires the
+\* WF assumptions in Spec).
+PROPERTY EventuallyServed

--- a/specs/tla/NPeerServeFreezeConvergence.tla
+++ b/specs/tla/NPeerServeFreezeConvergence.tla
@@ -1,0 +1,346 @@
+------------------- MODULE NPeerServeFreezeConvergence -------------------
+(***************************************************************************)
+(* TLA+ model of the N-peer hot-join SERVE GATE against per-survivor       *)
+(* freeze-frame convergence (the Session-33 round-5 review Finding 1,       *)
+(* coordinator sibling: `npeer_owed_freeze_readjust_at_or_below`).          *)
+(*                                                                         *)
+(* WHY THIS SPEC EXISTS (de-vacuizing NPeerReactivation's round-5 gates).   *)
+(*                                                                         *)
+(* `NPeerReactivation.tla` models the activation-frame agreement of an      *)
+(* N-peer rejoin, but its committed-history abstraction assumes the         *)
+(* pre-attempt per-survivor freeze frame `f0` is UNIFORM across survivors   *)
+(* (each survivor's frozen value lines up by construction). Under that      *)
+(* assumption the Session-33 round-5 freeze-CONVERGENCE serve gates         *)
+(* (acceptance / serve-open deferral; the owed-re-adjust defer/abort) are   *)
+(* checked VACUOUSLY: no survivor ever owes a downward re-adjust, so the     *)
+(* gate never fires. The NPeerReactivation cfg header records this as the   *)
+(* tracked spec-budget residual (session-33 residual 10): "With per-survivor*)
+(* f0 and the convergence re-adjust modeled, Agreement over `val` would     *)
+(* express exactly that divergence."                                        *)
+(*                                                                         *)
+(* This companion spec models exactly that: per-PEER freeze frames `f0`     *)
+(* that initially DIFFER (asymmetric packet loss → different received-      *)
+(* through frames for one dropped slot D), the downward convergence         *)
+(* re-adjust each over-frozen peer owes, and the coordinator's serve gate   *)
+(* that must defer the snapshot capture while a re-adjust at or below the   *)
+(* snapshot frame S is still owed-but-unapplied. A new joiner J' is served  *)
+(* a snapshot at S that BAKES the coordinator's view of D's stream for      *)
+(* frames 0..S; J' cannot re-adjust below its baseline S (the fold-below-S  *)
+(* structural impossibility, S58/S60), so a snapshot captured before the    *)
+(* coordinator's own re-adjust is applied is permanently divergent from the *)
+(* converged mesh. The gate closes that.                                    *)
+(*                                                                         *)
+(* It is the companion to NPeerReactivation.tla in exactly the sense        *)
+(* SpectatorReactivationEpoch.tla (S56) is the companion to                 *)
+(* SpectatorFailover.tla and FreezeConvergence.tla (S37) is the companion   *)
+(* to InputQueue.tla: a dedicated spec for a distinct concern an in-place   *)
+(* bump would only check vacuously (and, here, would explode the already-   *)
+(* at-CI-budget NPeerReactivation state space). It reuses                   *)
+(* FreezeConvergence.tla's per-survivor freeze idioms (per-peer received-   *)
+(* through, the global-min agreed frame, monotone-down re-roll) and adds    *)
+(* the serve-gate interaction those do not model.                          *)
+(*                                                                         *)
+(* THE GATE (faithful to src/sessions/p2p_session.rs).                      *)
+(*                                                                         *)
+(* `npeer_owed_freeze_readjust_at_or_below(S)` (p2p_session.rs:1977) folds, *)
+(* for a remote dropped slot, over the running non-reserved REMOTE          *)
+(* endpoints' claims:                                                       *)
+(*     queue_min_confirmed = min over remotes of claim.last_frame           *)
+(*     readjust_owed = local_connected \/ status.last_frame > queue_min     *)
+(*     fire iff readjust_owed /\ queue_min + 1 <= S                         *)
+(* and the serve poll (`poll_npeer_host_serve`, p2p_session.rs:2134) defers *)
+(* the capture (pre-capture) or aborts the serve (post-capture) while it    *)
+(* fires. The capture itself bakes the coordinator's own connect-status     *)
+(* table and confirmed inputs at S (`capture_npeer_snapshot`,               *)
+(* p2p_session.rs:2034). Here the dropped slot D is always reported          *)
+(* disconnected (it was dropped), so `local_connected` is FALSE and the     *)
+(* live arm is `status.last_frame > queue_min` — the per-survivor-f0        *)
+(* MINE-DOWN the residual is about. (The `local_connected` first-freeze-    *)
+(* propagation arm is the orthogonal not-yet-frozen case, out of this       *)
+(* convergence-scope model.)                                                *)
+(*                                                                         *)
+(* THE FIX_MODE LADDER (the repo's standard negative→positive demo, cf.     *)
+(* DoubleFailureRelay / SpectatorReactivationEpoch).                        *)
+(*   - FIX_MODE = "GateBlind" — serve as soon as the wait-then-capture      *)
+(*     `confirmed >= S` precondition holds, IGNORING the owed re-adjust     *)
+(*     (the pre-Finding-1 behavior). DEMO-FAIL: the coordinator bakes its   *)
+(*     stale (over-frozen) view of D into the joiner's snapshot, which then *)
+(*     permanently diverges from the converged mesh (NoServeDivergence      *)
+(*     VIOLATED). This is the model-level RED that proves the gate is       *)
+(*     load-bearing.                                                        *)
+(*   - FIX_MODE = "Gate" — serve only when no re-adjust at or below S is    *)
+(*     owed (the landed gate). PASS: every served snapshot already reflects *)
+(*     the converged value for frames <= S, so the joiner agrees with the   *)
+(*     mesh forever.                                                        *)
+(*                                                                         *)
+(* SCOPE (honest).                                                          *)
+(*   - The agreed freeze frame for D in the gossip is the true GlobalMin    *)
+(*     (every survivor's gossiped claim is its current freeze, delivered    *)
+(*     instantly): the Finding-1 hazard is precisely that the gossip min    *)
+(*     is seen INSTANTLY by the fold while the coordinator's OWN re-adjust  *)
+(*     (the `update_player_disconnects` mine-down + re-roll, which runs     *)
+(*     only inside `advance_frame`) LAGS. Gossip LOSS/REORDER and the       *)
+(*     freeze-BARRIER that holds `confirmed_frame()` at the gossip min      *)
+(*     until convergence (S32/S55) are orthogonal and modeled elsewhere     *)
+(*     (DoubleFailureRelay.tla, FreezeConvergence.tla); the barrier is what *)
+(*     guarantees a serve is contemplated only once the gossip has          *)
+(*     converged, which this spec assumes by construction.                  *)
+(*   - One dropped slot D, one returning joiner J'. Multiple survivors      *)
+(*     exercise the fold's `min`.                                           *)
+(*   - `receivedThrough \in 0..MAX_FRAME` (>= 0): D is dropped after         *)
+(*     delivering at least frame 0, so every peer has a confirmed input at   *)
+(*     the global min. The production `NULL_FRAME (-1)` freeze (a slot       *)
+(*     frozen with NO confirmed input) is excluded — a faithful scoping for  *)
+(*     the dropped-after-frame-0 convergence this spec targets (NULL_FRAME   *)
+(*     is reserved here only for the not-yet-served joinerFreeze sentinel).  *)
+(***************************************************************************)
+
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS
+    SURVIVORS,      \* the REMOTE survivors the coordinator folds over (>= 1)
+    COORD,          \* the serving coordinator (holds local_connect_status)
+    MAX_FRAME,      \* highest frame number (small bound)
+    NULL_FRAME,     \* sentinel for "joiner not yet served" (-1 in impl)
+    FIX_MODE        \* "GateBlind" (demo-FAIL) | "Gate" (the landed gate)
+
+ASSUME SURVIVORS # {}
+ASSUME COORD \notin SURVIVORS
+ASSUME MAX_FRAME \in Nat /\ MAX_FRAME > 0
+ASSUME NULL_FRAME \notin 0..MAX_FRAME
+ASSUME FIX_MODE \in {"GateBlind", "Gate"}
+
+Peers == SURVIVORS \union {COORD}
+
+(***************************************************************************)
+(* The dropped peer's input alphabet. Two distinct values are enough to     *)
+(* make divergence observable; kept tiny for tractability.                  *)
+(***************************************************************************)
+InputValue == 0..1
+
+Frame == {NULL_FRAME} \union (0..MAX_FRAME)
+
+VARIABLES
+    streamValue,    \* [0..MAX_FRAME -> InputValue]: D's actual per-frame input
+    receivedThrough,\* [Peers -> 0..MAX_FRAME]: per-peer f0 (asymmetric loss)
+    localFreeze,    \* [Peers -> 0..MAX_FRAME]: peer's CURRENT freeze for D
+                    \*   (its gossiped connect-status last_frame AND the frame
+                    \*   its state is rolled to — they converge together in
+                    \*   `update_player_disconnects`); starts at receivedThrough,
+                    \*   re-adjusts monotone-DOWN toward GlobalMin.
+    serveFrame,     \* 0..MAX_FRAME: the snapshot frame S (chosen at Init)
+    served,         \* BOOLEAN: the coordinator has served the joiner
+    joinerFreeze    \* Frame: the freeze frame BAKED into the joiner's snapshot
+                    \*   at serve time (= localFreeze[COORD] then); NULL_FRAME
+                    \*   until served; immutable after (J' cannot re-adjust
+                    \*   below its snapshot baseline — fold-below-S, S58/S60).
+
+vars == <<streamValue, receivedThrough, localFreeze, serveFrame, served,
+          joinerFreeze>>
+
+(***************************************************************************)
+(* Min over a non-empty set of frame numbers. CHOOSE ranges over Int frame  *)
+(* values only (never over Peers), so it is symmetry-safe.                  *)
+(***************************************************************************)
+Min(S) == CHOOSE x \in S : \A y \in S : x <= y
+
+(***************************************************************************)
+(* The true agreed global-min freeze frame for D: the minimum, across ALL   *)
+(* peers, of the received-through high-water. Because frames are contiguous  *)
+(* from 0 and every peer received >= GlobalMin, the value at GlobalMin       *)
+(* (streamValue[GlobalMin]) is confirmed by every peer and is the value the  *)
+(* whole mesh converges to repeat for every frame above GlobalMin.          *)
+(***************************************************************************)
+GlobalMin == Min({receivedThrough[p] : p \in Peers})
+
+(***************************************************************************)
+(* The value peer p currently REPORTS for D at frame g: the real received    *)
+(* value at or below its freeze frame, the repeated frozen value above it.   *)
+(* (For g <= localFreeze[p] <= receivedThrough[p], p genuinely received g.)   *)
+(***************************************************************************)
+Report(p, g) ==
+    IF g <= localFreeze[p] THEN streamValue[g] ELSE streamValue[localFreeze[p]]
+
+(***************************************************************************)
+(* The value EVERY peer eventually reports for D at frame g, once the mesh   *)
+(* has converged to GlobalMin (localFreeze[p] = GlobalMin for all p): the    *)
+(* real value at/below GlobalMin, the frozen GlobalMin value above it. This  *)
+(* is the convergence target the joiner's baked snapshot must match.         *)
+(***************************************************************************)
+ConvergedValue(g) ==
+    IF g <= GlobalMin THEN streamValue[g] ELSE streamValue[GlobalMin]
+
+(***************************************************************************)
+(* The joiner's BAKED report for D at frame g (after serve): the frozen      *)
+(* stream of the coordinator's snapshot, captured at joinerFreeze and        *)
+(* immutable.                                                                *)
+(***************************************************************************)
+JoinerReport(g) ==
+    IF g <= joinerFreeze THEN streamValue[g] ELSE streamValue[joinerFreeze]
+
+(***************************************************************************)
+(* The serve gate (faithful to `npeer_owed_freeze_readjust_at_or_below`).    *)
+(* D is reported disconnected by every folded survivor, so queue_connected   *)
+(* is FALSE (never skipped) and any_folded is TRUE (SURVIVORS # {}). D is    *)
+(* locally disconnected too, so local_connected is FALSE and the live arm    *)
+(* is the mine-down `status.last_frame > queue_min`.                         *)
+(***************************************************************************)
+QueueMin == Min({localFreeze[s] : s \in SURVIVORS})
+
+ReadjustOwed == localFreeze[COORD] > QueueMin           \* local_connected = FALSE
+
+OwedAtOrBelow(s) == ReadjustOwed /\ (QueueMin + 1 <= s)
+
+(***************************************************************************)
+(* Type invariant.                                                         *)
+(***************************************************************************)
+TypeInvariant ==
+    /\ streamValue \in [0..MAX_FRAME -> InputValue]
+    /\ receivedThrough \in [Peers -> 0..MAX_FRAME]
+    /\ localFreeze \in [Peers -> 0..MAX_FRAME]
+    /\ serveFrame \in 0..MAX_FRAME
+    /\ served \in BOOLEAN
+    /\ joinerFreeze \in Frame
+
+(***************************************************************************)
+(* Init. The stream, the per-peer received-through (the per-survivor f0),    *)
+(* and the snapshot frame S are fixed by an adversarial nondeterministic     *)
+(* choice. Every peer has already frozen D at its own received-through (the  *)
+(* drop happened); none has converged yet; no serve has occurred.            *)
+(***************************************************************************)
+Init ==
+    /\ streamValue \in [0..MAX_FRAME -> InputValue]
+    /\ receivedThrough \in [Peers -> 0..MAX_FRAME]
+    /\ localFreeze = receivedThrough
+    /\ serveFrame \in 0..MAX_FRAME
+    /\ served = FALSE
+    /\ joinerFreeze = NULL_FRAME
+
+(***************************************************************************)
+(* ConvergeDown -- a peer applies its owed downward re-adjust, rolling its    *)
+(* freeze for D from its current frame down to a lower agreed frame f, never  *)
+(* below the true global min. Maps to production: the                        *)
+(* `update_player_disconnects` mine-down (`status.last_frame =                *)
+(* min(last_frame, agreed)`) + `set_frozen_value_at` re-roll + forced         *)
+(* re-simulation, which run only inside `advance_frame` (hence the lag the    *)
+(* gate guards against).                                                      *)
+(***************************************************************************)
+ConvergeDown(p, f) ==
+    /\ f \in GlobalMin..(localFreeze[p] - 1)
+    /\ localFreeze' = [localFreeze EXCEPT ![p] = f]
+    /\ UNCHANGED <<streamValue, receivedThrough, serveFrame, served,
+                   joinerFreeze>>
+
+(***************************************************************************)
+(* Serve -- the coordinator captures the snapshot at S and serves the joiner,*)
+(* baking its CURRENT view of D (localFreeze[COORD]) into the snapshot. The   *)
+(* FIX_MODE selects the gate:                                                 *)
+(*   - "GateBlind": serve unconditionally (the wait-then-capture              *)
+(*     `confirmed >= S` precondition is assumed met; this mode omits the      *)
+(*     Finding-1 owed-re-adjust check).                                       *)
+(*   - "Gate": serve only when no re-adjust at or below S is owed.            *)
+(***************************************************************************)
+GatePasses ==
+    CASE FIX_MODE = "GateBlind" -> TRUE
+      [] FIX_MODE = "Gate"      -> ~OwedAtOrBelow(serveFrame)
+
+Serve ==
+    /\ ~served
+    /\ GatePasses
+    /\ served' = TRUE
+    /\ joinerFreeze' = localFreeze[COORD]
+    /\ UNCHANGED <<streamValue, receivedThrough, localFreeze, serveFrame>>
+
+Next ==
+    \/ \E p \in Peers, f \in 0..MAX_FRAME: ConvergeDown(p, f)
+    \/ Serve
+
+(***************************************************************************)
+(* Fairness. Convergence and the (gated) serve are weakly fair so the mesh   *)
+(* reaches the converged + served fixpoint; nothing forces a premature        *)
+(* serve.                                                                     *)
+(***************************************************************************)
+Fairness ==
+    /\ \A p \in Peers : WF_vars(\E f \in 0..MAX_FRAME : ConvergeDown(p, f))
+    /\ WF_vars(Serve)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(***************************************************************************)
+(* Safety properties.                                                       *)
+(***************************************************************************)
+
+(***************************************************************************)
+(* Sanity: no peer ever freezes below the agreed global min or above what     *)
+(* it actually received (the FreezeConvergence FreezeFrameInRange lift). The  *)
+(* lower bound is the desync-relevant half.                                   *)
+(***************************************************************************)
+FreezeFrameInRange ==
+    \A p \in Peers :
+        /\ localFreeze[p] >= GlobalMin
+        /\ localFreeze[p] <= receivedThrough[p]
+
+(***************************************************************************)
+(* HEADLINE -- NoServeDivergence. Once the joiner has been served, its baked   *)
+(* report for D agrees, at EVERY frame at or below the snapshot frame S, with  *)
+(* the value the whole mesh converges to. The joiner cannot re-adjust below    *)
+(* its baseline, so a snapshot baked from a stale (over-frozen) coordinator    *)
+(* view is a PERMANENT cross-peer confirmed-state desync — exactly the         *)
+(* divergence NPeerReactivation's gates were vacuously assumed to prevent.     *)
+(*                                                                            *)
+(* Stated against ConvergedValue (the known fixpoint target) rather than a     *)
+(* live peer so it is checkable the instant `served` becomes TRUE, not only    *)
+(* at the convergence fixpoint: under "GateBlind" TLC reports the violation    *)
+(* immediately on a premature serve; under "Gate" it never can.               *)
+(***************************************************************************)
+NoServeDivergence ==
+    served => \A g \in 0..serveFrame : JoinerReport(g) = ConvergedValue(g)
+
+(***************************************************************************)
+(* The user-facing cross-peer corollary (mirrors FreezeConvergence's          *)
+(* ConvergedNoDesync). Once the joiner is served AND the mesh has converged    *)
+(* (every peer's freeze = GlobalMin), the joiner's baked D-stream is            *)
+(* byte-identical to EVERY live peer's reported D-stream at every frame <= S.   *)
+(* This is the corollary of NoServeDivergence evaluated at the AllConverged     *)
+(* fixpoint (where Report(p, g) = ConvergedValue(g)), not an independent guard  *)
+(* — but "no cross-peer desync" is the property the whole gate exists to        *)
+(* deliver, so it is stated explicitly. EventuallyServed + ConvergeDown         *)
+(* fairness prove its AllConverged /\ served hypothesis is reachable (so it is   *)
+(* not vacuously true).                                                         *)
+(***************************************************************************)
+AllConverged == \A p \in Peers : localFreeze[p] = GlobalMin
+
+ServedMeshNoDesync ==
+    (served /\ AllConverged) =>
+        \A p \in Peers, g \in 0..serveFrame : JoinerReport(g) = Report(p, g)
+
+SafetyInvariant ==
+    /\ TypeInvariant
+    /\ FreezeFrameInRange
+    /\ NoServeDivergence
+    /\ ServedMeshNoDesync
+
+(***************************************************************************)
+(* Liveness: the protocol always reaches the served fixpoint (the gate never  *)
+(* deadlocks the serve — every owed re-adjust is eventually applied, after     *)
+(* which the gate opens). Under the weak-fairness assumptions: every           *)
+(* over-frozen peer eventually ConvergeDowns to GlobalMin, so ReadjustOwed     *)
+(* clears and Serve is enabled.                                                *)
+(***************************************************************************)
+EventuallyServed == <>served
+
+(***************************************************************************)
+(* Non-vacuity witness (see NPeerServeFreezeConvergence_Witness.cfg). The      *)
+(* "Gate" PASS is meaningful only if the gate actually has work to do — i.e.   *)
+(* a reachable state exists where the serve is NOT yet done AND a re-adjust at  *)
+(* or below S is owed, so the gate is actively DEFERRING a serve that          *)
+(* "GateBlind" would take (and that would then fail NoServeDivergence). This    *)
+(* invariant is deliberately FALSIFIABLE: TLC reports it VIOLATED, exhibiting   *)
+(* that exact gate-deferral state, proving the "Gate" coverage is non-vacuous   *)
+(* (the gate is not merely satisfied because no serve is ever owed-blocked).    *)
+(***************************************************************************)
+WitnessGateDefers == ~(~served /\ OwedAtOrBelow(serveFrame))
+
+THEOREM Spec => []SafetyInvariant
+
+=============================================================================

--- a/specs/tla/NPeerServeFreezeConvergence_GateBlind.cfg
+++ b/specs/tla/NPeerServeFreezeConvergence_GateBlind.cfg
@@ -1,0 +1,46 @@
+SPECIFICATION Spec
+
+\* DEMONSTRATION CONFIG (NOT the default; NOT registered in verify-tla.sh).
+\*
+\* Differs from NPeerServeFreezeConvergence.cfg in: FIX_MODE = "GateBlind" (the
+\* pre-Session-33-round-5 behavior — serve as soon as the wait-then-capture
+\* `confirmed >= S` precondition holds, with NO owed-re-adjust check). The point
+\* of the demonstration is that the cross-peer state-divergence invariant
+\* NoServeDivergence is NOT pinned without the gate: TLC reports a COUNTEREXAMPLE
+\* in which the coordinator, while still owing a downward freeze re-adjust for the
+\* dropped slot D (its local freeze sits above the mesh-agreed global min), bakes
+\* its STALE over-frozen view of D into the joiner's snapshot at S. The joiner
+\* cannot re-adjust below its snapshot baseline (the fold-below-S structural
+\* impossibility, S58/S60), so once the mesh converges to the global min the
+\* joiner's baked D-stream permanently diverges from every other peer's.
+\*
+\* This is the model-level RED that de-vacuizes the Session-33 round-5
+\* freeze-convergence serve gates NPeerReactivation.tla checks only vacuously
+\* (its f0 is uniform). It mirrors the production gate
+\* `npeer_owed_freeze_readjust_at_or_below` in
+\* src/sessions/p2p_session.rs:1977 (the serve poll defers/aborts on it,
+\* p2p_session.rs:2134) and the fold-below-S fail-closed guard the gate makes
+\* unreachable over a genuine wire.
+\*
+\* Expected result: TLC reports "Invariant NoServeDivergence is violated" with a
+\* trace. Run this manually:
+\*
+\*   java -jar .tla-tools/tla2tools.jar -deadlock \
+\*        -config specs/tla/NPeerServeFreezeConvergence_GateBlind.cfg \
+\*        specs/tla/NPeerServeFreezeConvergence.tla
+\*
+\* Do NOT add this config to verify-tla.sh; it is MEANT to FAIL (on the safety
+\* invariant) — it proves the residual is real and the gate is load-bearing.
+CONSTANT SURVIVORS = {s1, s2}
+CONSTANT COORD = k
+CONSTANT MAX_FRAME = 3
+CONSTANT NULL_FRAME = 999
+CONSTANT FIX_MODE = "GateBlind"
+
+\* Only the safety invariants — the counterexample is a safety violation; the
+\* liveness property is irrelevant to the demonstration (GateBlind serves
+\* unconditionally, so it satisfies EventuallyServed anyway).
+INVARIANT TypeInvariant
+INVARIANT FreezeFrameInRange
+INVARIANT NoServeDivergence
+INVARIANT SafetyInvariant

--- a/specs/tla/NPeerServeFreezeConvergence_Witness.cfg
+++ b/specs/tla/NPeerServeFreezeConvergence_Witness.cfg
@@ -1,0 +1,35 @@
+SPECIFICATION Spec
+
+\* NON-VACUITY WITNESS config (run MANUALLY; NOT auto-run by verify-tla.sh, like
+\* the DoubleFailureRelay `_Witness` cfgs).
+\*
+\* Same constants as the default NPeerServeFreezeConvergence.cfg (FIX_MODE =
+\* "Gate"), but it checks the deliberately-FALSIFIABLE invariant
+\* WitnessGateDefers instead of the safety set. WitnessGateDefers asserts that
+\* NO reachable state has the serve un-done while a re-adjust at or below S is
+\* owed — which is FALSE: the gate genuinely reaches such states and defers the
+\* serve there. TLC reporting it VIOLATED exhibits that exact gate-deferral state
+\* (the coordinator over-frozen above the mesh-agreed min, S above the min, serve
+\* held back), proving the "Gate" PASS is NON-VACUOUS: the gate is doing real
+\* work — it is not merely satisfied because no serve is ever owed-blocked. (The
+\* sibling EventuallyServed liveness in the default cfg proves the converse: the
+\* gate eventually opens, so the deferral is not a deadlock.)
+\*
+\* Expected result: TLC reports "Invariant WitnessGateDefers is violated" with a
+\* trace ending in a state where ~served /\ OwedAtOrBelow(serveFrame). Run this
+\* manually:
+\*
+\*   java -jar .tla-tools/tla2tools.jar -deadlock \
+\*        -config specs/tla/NPeerServeFreezeConvergence_Witness.cfg \
+\*        specs/tla/NPeerServeFreezeConvergence.tla
+\*
+\* Do NOT add this config to verify-tla.sh; it is MEANT to FAIL (it is a
+\* reachability witness, not a safety check).
+CONSTANT SURVIVORS = {s1, s2}
+CONSTANT COORD = k
+CONSTANT MAX_FRAME = 3
+CONSTANT NULL_FRAME = 999
+CONSTANT FIX_MODE = "Gate"
+
+\* The deliberately-falsifiable reachability witness (expected VIOLATED).
+INVARIANT WitnessGateDefers

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -601,8 +601,8 @@ by pinning `f0` uniform: here each peer freezes one dropped slot `D` at its own
 received-through frame (`receivedThrough`, the per-survivor `f0`), which under asymmetric
 loss differs across peers, and an over-frozen peer owes a monotone-**down** re-adjust to the
 mesh-agreed global min (`ConvergeDown`, the production `update_player_disconnects` mine-down
-+ `set_frozen_value_at` re-roll + forced re-simulation that runs only inside `advance_frame`
-— hence the lag the gate guards against). The coordinator serves a returning joiner a
+plus `set_frozen_value_at` re-roll plus forced re-simulation that runs only inside
+`advance_frame` — hence the lag the gate guards against). The coordinator serves a returning joiner a
 snapshot at frame `S` that **bakes its current view of `D`**; the joiner cannot re-base below
 `S` (the fold-below-`S` structural impossibility, S58/S60), so a snapshot captured before the
 coordinator's own re-adjust is applied is a **permanent** cross-peer confirmed-state desync.

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -35,6 +35,7 @@ This directory contains TLA+ specifications for formally verifying the correctne
 | `TimeSync.tla` | `TimeSync.cfg` | ✓ CI | Per-endpoint rolling-window frame-advantage (pinned N=2; the cross-endpoint aggregation is modeled separately in `FrameAdvantageAggregation.tla`, see cfg) |
 | `PeerDrop.tla` | `PeerDrop.cfg` | ✓ CI | Halt vs ContinueWithout peer-drop policy model |
 | `NPeerReactivation.tla` | `NPeerReactivation.cfg` | ✓ CI | N-peer mesh reconnection activation-frame agreement (Agreement C) (N=3 survivors) |
+| `NPeerServeFreezeConvergence.tla` | `NPeerServeFreezeConvergence.cfg` (+ `_GateBlind.cfg` demo-FAIL, `_Witness.cfg` non-vacuity — both manual, not auto-run) | ✓ CI | N-peer hot-join SERVE GATE vs per-survivor freeze convergence (Session-33 round-5 Finding 1, `npeer_owed_freeze_readjust_at_or_below`), the companion to `NPeerReactivation.tla` that de-vacuizes its round-5 gates: models per-PEER freeze frames `f0` that initially differ (asymmetric loss), the owed downward re-adjust, and the coordinator serving a joiner a snapshot it cannot re-base below (fold-below-S, S58/S60). FIX_MODE ladder mirrors `DoubleFailureRelay.tla` (GateBlind → `NoServeDivergence` violated; Gate PASS safety+liveness). Closes the NPeerReactivation per-survivor-`f0` spec-budget residual (S33 residual 10) |
 | `FreezeConvergence.tla` | `FreezeConvergence.cfg` | ✓ CI | Cross-survivor freeze-value convergence to the global-min agreed frame (the c25fc1f desync fix, N=3 survivors) |
 | `FrameAdvantageAggregation.tla` | `FrameAdvantageAggregation.cfg` | ✓ CI | Cross-endpoint `max_frame_advantage` fold over N≥3 remotes — multi-handle idempotence, disconnect-gate exclusion, `i32::MIN→0` fallback (companion to `TimeSync.tla`) |
 | `SpectatorFailover.tla` | `SpectatorFailover.cfg` | ✓ CI | Multi-host spectator connect-status merge — converge-down to live global-min freeze + provenance-gated reactivation under host failover (companion to `SpectatorSession.tla`; audit F4 / critic-#1 / critic-#2) |
@@ -581,6 +582,62 @@ values. The default config pins P-A (`AssumePA = TRUE`) and passes. `NPeerReacti
 (`AssumePA = FALSE`, not registered in CI) drops P-A and TLC reports an `Agreement`
 counterexample — demonstrating P-A is necessary.
 
+**Tracked spec-budget residual — the per-survivor `f0` extension — is now CLOSED by a
+companion spec.** NPeerReactivation's committed-history abstraction assumes the pre-attempt
+per-survivor freeze frame `f0` is *uniform*, so its Session-33 round-5 freeze-convergence
+serve gates are checked only vacuously. That extension is modeled separately in
+`NPeerServeFreezeConvergence.tla` (below) — a dedicated companion, in the same spirit as
+`SpectatorReactivationEpoch.tla` (companion to `SpectatorFailover.tla`) and
+`FreezeConvergence.tla` (companion to `InputQueue.tla`), since an in-place bump would
+explode this already-at-CI-budget liveness spec.
+
+### NPeerServeFreezeConvergence.tla
+
+Models the N-peer hot-join **serve gate** against per-survivor freeze-frame convergence —
+the Session-33 round-5 review Finding 1 (coordinator sibling),
+`npeer_owed_freeze_readjust_at_or_below` in `src/sessions/p2p_session.rs:1977`. It
+**de-vacuizes the round-5 freeze-convergence gates** `NPeerReactivation.tla` assumes away
+by pinning `f0` uniform: here each peer freezes one dropped slot `D` at its own
+received-through frame (`receivedThrough`, the per-survivor `f0`), which under asymmetric
+loss differs across peers, and an over-frozen peer owes a monotone-**down** re-adjust to the
+mesh-agreed global min (`ConvergeDown`, the production `update_player_disconnects` mine-down
++ `set_frozen_value_at` re-roll + forced re-simulation that runs only inside `advance_frame`
+— hence the lag the gate guards against). The coordinator serves a returning joiner a
+snapshot at frame `S` that **bakes its current view of `D`**; the joiner cannot re-base below
+`S` (the fold-below-`S` structural impossibility, S58/S60), so a snapshot captured before the
+coordinator's own re-adjust is applied is a **permanent** cross-peer confirmed-state desync.
+
+**FIX_MODE ladder** (the repo's standard negative→positive demo, cf. `DoubleFailureRelay.tla`
+/ `SpectatorReactivationEpoch.tla`):
+
+- `FIX_MODE = "GateBlind"` (demo-FAIL, `_GateBlind.cfg`, manual): serve as soon as the
+  wait-then-capture `confirmed >= S` precondition holds, ignoring the owed re-adjust. TLC
+  reports `NoServeDivergence` **violated** — the coordinator bakes a stale over-frozen view
+  of `D` (its real input at `S`) into the joiner, which then diverges from the converged
+  mesh (which freezes `D` at the global min). Model-level RED proving the gate is load-bearing.
+- `FIX_MODE = "Gate"` (default, `NPeerServeFreezeConvergence.cfg`, ✓ CI): serve only when no
+  re-adjust at or below `S` is owed (`~OwedAtOrBelow(serveFrame)`, faithful to the production
+  fold). **PASS** — every served snapshot already reflects the converged value for frames
+  `<= S`, so the joiner agrees with the mesh forever.
+
+**Safety:** `NoServeDivergence` (the served joiner's baked `D`-stream matches the converged
+mesh value at every frame `<= S`), `FreezeFrameInRange` (no peer ever freezes below the
+global min — the `FreezeConvergence` lift), `TypeInvariant`.
+**Liveness (weak fairness):** `EventuallyServed` — the gate never deadlocks the serve (every
+owed re-adjust is eventually applied, then the gate opens).
+**Non-vacuity** (`_Witness.cfg`, manual): `WitnessGateDefers` is deliberately falsifiable —
+TLC reports it violated, exhibiting a reachable state where the gate genuinely defers an owed
+serve (the coordinator over-frozen above the agreed min, `S` above it), so the "Gate" PASS is
+not vacuous.
+
+**Scope (honest):** the gossiped agreed freeze frame is the true global min (claims delivered
+instantly — the Finding-1 hazard is precisely that the fold sees mesh agreement *instantly*
+while the coordinator's own re-adjust lags); gossip loss/reorder and the freeze barrier that
+holds `confirmed_frame()` at the gossip min until convergence (S32/S55) are orthogonal and
+modeled in `DoubleFailureRelay.tla` / `FreezeConvergence.tla`. The gate's `local_connected`
+first-freeze-propagation arm is the orthogonal not-yet-frozen case, out of this
+convergence-scope model.
+
 ### Rollback.tla
 
 **Safety (from formal-spec.md):**
@@ -700,6 +757,9 @@ Each spec has a `.cfg` file with TLC-compatible settings:
 | `Rollback.cfg` | MAX_PREDICTION=1, MAX_FRAME=3 | ~1.8M distinct states (~29.2M generated) |
 | `ChecksumExchange.cfg` | PEERS={p1,p2,p3}, MAX_FRAME=3, SYMMETRY | ~1.47M distinct states (~11.7M generated), ~106s single worker |
 | `FreezeConvergence.cfg` | SURVIVORS={s1,s2,s3}, MAX_FRAME=3, NULL_FRAME=999 (no symmetry — liveness) | ~24,100 distinct states (~79,000 generated) |
+| `NPeerServeFreezeConvergence.cfg` | SURVIVORS={s1,s2}, COORD=k, MAX_FRAME=3, NULL_FRAME=999, FIX_MODE="Gate" (no symmetry — liveness) | ~47,000 distinct states (~103,000 generated), ~1s workers-auto |
+| `NPeerServeFreezeConvergence_GateBlind.cfg` (demo, expected FAIL — safety) | same constants, FIX_MODE="GateBlind" | `NoServeDivergence` violated (premature serve bakes the over-frozen view) |
+| `NPeerServeFreezeConvergence_Witness.cfg` (demo, expected FAIL — non-vacuity) | same constants, FIX_MODE="Gate" | `WitnessGateDefers` violated — a reachable gate-deferral state, so the Gate PASS is non-vacuous |
 | `FrameAdvantageAggregation.cfg` | NUM_ENDPOINTS=3, MAX_ADVANTAGE=4, MULTI_HANDLE_COUNT=2, MIN_RECOMMENDATION=3 (no symmetry) | ~26,200 distinct states (~901,000 generated) |
 | `SpectatorFailover.cfg` | HOSTS={1,2,3}, MAX_FRAME=3, NULL_FRAME=999 (no symmetry — canonical=min(live), liveness) | ~96,800 distinct states (~446,000 generated), ~6s single worker |
 | `SpectatorReactivationEpoch.cfg` | HOSTS={1,2}, MAX_FRAME=2, NULL_FRAME=999, MAXGEN=3, FIX_MODE="Epoch" (no symmetry — canonical=min(HOSTS)) | ~10,900 distinct states (~92,700 generated), ~3s single worker |

--- a/src/sessions/builder.rs
+++ b/src/sessions/builder.rs
@@ -1076,21 +1076,16 @@ impl<T: Config> SessionBuilder<T> {
 
     /// Sets a custom observer for specification violations.
     ///
-    /// **Current routing (varies by session type):**
-    ///
-    /// - [`SpectatorSession`]: violations during
-    ///   session operation (e.g. frame sync issues, input anomalies) are
-    ///   reported to this observer, enabling programmatic monitoring, custom
-    ///   logging, or test assertions. With no observer set they are logged
-    ///   via the `tracing` crate ([`TracingObserver`]).
-    /// - [`P2PSession`] and [`SyncTestSession`]:
-    ///   violation reporting currently goes to the `tracing`-backed default
-    ///   observer ([`TracingObserver`] — `warn!`/`error!` events)
-    ///   regardless of this setting; the per-session observer is carried
-    ///   and exposed through the session's `violation_observer()` accessor,
-    ///   but the violation paths of these session types do not invoke it
-    ///   yet. Routing their violations to the per-session observer is
-    ///   tracked future work.
+    /// **Routing:** When set, violations raised during session operation
+    /// (frame-sync issues, input anomalies, internal invariant checks) are
+    /// routed to this observer, enabling programmatic monitoring, custom
+    /// logging, or test assertions. [`P2PSession`], [`SyncTestSession`], and
+    /// [`SpectatorSession`] each install the configured observer as a
+    /// thread-local scope at their public entry points (e.g. `advance_frame`,
+    /// `poll_remote_clients`), so violations emitted beneath them — including
+    /// those raised by lower-level components (`input_queue`, `sync_layer`,
+    /// `protocol`) — are captured. With no observer set, violations fall back
+    /// to the `tracing` crate ([`TracingObserver`]).
     ///
     /// [`TracingObserver`]: crate::telemetry::TracingObserver
     ///

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -774,6 +774,12 @@ impl<T: Config> P2PSession<T> {
         disconnect_behavior: DisconnectBehavior,
         #[cfg(feature = "hot-join")] hot_join: HotJoinConfig<T>,
     ) -> Result<Self, FortressError> {
+        // Route construction-time violations (e.g. a failed frame-delay setup or
+        // reserved-slot freeze) to the configured observer, the same as runtime
+        // entry points do.
+        let _violation_scope = violation_observer
+            .as_ref()
+            .map(|observer| crate::telemetry::push_violation_observer(Arc::clone(observer)));
         // local connection status
         let mut local_connect_status = Vec::new();
         local_connect_status
@@ -934,6 +940,7 @@ impl<T: Config> P2PSession<T> {
         player_handle: PlayerHandle,
         input: T::Input,
     ) -> Result<(), FortressError> {
+        let _violation_scope = self.scoped_violation_observer();
         // make sure the input is for a registered local player (zero-allocation check)
         if !self.player_reg.is_local_player(player_handle) {
             return Err(InvalidRequestKind::NotLocalPlayer {
@@ -979,6 +986,7 @@ impl<T: Config> P2PSession<T> {
     /// [`RequestVec`]: crate::RequestVec
     #[must_use = "FortressRequests must be processed to advance the game state"]
     pub fn advance_frame(&mut self) -> FortressResult<RequestVec<T>> {
+        let _violation_scope = self.scoped_violation_observer();
         // receive info from remote players, trigger events and send messages
         self.poll_remote_clients();
 
@@ -1240,6 +1248,7 @@ impl<T: Config> P2PSession<T> {
     /// Should be called periodically by your application to give Fortress Rollback a chance to do internal work.
     /// Fortress Rollback will receive packets, distribute them to corresponding endpoints, handle all occurring events and send all outgoing packets.
     pub fn poll_remote_clients(&mut self) {
+        let _violation_scope = self.scoped_violation_observer();
         // Get all packets and distribute them to associated endpoints.
         // The endpoints will handle their packets, which will trigger both events and UPD replies.
         for (from_addr, msg) in &self.socket.receive_all_messages() {
@@ -5329,6 +5338,7 @@ impl<T: Config> P2PSession<T> {
     /// [`InternalErrorKind::IndexOutOfBounds`]: crate::error::InternalErrorKind::IndexOutOfBounds
     #[must_use = "remove_player errors should be handled"]
     pub fn remove_player(&mut self, player_handle: PlayerHandle) -> Result<(), FortressError> {
+        let _violation_scope = self.scoped_violation_observer();
         let player_type = self.player_reg.handles.get(&player_handle).ok_or(
             InvalidRequestKind::DisconnectInvalidHandle {
                 handle: player_handle,
@@ -5440,6 +5450,7 @@ impl<T: Config> P2PSession<T> {
     /// [`InternalErrorKind::DisconnectStatusNotFound`]: crate::error::InternalErrorKind::DisconnectStatusNotFound
     #[must_use = "disconnect errors should be handled"]
     pub fn disconnect_player(&mut self, player_handle: PlayerHandle) -> Result<(), FortressError> {
+        let _violation_scope = self.scoped_violation_observer();
         match self.player_reg.handles.get(&player_handle) {
             // the local player cannot be disconnected
             None => Err(InvalidRequestKind::DisconnectInvalidHandle {
@@ -5672,6 +5683,13 @@ impl<T: Config> P2PSession<T> {
     /// decreases.
     #[must_use]
     pub fn confirmed_frame(&self) -> Frame {
+        // This public accessor can itself emit a violation (the all-disconnected
+        // fallback below), and it is also reachable directly (not only via the
+        // already-scoped `advance_frame`/`poll_remote_clients`), so it installs
+        // the per-session observer scope too. When no observer is configured this
+        // is a cheap `Option` check (no push), so it adds no cost to the common
+        // path; nested under a driver method's scope it is a harmless re-push.
+        let _violation_scope = self.scoped_violation_observer();
         let mut confirmed_frame = Frame::new(i32::MAX);
 
         // The double-failure-relay fold-membership-asymmetry gate is
@@ -6463,6 +6481,7 @@ impl<T: Config> P2PSession<T> {
         player_handle: PlayerHandle,
         delay: usize,
     ) -> Result<(), FortressError> {
+        let _violation_scope = self.scoped_violation_observer();
         if !self.player_reg.is_local_player(player_handle) {
             return Err(InvalidRequestKind::NotLocalPlayer {
                 handle: player_handle,
@@ -6604,19 +6623,41 @@ impl<T: Config> P2PSession<T> {
 
     /// Returns a reference to the violation observer, if one was configured.
     ///
-    /// Note that `P2PSession`'s violation paths currently report through the
-    /// `tracing`-backed default observer and do **not** invoke this
-    /// per-session observer yet (see
-    /// [`SessionBuilder::with_violation_observer`] for the current routing
-    /// per session type); a [`CollectingObserver`] attached here therefore
-    /// stays empty for now. Routing P2P violations to the per-session
-    /// observer is tracked future work.
+    /// While any public, state-driving method of this session is executing
+    /// (e.g. [`advance_frame`](Self::advance_frame),
+    /// [`poll_remote_clients`](Self::poll_remote_clients),
+    /// [`add_local_input`](Self::add_local_input)), every `report_violation!`
+    /// emitted beneath it — including from the low-level `input_queue`,
+    /// `sync_layer`, and `protocol` components — is routed to this observer
+    /// instead of the default `tracing`-backed observer, via a thread-local
+    /// scope installed for the duration of the call (see
+    /// [`push_violation_observer`]). A [`CollectingObserver`] attached here
+    /// therefore captures violations raised during session operations.
     ///
     /// [`CollectingObserver`]: crate::telemetry::CollectingObserver
+    /// [`push_violation_observer`]: crate::telemetry::push_violation_observer
     /// [`SessionBuilder::with_violation_observer`]: crate::SessionBuilder::with_violation_observer
     #[must_use]
     pub fn violation_observer(&self) -> Option<&Arc<dyn ViolationObserver>> {
         self.violation_observer.as_ref()
+    }
+
+    /// Installs the session's configured violation observer (if any) as the
+    /// current thread's scoped observer for the duration of a public entry
+    /// point, so every `report_violation!` emitted beneath it routes to the
+    /// per-session observer. Returns `None` (a no-op — violations fall back to
+    /// the default `TracingObserver`) when no observer was configured.
+    ///
+    /// Hold the returned guard in a local (`let _scope = …;`) for the whole
+    /// method body. Nested entry points (e.g. `advance_frame` calling
+    /// `poll_remote_clients`) push the same observer twice and pop in LIFO
+    /// order, which is harmless.
+    #[inline]
+    #[must_use]
+    fn scoped_violation_observer(&self) -> Option<crate::telemetry::ScopedObserverGuard> {
+        self.violation_observer
+            .as_ref()
+            .map(|observer| crate::telemetry::push_violation_observer(Arc::clone(observer)))
     }
 
     /// Returns a reference to the telemetry observer, if one is attached.
@@ -10868,6 +10909,89 @@ mod tests {
             .expect("Failed to add remote player D")
             .start_p2p_session(DummySocket)
             .expect("Failed to create session")
+    }
+
+    /// session-59: `P2PSession` routes a `report_violation!` emitted while a
+    /// public entry point is executing to the **per-session** violation observer
+    /// configured via [`SessionBuilder::with_violation_observer`]. Before the
+    /// thread-local scoped-observer wiring, P2P violations went only to the
+    /// global `TracingObserver`, so a [`CollectingObserver`] attached to the
+    /// session stayed empty (the released API promise was false — see the audit
+    /// `with_violation_observer` P2P-gap item).
+    ///
+    /// This drives the B3 checksum-mismatch trust-downgrade WARNING through the
+    /// **public** [`advance_frame`](P2PSession::advance_frame) path (which calls
+    /// `compare_local_checksums_against_peers` under the scoped-observer guard)
+    /// and asserts the per-session observer captured exactly that one WARNING.
+    ///
+    /// NON-VACUITY: deleting the `let _violation_scope = self.scoped_violation_observer();`
+    /// guard from `advance_frame` leaves the observer empty and fails this test.
+    #[test]
+    fn p2p_advance_frame_routes_report_violation_to_session_observer() {
+        let observer = Arc::new(crate::telemetry::CollectingObserver::new());
+        let addr_b = test_addr(8080);
+        let mut session = SessionBuilder::<TestConfig>::new()
+            .with_num_players(3)
+            .unwrap()
+            .with_desync_detection_mode(DesyncDetection::On { interval: 1 })
+            .with_violation_observer(observer.clone())
+            .add_player(PlayerType::Local, PlayerHandle::new(0))
+            .unwrap()
+            .add_player(PlayerType::Remote(addr_b), PlayerHandle::new(1))
+            .unwrap()
+            .add_player(PlayerType::Remote(test_addr(8081)), PlayerHandle::new(2))
+            .unwrap()
+            .start_p2p_session(DummySocket)
+            .expect("Failed to create session");
+
+        // Advance the sync layer so frame 0 is comparable (the comparison skips
+        // frames >= last_confirmed_frame) and force Running so advance_frame runs
+        // its desync-detection block (DummySocket never synchronizes on its own).
+        session.sync_layer.advance_frame();
+        session.sync_layer.advance_frame();
+        session
+            .sync_layer
+            .set_last_confirmed_frame(Frame::new(2), session.save_mode);
+        session.state = SessionState::Running;
+
+        // Arm B one mismatch below the trust-downgrade threshold, then plant a
+        // mismatching confirmed-frame checksum so the next comparison crosses the
+        // threshold and fires exactly one WARNING.
+        let frame = Frame::new(0);
+        session.local_checksum_history.insert(frame, 0xABCD_1234);
+        {
+            let b = session
+                .player_reg
+                .remotes
+                .get_mut(&addr_b)
+                .expect("B endpoint exists");
+            b.checksum_mismatch_count = CHECKSUM_MISMATCH_TRUST_DOWNGRADE_THRESHOLD - 1;
+            b.pending_checksums.insert(frame, 0x0000_0001); // differs from local
+        }
+
+        session
+            .add_local_input(PlayerHandle::new(0), 0)
+            .expect("local input accepted");
+        // The desync-detection comparison runs inside advance_frame, under the
+        // scoped-observer guard, BEFORE the rest of the advance can error. We
+        // only assert the violation routed, so either outcome is acceptable —
+        // handled explicitly (the result is deliberately not propagated).
+        match session.advance_frame() {
+            Ok(_) | Err(_) => {},
+        }
+
+        let downgrades: Vec<_> = observer
+            .violations()
+            .into_iter()
+            .filter(|v| v.kind == crate::telemetry::ViolationKind::ChecksumMismatch)
+            .collect();
+        assert_eq!(
+            downgrades.len(),
+            1,
+            "the B3 trust-downgrade WARNING emitted inside advance_frame must reach \
+             the per-session observer; got: {:?}",
+            observer.violations()
+        );
     }
 
     /// F12 regression: with N>=3, a matching checksum from ONE remote (B) must not

--- a/src/sessions/p2p_spectator_session.rs
+++ b/src/sessions/p2p_spectator_session.rs
@@ -490,6 +490,7 @@ impl<T: Config> SpectatorSession<T> {
     /// Returns the number of frames behind the host
     #[must_use]
     pub fn frames_behind_host(&self) -> usize {
+        let _violation_scope = self.scoped_violation_observer();
         // Gracefully handle the case where current_frame somehow exceeds last_recv_frame.
         // This shouldn't happen in normal operation, but we report it and return 0 rather than panic.
         if self.current_frame > self.last_recv_frame {
@@ -587,6 +588,29 @@ impl<T: Config> SpectatorSession<T> {
         self.violation_observer.as_ref()
     }
 
+    /// Installs the session's configured violation observer (if any) as the
+    /// current thread's scoped observer for the duration of a public entry
+    /// point, so every `report_violation!` emitted beneath it routes to the
+    /// per-session observer. Returns `None` (a no-op — violations fall back to
+    /// the default [`TracingObserver`]) when no observer was configured.
+    ///
+    /// Mirrors the scoping in [`P2PSession`] and [`SyncTestSession`]. Nested
+    /// entry points (e.g. `advance_frame` calling `poll_remote_clients`) push
+    /// the same observer twice and pop in LIFO order, which is harmless. Sites
+    /// that already hold the observer in hand use `report_violation_to!` and
+    /// route directly regardless of this scope.
+    ///
+    /// [`TracingObserver`]: crate::telemetry::TracingObserver
+    /// [`P2PSession`]: crate::P2PSession
+    /// [`SyncTestSession`]: crate::SyncTestSession
+    #[inline]
+    #[must_use]
+    fn scoped_violation_observer(&self) -> Option<crate::telemetry::ScopedObserverGuard> {
+        self.violation_observer
+            .as_ref()
+            .map(|observer| crate::telemetry::push_violation_observer(Arc::clone(observer)))
+    }
+
     /// Computes the request-batch preallocation capacity for [`advance_frame`].
     ///
     /// `frames_to_advance` is clamped to `buffer_size` because the advance loop
@@ -623,6 +647,7 @@ impl<T: Config> SpectatorSession<T> {
     /// [`NotSynchronized`]: FortressError::NotSynchronized
     #[must_use = "FortressRequests must be processed to advance the game state"]
     pub fn advance_frame(&mut self) -> FortressResult<RequestVec<T>> {
+        let _violation_scope = self.scoped_violation_observer();
         if let Some(err) = self.spectator_divergence_error() {
             return Err(err);
         }
@@ -802,6 +827,7 @@ impl<T: Config> SpectatorSession<T> {
     /// [`SpectatorConfig::enable_rewind`]: crate::SpectatorConfig::enable_rewind
     #[must_use = "FortressRequests must be processed to seek the game state"]
     pub fn seek_to_frame(&mut self, target_frame: Frame) -> FortressResult<RequestVec<T>> {
+        let _violation_scope = self.scoped_violation_observer();
         if !self.enable_rewind {
             return Err(InvalidRequestKind::NotSupported {
                 operation: "seek_to_frame",
@@ -855,6 +881,7 @@ impl<T: Config> SpectatorSession<T> {
     /// Receive UDP packages, distribute them to corresponding UDP endpoints, handle all occurring events and send all outgoing UDP packages.
     /// Should be called periodically by your application to give Fortress Rollback a chance to do internal work like packet transmissions.
     pub fn poll_remote_clients(&mut self) {
+        let _violation_scope = self.scoped_violation_observer();
         // Get all udp packets and distribute them to associated endpoints.
         // The endpoints will handle their packets, which will trigger both events and UDP replies.
         // Route each message to the FIRST host that claims to handle it, then stop.
@@ -3092,6 +3119,45 @@ mod tests {
             .violations()
             .iter()
             .any(|violation| violation.kind == ViolationKind::FrameSync));
+    }
+
+    #[test]
+    fn spectator_frames_behind_host_routes_report_violation_to_session_observer() {
+        use crate::telemetry::CollectingObserver;
+
+        let observer = Arc::new(CollectingObserver::new());
+        let mut session: SpectatorSession<TestConfig> = SessionBuilder::new()
+            .with_num_players(2)
+            .unwrap()
+            .with_violation_observer(observer.clone())
+            .start_spectator_session(test_addr(7350), DummySocket)
+            .unwrap();
+
+        // Force the defensive guard `current_frame > last_recv_frame`. That site
+        // uses the plain `report_violation!` macro (which routes through the
+        // thread-local scoped observer), unlike the session's `report_violation_to!`
+        // sites which carry the observer explicitly. Without a scope installed at
+        // this entry point the violation reaches only the default `TracingObserver`
+        // and never the per-session observer configured via
+        // `with_violation_observer` — the gap this test pins.
+        session.current_frame = Frame::new(10);
+        session.last_recv_frame = Frame::new(5);
+
+        let behind = session.frames_behind_host();
+        assert_eq!(
+            behind, 0,
+            "frames_behind_host returns 0 when current_frame exceeds last_recv_frame"
+        );
+
+        // NON-VACUITY: deleting the `let _violation_scope = self.scoped_violation_observer();`
+        // line from `frames_behind_host` makes this assertion fail.
+        assert!(
+            observer
+                .violations()
+                .iter()
+                .any(|violation| violation.kind == ViolationKind::FrameSync),
+            "frames_behind_host violation must route to the per-session observer"
+        );
     }
 
     #[test]

--- a/src/sessions/sync_test_session.rs
+++ b/src/sessions/sync_test_session.rs
@@ -75,6 +75,11 @@ impl<T: Config> SyncTestSession<T> {
         violation_observer: Option<Arc<dyn ViolationObserver>>,
         queue_length: usize,
     ) -> Self {
+        // Route construction-time violations (e.g. a failed frame-delay setup)
+        // to the configured observer, the same as runtime entry points do.
+        let _violation_scope = violation_observer
+            .as_ref()
+            .map(|observer| crate::telemetry::push_violation_observer(Arc::clone(observer)));
         match Self::try_with_queue_length(
             num_players,
             max_prediction,
@@ -166,6 +171,7 @@ impl<T: Config> SyncTestSession<T> {
         player_handle: PlayerHandle,
         input: T::Input,
     ) -> Result<(), FortressError> {
+        let _violation_scope = self.scoped_violation_observer();
         if !player_handle.is_valid_player_for(self.num_players) {
             return Err(InvalidRequestKind::InvalidLocalPlayerHandle {
                 handle: player_handle,
@@ -189,6 +195,7 @@ impl<T: Config> SyncTestSession<T> {
     /// [`MismatchedChecksum`]: FortressError::MismatchedChecksum
     #[must_use = "FortressRequests must be processed to advance the game state"]
     pub fn advance_frame(&mut self) -> FortressResult<RequestVec<T>> {
+        let _violation_scope = self.scoped_violation_observer();
         // SmallVec inline capacity of 4 covers the typical case (save + advance)
         // without heap allocation. During rollback testing, it spills to the heap as needed.
         let mut requests = RequestVec::<T>::new();
@@ -306,6 +313,20 @@ impl<T: Config> SyncTestSession<T> {
     #[must_use]
     pub fn violation_observer(&self) -> Option<&Arc<dyn ViolationObserver>> {
         self.violation_observer.as_ref()
+    }
+
+    /// Installs the session's configured violation observer (if any) as the
+    /// current thread's scoped observer for the duration of a public entry
+    /// point, so every `report_violation!` emitted beneath it routes to the
+    /// per-session observer. Returns `None` (a no-op — violations fall back to
+    /// the default `TracingObserver`) when no observer was configured. See
+    /// [`push_violation_observer`](crate::telemetry::push_violation_observer).
+    #[inline]
+    #[must_use]
+    fn scoped_violation_observer(&self) -> Option<crate::telemetry::ScopedObserverGuard> {
+        self.violation_observer
+            .as_ref()
+            .map(|observer| crate::telemetry::push_violation_observer(Arc::clone(observer)))
     }
 
     /// Returns handles for all players in the session.
@@ -674,6 +695,34 @@ mod tests {
         let session: SyncTestSession<TestConfig> = SyncTestSession::new(2, 8, 2, 2, Some(observer));
 
         assert!(session.violation_observer().is_some());
+    }
+
+    /// session-59: a `report_violation!` emitted during construction (here, a
+    /// failed per-player frame-delay setup) routes to the per-session observer —
+    /// `with_queue_length` installs a scoped observer for the duration of
+    /// construction, the same way the runtime entry points do. Before the
+    /// thread-local scoped-observer wiring this went only to the global
+    /// `TracingObserver`, so a `CollectingObserver` attached here stayed empty.
+    ///
+    /// NON-VACUITY: removing the construction-time scope push leaves the observer
+    /// empty and fails this test.
+    #[test]
+    fn sync_test_construction_violation_routes_to_session_observer() {
+        let observer = Arc::new(CollectingObserver::new());
+        // queue_length 8 => max_frame_delay 7; an input_delay of 100 exceeds it,
+        // so the per-player set_frame_delay fails during construction and reports
+        // a violation (logged, non-fatal — construction still succeeds).
+        let session: SyncTestSession<TestConfig> =
+            SyncTestSession::with_queue_length(2, 4, 2, 100, Some(observer.clone()), 8);
+
+        assert!(
+            session.violation_observer().is_some(),
+            "construction succeeded (the frame-delay failure is non-fatal)"
+        );
+        assert!(
+            !observer.violations().is_empty(),
+            "construction-time report_violation! must reach the per-session observer"
+        );
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -24,7 +24,9 @@
 use crate::network::network_stats::NetworkStats;
 use crate::sync::Mutex;
 use crate::{Frame, PlayerHandle};
+use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 /// Custom serializer for `Option<Frame>` that outputs clean integers or null.
@@ -788,14 +790,13 @@ macro_rules! report_violation {
     ($severity:expr, $kind:expr, $msg:literal) => {{
         #[cfg(not(kani))]
         {
-            use $crate::telemetry::ViolationObserver as _;
             let violation = $crate::telemetry::SpecViolation::new(
                 $severity,
                 $kind,
                 $msg,
                 concat!(file!(), ":", line!()),
             );
-            $crate::telemetry::TracingObserver.on_violation(&violation);
+            $crate::telemetry::report_to_current_observer(&violation);
         }
         // Under Kani, borrow severity and kind to suppress unused import warnings
         // for ViolationSeverity/ViolationKind, but avoid format!() and tracing
@@ -810,14 +811,13 @@ macro_rules! report_violation {
     ($severity:expr, $kind:expr, $fmt:literal, $($arg:tt)+) => {{
         #[cfg(not(kani))]
         {
-            use $crate::telemetry::ViolationObserver as _;
             let violation = $crate::telemetry::SpecViolation::new(
                 $severity,
                 $kind,
                 format!($fmt, $($arg)+),
                 concat!(file!(), ":", line!()),
             );
-            $crate::telemetry::TracingObserver.on_violation(&violation);
+            $crate::telemetry::report_to_current_observer(&violation);
         }
         // Under Kani, borrow format arguments so non-Copy values are not moved
         // and unused-variable lints stay quiet. Accept `tt` here to preserve
@@ -1025,6 +1025,107 @@ pub fn report_to_observer<O: ViolationObserver + ?Sized>(
 ) {
     match observer {
         Some(obs) => obs.on_violation(violation),
+        None => TracingObserver.on_violation(violation),
+    }
+}
+
+thread_local! {
+    /// Per-thread stack of violation observers installed for the duration of a
+    /// session method call.
+    ///
+    /// The [`report_violation!`] macro consults the **top** of this stack via
+    /// [`report_to_current_observer`], falling back to [`TracingObserver`] when
+    /// it is empty. This is the ambient-context shim that lets a session route
+    /// `report_violation!` calls — emitted by low-level components
+    /// (`input_queue`, `sync_layer`, `protocol`, …) that hold no reference to the
+    /// session — to its configured [`ViolationObserver`] without threading the
+    /// observer through every one of the hundreds of call sites. A session
+    /// installs its observer with [`push_violation_observer`] at the top of each
+    /// public entry point (e.g. `advance_frame`, `poll_remote_clients`) and the
+    /// returned [`ScopedObserverGuard`] uninstalls it when the call returns.
+    ///
+    /// Thread-local, so it is parallel-test-safe and never observed across
+    /// threads; a violation emitted on a thread with no installed observer (e.g.
+    /// a background socket thread) routes to `TracingObserver` exactly as before.
+    static CURRENT_OBSERVER: RefCell<Vec<Arc<dyn ViolationObserver>>> = RefCell::new(Vec::new());
+}
+
+/// RAII guard returned by [`push_violation_observer`]. Pops the installed
+/// observer off the current thread's scoped-observer stack when dropped.
+///
+/// Guards must be dropped in reverse install order (the natural LIFO order of
+/// stack-allocated `let _guard = …` bindings), which sessions guarantee by
+/// holding the guard as a local for the duration of a single method call. The
+/// guard is intentionally **not** `Send`/`Sync`: moving it to another thread
+/// would pop the wrong thread's stack.
+#[must_use = "the scoped observer is uninstalled as soon as this guard is dropped"]
+pub struct ScopedObserverGuard {
+    // Make the guard `!Send` + `!Sync` so it cannot leave the installing thread.
+    _not_send: PhantomData<*const ()>,
+}
+
+impl Drop for ScopedObserverGuard {
+    fn drop(&mut self) {
+        CURRENT_OBSERVER.with(|stack| {
+            stack.borrow_mut().pop();
+        });
+    }
+}
+
+impl std::fmt::Debug for ScopedObserverGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScopedObserverGuard").finish()
+    }
+}
+
+/// Installs `observer` as the current thread's scoped violation observer until
+/// the returned [`ScopedObserverGuard`] is dropped.
+///
+/// While installed, the [`report_violation!`] macro routes violations to
+/// `observer` instead of the default [`TracingObserver`]. Installs nest: each
+/// call pushes onto a per-thread stack and the **innermost** observer receives
+/// violations; dropping a guard restores the previously-installed observer. This
+/// is the mechanism behind [`SessionBuilder::with_violation_observer`] for
+/// `P2PSession` and `SyncTestSession`.
+///
+/// [`SessionBuilder::with_violation_observer`]: crate::SessionBuilder::with_violation_observer
+///
+/// # Example
+///
+/// ```
+/// use fortress_rollback::{report_violation, telemetry::{
+///     push_violation_observer, CollectingObserver, ViolationKind, ViolationSeverity,
+/// }};
+/// use std::sync::Arc;
+///
+/// let observer = Arc::new(CollectingObserver::new());
+/// {
+///     let _guard = push_violation_observer(observer.clone());
+///     report_violation!(ViolationSeverity::Warning, ViolationKind::FrameSync, "scoped");
+/// }
+/// assert_eq!(observer.len(), 1);
+/// ```
+pub fn push_violation_observer(observer: Arc<dyn ViolationObserver>) -> ScopedObserverGuard {
+    CURRENT_OBSERVER.with(|stack| stack.borrow_mut().push(observer));
+    ScopedObserverGuard {
+        _not_send: PhantomData,
+    }
+}
+
+/// Routes `violation` to the current thread's installed scoped observer (the top
+/// of the [`push_violation_observer`] stack), or to [`TracingObserver`] when no
+/// observer is installed.
+///
+/// This is the dispatch target of the [`report_violation!`] macro. The active
+/// observer's `Arc` is cloned out and the thread-local borrow released **before**
+/// `on_violation` is invoked, so an observer whose `on_violation` itself calls
+/// `report_violation!` cannot trigger a `RefCell` double-borrow.
+#[cold]
+#[inline(never)]
+pub fn report_to_current_observer(violation: &SpecViolation) {
+    let current = CURRENT_OBSERVER.with(|stack| stack.borrow().last().cloned());
+    match current {
+        Some(observer) => observer.on_violation(violation),
         None => TracingObserver.on_violation(violation),
     }
 }
@@ -3130,5 +3231,147 @@ mod tests {
         assert_eq!(telemetry.frame_advances().len(), 2);
         assert_eq!(telemetry.rollbacks().len(), 1);
         assert_eq!(telemetry.prediction_misses().len(), 1);
+    }
+
+    // ==========================================
+    // Scoped (thread-local) observer routing tests
+    // ==========================================
+    //
+    // These pin the contract that `report_violation!` routes to the
+    // thread-local observer installed by `push_violation_observer` (the ambient
+    // context shim sessions use so low-level components reach the per-session
+    // observer without threading it through every call site). Before the routing
+    // change, `report_violation!` unconditionally targeted `TracingObserver`, so
+    // the pushed observer received nothing — these are the red tests.
+
+    #[test]
+    fn report_violation_routes_to_pushed_thread_local_observer() {
+        let observer = Arc::new(CollectingObserver::new());
+        {
+            let _guard = push_violation_observer(observer.clone());
+            report_violation!(
+                ViolationSeverity::Warning,
+                ViolationKind::FrameSync,
+                "scoped {}",
+                1
+            );
+            report_violation!(
+                ViolationSeverity::Error,
+                ViolationKind::InputQueue,
+                "scoped no-args"
+            );
+        }
+        assert_eq!(
+            observer.len(),
+            2,
+            "report_violation! must route to the installed scoped observer"
+        );
+    }
+
+    #[test]
+    fn report_violation_falls_back_to_tracing_when_no_observer_installed() {
+        // With no observer pushed, the pushed-elsewhere observer must NOT receive
+        // anything (the macro falls back to TracingObserver). We prove this by
+        // popping the guard and confirming subsequent violations are not captured.
+        let observer = Arc::new(CollectingObserver::new());
+        {
+            let _guard = push_violation_observer(observer.clone());
+            report_violation!(
+                ViolationSeverity::Warning,
+                ViolationKind::FrameSync,
+                "inside scope"
+            );
+        }
+        // Guard dropped: stack is empty again, fallback to TracingObserver.
+        report_violation!(
+            ViolationSeverity::Warning,
+            ViolationKind::FrameSync,
+            "outside scope"
+        );
+        assert_eq!(
+            observer.len(),
+            1,
+            "only the in-scope violation should reach the observer; \
+             the post-drop violation must fall back to TracingObserver"
+        );
+    }
+
+    #[test]
+    fn nested_scoped_observers_route_to_innermost_then_restore() {
+        let outer = Arc::new(CollectingObserver::new());
+        let inner = Arc::new(CollectingObserver::new());
+        let outer_guard = push_violation_observer(outer.clone());
+        report_violation!(
+            ViolationSeverity::Warning,
+            ViolationKind::FrameSync,
+            "to outer"
+        );
+        {
+            let _inner_guard = push_violation_observer(inner.clone());
+            report_violation!(
+                ViolationSeverity::Warning,
+                ViolationKind::FrameSync,
+                "to inner"
+            );
+        }
+        // Inner guard dropped: routing restored to the outer observer.
+        report_violation!(
+            ViolationSeverity::Warning,
+            ViolationKind::FrameSync,
+            "to outer again"
+        );
+        drop(outer_guard);
+        assert_eq!(
+            outer.len(),
+            2,
+            "outer observer gets the two outer-scope violations"
+        );
+        assert_eq!(
+            inner.len(),
+            1,
+            "inner observer gets only the inner-scope violation"
+        );
+    }
+
+    #[test]
+    fn reentrant_report_from_observer_does_not_deadlock() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // An observer whose on_violation itself calls report_violation! must not
+        // deadlock on the thread-local borrow: the dispatcher clones the active
+        // Arc out and releases the RefCell borrow BEFORE invoking on_violation,
+        // so a re-entrant report is safe. A lock-free counter is used so the test
+        // does not itself deadlock on a non-reentrant lock held across re-entry.
+        struct ReentrantObserver {
+            seen: AtomicUsize,
+        }
+        impl ViolationObserver for ReentrantObserver {
+            fn on_violation(&self, _violation: &SpecViolation) {
+                // First entry re-enters once; the re-entry stops the recursion.
+                if self.seen.fetch_add(1, Ordering::SeqCst) == 0 {
+                    report_violation!(
+                        ViolationSeverity::Warning,
+                        ViolationKind::FrameSync,
+                        "reentrant"
+                    );
+                }
+            }
+        }
+        let observer = Arc::new(ReentrantObserver {
+            seen: AtomicUsize::new(0),
+        });
+        {
+            let _guard = push_violation_observer(observer.clone());
+            report_violation!(
+                ViolationSeverity::Warning,
+                ViolationKind::FrameSync,
+                "outer reentrant trigger"
+            );
+        }
+        assert_eq!(
+            observer.seen.load(Ordering::SeqCst),
+            2,
+            "the re-entrant violation must also route to the observer (no deadlock)"
+        );
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -27,6 +27,7 @@ use crate::{Frame, PlayerHandle};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
+use std::rc::Rc;
 use std::sync::Arc;
 
 /// Custom serializer for `Option<Frame>` that outputs clean integers or null.
@@ -1029,6 +1030,49 @@ pub fn report_to_observer<O: ViolationObserver + ?Sized>(
     }
 }
 
+struct ScopedObserverEntry {
+    token: u64,
+    observer: Arc<dyn ViolationObserver>,
+}
+
+#[derive(Default)]
+struct ScopedObserverStack {
+    next_token: u64,
+    entries: Vec<ScopedObserverEntry>,
+}
+
+impl ScopedObserverStack {
+    fn push(&mut self, observer: Arc<dyn ViolationObserver>) -> u64 {
+        let token = self.next_token;
+        self.next_token = self.next_token.wrapping_add(1);
+        // alloc-bound: scoped observer stack depth is bounded by same-thread
+        // nested observer scopes; every entry is removed by its guard's Drop.
+        self.entries.push(ScopedObserverEntry { token, observer });
+        token
+    }
+
+    fn remove(&mut self, token: u64) -> Option<ScopedObserverEntry> {
+        let position = self
+            .entries
+            .iter()
+            .rposition(|entry| entry.token == token)?;
+        Some(self.entries.remove(position))
+    }
+
+    fn current_observer(&self) -> Option<Arc<dyn ViolationObserver>> {
+        self.entries.last().map(|entry| Arc::clone(&entry.observer))
+    }
+}
+
+fn report_scoped_observer_drop_failure() {
+    TracingObserver.on_violation(&SpecViolation::new(
+        ViolationSeverity::Critical,
+        ViolationKind::InternalError,
+        "scoped observer guard could not borrow the thread-local observer stack during drop",
+        "src/telemetry.rs:ScopedObserverGuard::drop",
+    ));
+}
+
 thread_local! {
     /// Per-thread stack of violation observers installed for the duration of a
     /// session method call.
@@ -1047,28 +1091,69 @@ thread_local! {
     /// Thread-local, so it is parallel-test-safe and never observed across
     /// threads; a violation emitted on a thread with no installed observer (e.g.
     /// a background socket thread) routes to `TracingObserver` exactly as before.
-    static CURRENT_OBSERVER: RefCell<Vec<Arc<dyn ViolationObserver>>> = RefCell::new(Vec::new());
+    static CURRENT_OBSERVER: RefCell<ScopedObserverStack> = RefCell::new(ScopedObserverStack::default());
 }
 
-/// RAII guard returned by [`push_violation_observer`]. Pops the installed
-/// observer off the current thread's scoped-observer stack when dropped.
+/// RAII guard returned by [`push_violation_observer`]. Removes the installed
+/// observer from the current thread's scoped-observer stack when dropped.
 ///
-/// Guards must be dropped in reverse install order (the natural LIFO order of
-/// stack-allocated `let _guard = …` bindings), which sessions guarantee by
-/// holding the guard as a local for the duration of a single method call. The
-/// guard is intentionally **not** `Send`/`Sync`: moving it to another thread
-/// would pop the wrong thread's stack.
+/// Guards normally drop in reverse install order (the natural LIFO order of
+/// stack-allocated `let _guard = …` bindings), which sessions get by holding the
+/// guard as a local for the duration of a single method call. Out-of-order drops
+/// on the same thread remove that guard's own observer entry rather than popping
+/// an unrelated nested observer. The guard is intentionally **not** `Send`/`Sync`:
+/// moving it to another thread would remove from the wrong thread's stack.
+///
+/// # Compile-time thread affinity
+///
+/// A guard cannot be moved to another thread:
+///
+/// ```compile_fail
+/// use fortress_rollback::telemetry::{
+///     push_violation_observer, CollectingObserver, ViolationObserver,
+/// };
+/// use std::sync::Arc;
+///
+/// let observer: Arc<dyn ViolationObserver> = Arc::new(CollectingObserver::new());
+/// let guard = push_violation_observer(observer);
+/// let _handle = std::thread::spawn(move || drop(guard));
+/// ```
+///
+/// A guard also cannot be shared with another thread by reference:
+///
+/// ```compile_fail
+/// use fortress_rollback::telemetry::{
+///     push_violation_observer, CollectingObserver, ViolationObserver,
+/// };
+/// use std::sync::Arc;
+///
+/// let observer: Arc<dyn ViolationObserver> = Arc::new(CollectingObserver::new());
+/// let guard = push_violation_observer(observer);
+/// std::thread::scope(|scope| {
+///     scope.spawn(|| {
+///         let _guard_ref = &guard;
+///     });
+/// });
+/// ```
 #[must_use = "the scoped observer is uninstalled as soon as this guard is dropped"]
 pub struct ScopedObserverGuard {
+    token: u64,
     // Make the guard `!Send` + `!Sync` so it cannot leave the installing thread.
-    _not_send: PhantomData<*const ()>,
+    _not_send: PhantomData<Rc<()>>,
 }
 
 impl Drop for ScopedObserverGuard {
     fn drop(&mut self) {
-        CURRENT_OBSERVER.with(|stack| {
-            stack.borrow_mut().pop();
+        let removed = CURRENT_OBSERVER.try_with(|stack| {
+            if let Ok(mut stack) = stack.try_borrow_mut() {
+                stack.remove(self.token)
+            } else {
+                report_scoped_observer_drop_failure();
+                None
+            }
         });
+        let removed = removed.unwrap_or(None);
+        drop(removed);
     }
 }
 
@@ -1084,9 +1169,11 @@ impl std::fmt::Debug for ScopedObserverGuard {
 /// While installed, the [`report_violation!`] macro routes violations to
 /// `observer` instead of the default [`TracingObserver`]. Installs nest: each
 /// call pushes onto a per-thread stack and the **innermost** observer receives
-/// violations; dropping a guard restores the previously-installed observer. This
-/// is the mechanism behind [`SessionBuilder::with_violation_observer`] for
-/// `P2PSession` and `SyncTestSession`.
+/// violations; dropping a guard removes that guard's observer, so normal LIFO
+/// drops restore the previously-installed observer and same-thread out-of-order
+/// drops leave newer observers active. This is the mechanism behind
+/// [`SessionBuilder::with_violation_observer`] for `P2PSession`,
+/// `SyncTestSession`, and `SpectatorSession`.
 ///
 /// [`SessionBuilder::with_violation_observer`]: crate::SessionBuilder::with_violation_observer
 ///
@@ -1106,8 +1193,9 @@ impl std::fmt::Debug for ScopedObserverGuard {
 /// assert_eq!(observer.len(), 1);
 /// ```
 pub fn push_violation_observer(observer: Arc<dyn ViolationObserver>) -> ScopedObserverGuard {
-    CURRENT_OBSERVER.with(|stack| stack.borrow_mut().push(observer));
+    let token = CURRENT_OBSERVER.with(|stack| stack.borrow_mut().push(observer));
     ScopedObserverGuard {
+        token,
         _not_send: PhantomData,
     }
 }
@@ -1123,7 +1211,7 @@ pub fn push_violation_observer(observer: Arc<dyn ViolationObserver>) -> ScopedOb
 #[cold]
 #[inline(never)]
 pub fn report_to_current_observer(violation: &SpecViolation) {
-    let current = CURRENT_OBSERVER.with(|stack| stack.borrow().last().cloned());
+    let current = CURRENT_OBSERVER.with(|stack| stack.borrow().current_observer());
     match current {
         Some(observer) => observer.on_violation(violation),
         None => TracingObserver.on_violation(violation),
@@ -3331,6 +3419,106 @@ mod tests {
             1,
             "inner observer gets only the inner-scope violation"
         );
+    }
+
+    #[test]
+    fn out_of_order_scoped_observer_drop_removes_matching_scope() {
+        let outer = Arc::new(CollectingObserver::new());
+        let inner = Arc::new(CollectingObserver::new());
+
+        let outer_guard = push_violation_observer(outer.clone());
+        report_violation!(
+            ViolationSeverity::Warning,
+            ViolationKind::FrameSync,
+            "to outer before nested scope"
+        );
+
+        let inner_guard = push_violation_observer(inner.clone());
+        drop(outer_guard);
+
+        report_violation!(
+            ViolationSeverity::Warning,
+            ViolationKind::FrameSync,
+            "still to inner after out-of-order outer drop"
+        );
+
+        drop(inner_guard);
+        report_violation!(
+            ViolationSeverity::Warning,
+            ViolationKind::FrameSync,
+            "to tracing after both guards dropped"
+        );
+
+        assert_eq!(
+            outer.len(),
+            1,
+            "dropping the outer guard out of order must not pop the inner observer"
+        );
+        assert_eq!(
+            inner.len(),
+            1,
+            "the inner observer should remain installed until its own guard is dropped"
+        );
+    }
+
+    #[test]
+    fn pushed_observer_is_thread_local_to_installing_thread() {
+        let observer = Arc::new(CollectingObserver::new());
+        let _guard = push_violation_observer(observer.clone());
+
+        let child = std::thread::spawn(|| {
+            report_violation!(
+                ViolationSeverity::Warning,
+                ViolationKind::FrameSync,
+                "child thread"
+            );
+        });
+        assert!(child.join().is_ok(), "child thread should not panic");
+
+        report_violation!(
+            ViolationSeverity::Warning,
+            ViolationKind::FrameSync,
+            "installing thread"
+        );
+
+        assert_eq!(
+            observer.len(),
+            1,
+            "the pushed observer must only capture violations from the installing thread"
+        );
+    }
+
+    #[test]
+    fn observer_dropped_by_scope_can_report_without_refcell_panic() {
+        struct DropReportingObserver;
+
+        impl ViolationObserver for DropReportingObserver {
+            fn on_violation(&self, _violation: &SpecViolation) {}
+        }
+
+        impl Drop for DropReportingObserver {
+            fn drop(&mut self) {
+                report_violation!(
+                    ViolationSeverity::Warning,
+                    ViolationKind::InternalError,
+                    "observer drop reported"
+                );
+            }
+        }
+
+        let outer = Arc::new(CollectingObserver::new());
+        let outer_guard = push_violation_observer(outer.clone());
+        let inner_guard = push_violation_observer(Arc::new(DropReportingObserver));
+
+        drop(inner_guard);
+
+        assert_eq!(
+            outer.len(),
+            1,
+            "observer destructors must be able to report after their scope is removed"
+        );
+
+        drop(outer_guard);
     }
 
     #[test]

--- a/tests/common/filter_socket.rs
+++ b/tests/common/filter_socket.rs
@@ -184,3 +184,76 @@ pub fn create_filtered_channel_quad() -> (
         blocked,
     )
 }
+
+/// Creates a fully-meshed set of `n` [`FilterSocket`]-wrapped [`ChannelSocket`]s
+/// for N-player asymmetric-loss testing, all sharing one [`BlockedLinks`] handle.
+///
+/// This is the arbitrary-`n` generalization of [`create_filtered_channel_triple`]
+/// / [`create_filtered_channel_quad`], built on the generic
+/// [`create_channel_mesh`](super::channel_socket::create_channel_mesh). It returns
+/// `Vec`s (rather than a fixed-arity tuple) because at `n >= 5` a positional tuple
+/// becomes unwieldy and error-prone — index `sockets[i]` / `addrs[i]` instead.
+///
+/// It is needed for **N≥5** desync coverage that a 4-node mesh cannot express.
+/// The first consumer is the genuine multi-relay *double-failure relay* repro,
+/// where a receipt-bound lowering is folded as a `min` over **two** relay
+/// survivors (not the single relay an N=4 mesh affords), so the multi-relay
+/// fresh-ack round (S55) is exercised as a genuine many-element conjunction rather
+/// than a degenerate one-relay echo. (A future live-wire repro of the hot-join
+/// *fold-below-`S`* corner — which the S35 audit note flags as also needing N≥5 —
+/// can reuse this same harness.)
+///
+/// Returns the `n` sockets, their `n` addresses (index-aligned), and the shared
+/// [`BlockedLinks`] handle the test uses to toggle directional loss mid-run.
+///
+/// # Panics
+///
+/// Panics if `n` is outside `2..=1000` — this delegates to
+/// [`create_channel_mesh`](super::channel_socket::create_channel_mesh), which
+/// asserts that bound (both `n < 2` and `n > 1000` panic).
+#[allow(dead_code)]
+#[must_use]
+pub fn create_filtered_channel_mesh(
+    n: usize,
+) -> (Vec<FilterSocket>, Vec<SocketAddr>, BlockedLinks) {
+    let (sockets, addrs) = super::channel_socket::create_channel_mesh(n);
+    let blocked = BlockedLinks::new();
+    let filtered = sockets
+        .into_iter()
+        .map(|s| FilterSocket::new(s, blocked.clone()))
+        .collect();
+    (filtered, addrs, blocked)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_filtered_channel_mesh_sizes_and_shared_blocked_handle() {
+        for n in [2_usize, 3, 4, 5, 8] {
+            let (sockets, addrs, blocked) = create_filtered_channel_mesh(n);
+            assert_eq!(sockets.len(), n, "mesh must have n filtered sockets");
+            assert_eq!(addrs.len(), n, "mesh must have n addresses");
+            let unique: std::collections::HashSet<_> = addrs.iter().collect();
+            assert_eq!(unique.len(), n, "mesh addresses must be distinct (n={n})");
+            // The returned handle and every socket's handle alias the SAME set:
+            // a block toggled through the returned handle is observed by a socket.
+            assert!(!blocked.is_blocked(addrs[0], addrs[1]));
+            blocked.block(addrs[0], addrs[1]);
+            assert!(
+                blocked.is_blocked(addrs[0], addrs[1]),
+                "the returned BlockedLinks handle must toggle the shared set (n={n})"
+            );
+            // Directional: the reverse link is unaffected.
+            assert!(!blocked.is_blocked(addrs[1], addrs[0]));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "at least 2")]
+    fn create_filtered_channel_mesh_rejects_too_few_peers() {
+        let _ = create_filtered_channel_mesh(1);
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -36,7 +36,8 @@ pub use channel_socket::{
 };
 #[allow(unused_imports)]
 pub use filter_socket::{
-    create_filtered_channel_quad, create_filtered_channel_triple, BlockedLinks, FilterSocket,
+    create_filtered_channel_mesh, create_filtered_channel_quad, create_filtered_channel_triple,
+    BlockedLinks, FilterSocket,
 };
 #[allow(unused_imports)]
 pub use reorder_socket::{create_reorder_mesh_triple, HeldLinks, ReorderSocket};

--- a/tests/sessions/peer_drop.rs
+++ b/tests/sessions/peer_drop.rs
@@ -4486,6 +4486,16 @@ fn p2p_continue_without_gossip_lowered_disconnect_outside_window_stays_live(
     // genuine `frame_to_load > first_incorrect` Error, and must not raise any
     // Error/Critical FrameSync violation. At most a Warning explaining the
     // gossip-lowered-disconnect-frame-outside-window residual is allowed.
+    //
+    // Session-59 note: `P2PSession` now routes `report_violation!` to the
+    // per-session observer (via the thread-local scope installed in
+    // `advance_frame` / `poll_remote_clients`), so the two checks below are no
+    // longer vacuous — an Error/Critical violation raised on this path would now
+    // be captured and would fail the test. (This particular scenario converges
+    // cleanly without raising any violation, so the observer may legitimately be
+    // empty; the dedicated routing red-green lives in the `telemetry` unit tests
+    // and the `p2p_advance_frame_routes_report_violation_to_session_observer` /
+    // `sync_test_construction_violation_routes_to_session_observer` tests.)
     let violations = observer.violations();
     let genuine_bug_errors: Vec<_> = violations
         .iter()
@@ -4551,9 +4561,10 @@ fn p2p_continue_without_gossip_lowered_disconnect_outside_window_stays_live(
 //
 // It asserts byte-identical recorded state across A and B for every mutually
 // confirmed frame. (The genuine `frame_to_load > first_incorrect` Error logged by
-// `adjust_gamestate` is NOT asserted here: it routes through the bare
-// `report_violation!` macro to the global `TracingObserver` only and never reaches
-// a session `CollectingObserver`, so it is unobservable from this test. See the
+// `adjust_gamestate` is NOT asserted here. Since session-59 such a
+// `report_violation!` raised inside `advance_frame` WOULD reach a per-session
+// `CollectingObserver`; this test simply installs none, and no
+// `tracing-subscriber` layer either, so the Error is unobservable here. See the
 // note at the verdict assertion below.) The verdict is whichever way it runs on
 // current code.
 #[test]
@@ -4770,15 +4781,13 @@ fn p2p_sparse_continue_without_gossip_lowered_disconnect_confirmed_stream_conver
     //
     // This state-equality check is the genuine red->green guard for F7. We do NOT
     // assert on the sparse-mode `frame_to_load > first_incorrect` Error (tagged
-    // "this indicates a bug") emitted by `adjust_gamestate`: that guard uses the
-    // bare `report_violation!` macro, which routes ONLY to the global
-    // `TracingObserver` and never pushes into a session's `CollectingObserver`
-    // (documented at `src/network/protocol/mod.rs` near the
-    // `enqueue_replicated_input_drops_entry_when_pending_output_full` test). The
-    // observer wired onto `sess1` therefore cannot observe that violation, and no
-    // test in this suite installs a `tracing-subscriber` layer to capture it.
-    // Byte-identical confirmed state across survivors is the contract that
-    // actually matters and the divergence the bug produces, so we rely on it. ---
+    // "this indicates a bug") emitted by `adjust_gamestate`. Since session-59,
+    // `report_violation!` raised inside `advance_frame` DOES route to a
+    // per-session `CollectingObserver` (via the thread-local scope) — but this
+    // test installs no observer on its sessions and no `tracing-subscriber`
+    // layer, so it simply does not observe that violation here. Byte-identical
+    // confirmed state across survivors is the contract that actually matters and
+    // the divergence the bug produces, so we rely on it. ---
     let confirmed_bound = std::cmp::min(
         sess1.confirmed_frame().as_i32(),
         sess2.confirmed_frame().as_i32(),

--- a/tests/sessions/peer_drop.rs
+++ b/tests/sessions/peer_drop.rs
@@ -7377,26 +7377,36 @@ fn p2p_n0_nudge_does_not_starve_pending_retransmission_after_blackout() -> Resul
 // of the corner), proven via the PUBLIC per-slot `InputStatus` threaded into
 // each `AdvanceFrame` request (`local_connect_status` is private).
 //
-// WHAT REMAINS OPEN (the fold-below-`S` violation TRIGGER, not landed here): a
-// genuine wire delivery of a below-`f_carried` freeze to the committed joiner.
-// Roles for the intended N>=5 double-failure relay (num_players=5): A=h0
-// coordinator/HOST holding the dead slot HIGH and serving; B=h1 RELAY holding
-// it LOW and reachable to the joiner; C=h2 the joiner's re-filled slot; D=h3
-// the carried-dead slot (dies asymmetrically A-high/B-low); E=h4 a second
-// survivor. The obstruction (empirically demonstrated — see `progress/
-// session-58-…`): any RUNNING relay reporting the dead slot LOW is folded by
-// the coordinator, and the S32 freeze barrier / S55 floor-round then HOLD the
-// coordinator's `confirmed_frame()` at that low — which is exactly what stops
-// the coordinator from reaching `confirmed_frame() >= S` to SERVE the joiner at
-// `S` (the delayed-adoption staging wedges the coordinator below `S`, joiner
-// stuck `HotJoining`). Excluding the relay from the coordinator's fold (so it
-// can serve) means removing/reserving it — but then the snapshot carries that
-// slot reserved, contradicting "a live remote still delivering the low to the
-// joiner." Reconciling "excluded from the coordinator's roster" with "live
-// deliverer on the joiner" is the open roster-accounting problem; whether the
-// seam-injected bytes are reachable over a genuine wire to a committed joiner
-// is, at present, an OPEN question (the unit guard is sound defense-in-depth
-// either way).
+// WHY THE VIOLATION TRIGGER IS STRUCTURALLY UNREACHABLE OVER A GENUINE WIRE
+// (Session 60 — the resolution of S58's "open question / roster tension"). The
+// strongest natural attacker is an N>=5 double-failure relay aimed at the fresh
+// joiner: A=h0 coordinator/HOST holding the dead slot HIGH and serving; B=h1
+// RELAY; C=h2 the joiner's re-filled slot; D=h3 the carried-dead slot (dies
+// asymmetrically); E=h4 the low-origin (the only peer to freeze D at the low
+// receipt `g`). It cannot reach the violation, for three composing code reasons:
+//   1. The coordinator serves at `S` only when `confirmed_frame() >= S` AND
+//      `npeer_owed_freeze_readjust_at_or_below(S) == false` — and that gate folds
+//      EVERY running non-reserved endpoint's claims, so the serve DEFERS (pre-
+//      capture) / ABORTS (post-capture) while ANY folded endpoint reports a slot
+//      freeze that would re-sim at/below `S`. So A never serves D@f_carried while
+//      any folded peer (origin OR relay) holds D@`g` (`g < S`).
+//   2. To carry D@f_carried > `g`, A must EXCLUDE the low-origin from its fold
+//      (a connected remote reporting D@low also bounds A's confirmed low via
+//      `remote_slot_confirmed_bound`), and the only exclusion that does not stall
+//      A is to PRUNE it. Pruning gossips `origin@disconnected` to A's survivors.
+//   3. A Disconnected protocol endpoint drops all `Input`
+//      (`message_allowed_in_current_state` admits only `SyncRequest`), so any
+//      survivor that folds `origin@disconnected` disconnects its origin endpoint
+//      and can never adopt `g`. The relay that delivers `g` to the joiner MUST be
+//      a coordinator-directed survivor (only a survivor reactivating the joiner's
+//      slot gets a live endpoint to it) — hence A-folded, hence cascaded.
+// So the joiner commits carrying D below `S` and STAYS Running: no wire ordering
+// delivers a sub-baseline freeze. This is exercised end-to-end (over the wire,
+// strongest-attacker staging) by
+// `npeer_hot_join_fold_below_s_trigger_unreachable_over_wire` below, and the
+// seam-injected `src/` unit guard proves the bytes WOULD fail closed if delivered
+// — so that guard is the authoritative (and only-possible) coverage. Full
+// argument + adversarial-review consensus: `progress/session-60-…`.
 #[cfg(feature = "hot-join")]
 mod npeer_hot_join_joiner_integration {
     use super::{protocol_config, FilterBusSocket};
@@ -7985,6 +7995,213 @@ mod npeer_hot_join_joiner_integration {
             joiner.session.current_frame(),
             joiner.session.confirmed_frame(),
         );
+        Ok(())
+    }
+
+    /// The fold-below-`S` VIOLATION TRIGGER is **structurally unreachable over a
+    /// genuine wire** — the resolution of Session 58's "open question / roster
+    /// tension." This test drives the *strongest natural attacker construction* (a
+    /// genuine N≥5 double-failure relay aimed at a freshly-committed joiner) and
+    /// demonstrates the obstruction end-to-end over the `FilterBusSocket` mesh.
+    ///
+    /// **Roles:** A=h0 coordinator, B=h1 relay-survivor, C=h2 joiner-slot,
+    /// D=h3 dropped slot, E=h4 low-origin (the only peer to freeze D at the low
+    /// receipt `g`; its gossip to A/B/C is cut so `g` lives ONLY on E).
+    ///
+    /// **The obstruction (verified-code-grounded; the body exercises every step):**
+    /// 1. The serve gate is `confirmed_frame() >= S` AND
+    ///    `npeer_owed_freeze_readjust_at_or_below(S) == false` (the serve poll
+    ///    defers pre-capture / aborts post-capture otherwise). The owed-readjust
+    ///    dry-run folds EVERY running non-reserved endpoint, so A will not serve
+    ///    while ANY folded peer reports a slot freeze that re-sims at/below `S`.
+    ///    Separately, for A's confirmed to even climb to `S` above D's freeze, D
+    ///    must be **mesh-agreed disconnected** on A — `remote_slot_confirmed_bound`
+    ///    excludes a slot (`None`) ONLY in the `(true, false, _)` arm: locally
+    ///    disconnected AND no running remote reports it connected. A running remote
+    ///    reporting D at a low receipt instead bounds A low → A stalls below `S`.
+    /// 2. The low `g` is a FREEZE: its holder (E) reports D disconnected@`g`. If E is
+    ///    in A's fold, A's sticky-min merge adopts `g` → A captures D@`g`, the joiner
+    ///    inherits `g`, and there is no later lowering (the benign converged case, no
+    ///    violation). So to carry D@f_carried > `g`, A must EXCLUDE E — and the only
+    ///    exclusion that doesn't stall A's confirmed on E is to **prune** E.
+    /// 3. Pruning E gossips `E@disconnected` to B (the relay). A **Disconnected**
+    ///    protocol endpoint drops all `Input` (`message_allowed_in_current_state`
+    ///    admits only `SyncRequest`), so once B folds `E@disconnected` it disconnects
+    ///    its E endpoint (asserted here via B's `PeerDropped{E}`) and can **never**
+    ///    adopt `g` from E — even after the E→B link is re-opened post-commit.
+    /// 4. The relay MUST be a coordinator-directed survivor: only a survivor that
+    ///    reactivates the joiner's slot has a live endpoint to deliver `Input` to the
+    ///    joiner. A directed survivor is A-running, so if it held `g` A would have
+    ///    learned it (step 2). The same-poll fold-order race is unwinnable because A
+    ///    prunes E *pre-serve* (necessary to make D mesh-agreed), so B has long since
+    ///    disconnected E before any post-commit delivery window.
+    ///
+    /// So the joiner commits carrying D frozen strictly below `S` (the S58
+    /// foundational leg), the relay link is opened, B→joiner is a live gossip path
+    /// (the joiner confirms past `S` via its live remotes incl. B) — and yet the
+    /// joiner STAYS Running: no genuine-wire ordering delivers a sub-baseline freeze.
+    /// The seam-injected `src/` unit guard
+    /// `npeer_quad_committed_joiner_fold_below_snapshot_baseline_fails_closed_for_rejoin`
+    /// proves the violation MECHANISM fires on those exact bytes; this test proves the
+    /// bytes have no wire preimage, so that guard is the authoritative (and
+    /// only-possible) coverage. See `progress/session-60-*` for the full argument.
+    ///
+    /// **Scope:** unreachability for the committed N-peer JOINER specifically (no
+    /// history below `S` → fails closed). A *survivor* CAN see a below-its-history
+    /// lowering — that is the double-failure relay, which the S55 floor-round
+    /// CONVERGES (not fail-closes). The joiner is unique because its only inbound
+    /// relays are coordinator-directed survivors the coordinator necessarily folds.
+    #[test]
+    fn npeer_hot_join_fold_below_s_trigger_unreachable_over_wire() -> Result<(), FortressError> {
+        let mut mesh = build_mesh5()?;
+        let [a_addr, b_addr, _c_addr, _d_addr, e_addr] = mesh.addrs;
+
+        // Phase 1: warmup, all links open.
+        for i in 0..6_u32 {
+            mesh.poll_all(3);
+            mesh.advance_all(i);
+        }
+
+        // Phase 2: make E the low-origin. Cut E's gossip to A, B, C so E's low
+        // D-view never reaches them (`g` lives ONLY on E), then freeze D LOW on E.
+        // `e_g_upper` upper-bounds E's freeze frame `g` (E froze D at its own
+        // last_frame <= its current frame).
+        mesh.blocked.block(e_addr, a_addr);
+        mesh.blocked.block(e_addr, b_addr);
+        mesh.blocked.block(e_addr, mesh.addrs[2]);
+        mesh.e.remove_player(H_D).expect("E freezes D low");
+        let e_g_upper = mesh.e.current_frame();
+        let _ = mesh.e.events().count();
+
+        // Phase 3: prune E on A — the ONLY way to keep A's confirmed advancing past
+        // E's stale low D-view (a still-connected low-origin bounds A's confirmed
+        // for D, so without the prune A stalls and can never serve at S). The prune
+        // gossips `E@disconnected` to B (and C), which fold it and disconnect their
+        // E endpoint (the cascade — captured via B's `PeerDropped{E}`); this is the
+        // step that makes the relay B structurally unable to adopt `g`. With E
+        // excluded mesh-wide, A/B/C's confirmed for D now climbs HIGH (well above
+        // `g`) as D keeps delivering — building a wide, verifiable f_carried > g gap.
+        mesh.a.remove_player(H_E).expect("A prunes E");
+        let _ = mesh.a.events().count();
+        let mut b_dropped_e = false;
+        for i in 0..12_u32 {
+            mesh.poll_all(3);
+            mesh.advance_all(40 + i);
+            for e in mesh.b.events() {
+                if let FortressEvent::PeerDropped { handle, .. } = e {
+                    if handle == H_E {
+                        b_dropped_e = true;
+                    }
+                }
+            }
+        }
+        assert!(
+            b_dropped_e,
+            "the cascade did not fire: B never dropped E, so this staging does not \
+             exercise the structural obstruction (A's prune of the low-origin must \
+             disconnect the relay's endpoint to it)"
+        );
+
+        // Phase 4: freeze D HIGH (f_carried) on A, B, C; drop D's session.
+        // `a_confirmed_at_freeze` lower-bounds A's D-freeze (A freezes D at its
+        // last_frame for D, which is >= its session-wide `confirmed_frame()`), and
+        // `f_carried_upper` upper-bounds it. The assert pins `g < f_carried`: E's
+        // low freeze IS strictly below the value the joiner will carry, so a relay
+        // that COULD deliver `g` would genuinely trip `converged < baseline`.
+        let a_confirmed_at_freeze = mesh.a.confirmed_frame();
+        let f_carried_upper = mesh.a.current_frame();
+        assert!(
+            a_confirmed_at_freeze.as_i32() > e_g_upper.as_i32(),
+            "the gradient is not established: A's D-freeze lower bound \
+             {a_confirmed_at_freeze:?} must sit strictly above E's `g` upper bound \
+             {e_g_upper:?}, else E's `g` is not a genuine lowering of the carried value \
+             (the test would be vacuous)"
+        );
+        mesh.a.remove_player(H_D).expect("A freezes D high");
+        mesh.b.remove_player(H_D).expect("B freezes D high");
+        if let Some(c) = mesh.c.as_mut() {
+            c.remove_player(H_D).expect("C freezes D high");
+        }
+        mesh.drop_d();
+        let _ = mesh.a.events().count();
+        let _ = mesh.b.events().count();
+
+        // Phase 5: rejoin C. Drop C cleanly; coordinator A re-reserves the slot.
+        drop_c_cleanly(&mut mesh);
+        let mut joiner = Joiner::build(&mesh)?;
+        assert_eq!(joiner.session.current_state(), SessionState::HotJoining);
+
+        // Phase 6: drive the joiner to Running over the wire. A serves carrying
+        // D@f_carried (it never learned `g`).
+        let mut reached = false;
+        for i in 0..1500_u32 {
+            mesh.poll_all(1);
+            joiner.poll();
+            if i % 3 == 2 {
+                mesh.advance_all(80 + (i % 8));
+            }
+            if joiner.session.current_state() == SessionState::Running {
+                reached = true;
+                break;
+            }
+        }
+        assert!(
+            reached,
+            "joiner reached Running over the wire (state {:?})",
+            joiner.session.current_state()
+        );
+        let serve_s = drive_first_advance(&mut joiner);
+        assert!(
+            serve_s.as_i32() > f_carried_upper.as_i32(),
+            "snapshot baseline S={serve_s:?} must sit strictly above D's freeze \
+             (upper bound {f_carried_upper:?}) — else 'D carried below S' is unproven"
+        );
+
+        // Phase 7: open E->B post-commit — the relay's chance to adopt `g` and relay
+        // it to the joiner. B's E endpoint is already terminal (Phase 3 cascade), so
+        // B drops E's Input and never adopts `g`.
+        mesh.blocked.unblock(e_addr, b_addr);
+        joiner.d_slot.clear();
+        run_mesh_and_joiner(&mut mesh, &mut joiner, 120);
+
+        // The joiner confirmed deep past S using its live remotes (A AND B): B IS a
+        // live gossip path, so a lowering WOULD reach the joiner if B held one. It
+        // does not.
+        assert!(
+            joiner.session.confirmed_frame().as_i32() > serve_s.as_i32(),
+            "joiner must confirm past S={serve_s:?} via its live remotes (incl. the \
+             relay B) — else 'B is a live path' is unproven (confirmed {:?})",
+            joiner.session.confirmed_frame()
+        );
+        // The violation never fired over the wire: the joiner stays Running, carrying
+        // D frozen at a single constant value (never lowered to `g`).
+        assert_eq!(
+            joiner.session.current_state(),
+            SessionState::Running,
+            "the fold-below-S trigger fired over the wire (joiner left Running) — the \
+             structural obstruction was bypassed"
+        );
+        assert!(
+            joiner.d_slot.len() >= 10,
+            "joiner recorded too few post-relay D-slot statuses ({}) — vacuous staging",
+            joiner.d_slot.len()
+        );
+        let frozen_values: std::collections::BTreeSet<u32> =
+            joiner.d_slot.values().map(|&(v, _)| v).collect();
+        assert_eq!(
+            frozen_values.len(),
+            1,
+            "D's carried value must stay frozen (never lowered to g) across all {} \
+             post-relay frames, got {frozen_values:?}",
+            joiner.d_slot.len()
+        );
+        for (frame, (value, status)) in &joiner.d_slot {
+            assert_eq!(
+                *status,
+                InputStatus::Disconnected,
+                "joiner must keep D Disconnected at frame {frame} (value {value})"
+            );
+        }
         Ok(())
     }
 }

--- a/tests/sessions/peer_drop.rs
+++ b/tests/sessions/peer_drop.rs
@@ -20,10 +20,10 @@
 
 use crate::common::stubs::{GameStub, StateStub, StubConfig, StubInput};
 use crate::common::{
-    create_channel_pair, create_channel_quad, create_channel_triple, create_filtered_channel_quad,
-    create_filtered_channel_triple, drain_sync_events, poll_with_advance,
-    synchronize_sessions_deterministic, BlockedLinks, BusSocket, FilterSocket, RoutingBus,
-    SyncConfig, TestClock, POLL_INTERVAL_DETERMINISTIC,
+    create_channel_pair, create_channel_quad, create_channel_triple, create_filtered_channel_mesh,
+    create_filtered_channel_quad, create_filtered_channel_triple, drain_sync_events,
+    poll_with_advance, synchronize_sessions_deterministic, BlockedLinks, BusSocket, FilterSocket,
+    RoutingBus, SyncConfig, TestClock, POLL_INTERVAL_DETERMINISTIC,
 };
 use fortress_rollback::{
     telemetry::{CollectingObserver, ViolationSeverity},
@@ -2496,6 +2496,200 @@ fn poll_four(
     }
 }
 
+/// Builds five fully-meshed `P2PSession`s over a filtered in-process mesh, with a
+/// PER-SESSION disconnect timeout (`timeouts[i]` applies to session i) and an
+/// explicit `max_prediction` window — the 5-player analog of
+/// [`build_filtered_four_player_sessions_with_timeouts_and_prediction`].
+///
+/// Returns `(A, B, C, D, C2, blocked, a_A, a_B, a_C, a_D, a_C2, clock)`, where the
+/// session order is handles `0..5` (A=h0, B=h1, C=h2, D=h3, C2=h4) and the five
+/// addresses are index-aligned to those handles. The N=5 double-failure-relay
+/// coverage needs the SECOND relay survivor C2 so the fold-min over relays is a
+/// genuine multi-element conjunction (see the test for the choreography).
+#[allow(clippy::type_complexity)]
+fn build_filtered_five_player_sessions_with_timeouts_and_prediction(
+    timeouts: [Duration; 5],
+    max_prediction: usize,
+) -> Result<
+    (
+        P2PSession<StubConfig>,
+        P2PSession<StubConfig>,
+        P2PSession<StubConfig>,
+        P2PSession<StubConfig>,
+        P2PSession<StubConfig>,
+        BlockedLinks,
+        SocketAddr,
+        SocketAddr,
+        SocketAddr,
+        SocketAddr,
+        SocketAddr,
+        TestClock,
+    ),
+    FortressError,
+> {
+    let clock = TestClock::new();
+    let (mut sockets, addrs, blocked) = create_filtered_channel_mesh(5);
+    assert_eq!(sockets.len(), 5, "five-player mesh must yield five sockets");
+    assert_eq!(addrs.len(), 5, "five-player mesh must yield five addresses");
+    // Drain the socket Vec into named bindings (reverse order so `pop` is in
+    // index order). The addresses stay index-aligned to the handles below.
+    let s5 = sockets.pop().expect("socket 5");
+    let s4 = sockets.pop().expect("socket 4");
+    let s3 = sockets.pop().expect("socket 3");
+    let s2 = sockets.pop().expect("socket 2");
+    let s1 = sockets.pop().expect("socket 1");
+    let (a1, a2, a3, a4, a5) = (addrs[0], addrs[1], addrs[2], addrs[3], addrs[4]);
+    let pc = protocol_config(&clock);
+
+    let build = |local: PlayerHandle,
+                 socket: FilterSocket,
+                 disconnect_timeout: Duration,
+                 remotes: [(PlayerHandle, SocketAddr); 4]|
+     -> Result<P2PSession<StubConfig>, FortressError> {
+        let mut builder = SessionBuilder::<StubConfig>::new()
+            .with_protocol_config(pc.clone())
+            .with_num_players(5)?
+            .with_max_prediction_window(max_prediction)
+            .with_disconnect_behavior(DisconnectBehavior::ContinueWithout)
+            .with_disconnect_timeout(disconnect_timeout)
+            .with_disconnect_notify_delay(Duration::from_millis(100))
+            .add_player(PlayerType::Local, local)?;
+        for (handle, addr) in remotes {
+            builder = builder.add_player(PlayerType::Remote(addr), handle)?;
+        }
+        builder.start_p2p_session(socket)
+    };
+
+    let mut sess1 = build(
+        PlayerHandle::new(0),
+        s1,
+        timeouts[0],
+        [
+            (PlayerHandle::new(1), a2),
+            (PlayerHandle::new(2), a3),
+            (PlayerHandle::new(3), a4),
+            (PlayerHandle::new(4), a5),
+        ],
+    )?;
+    let mut sess2 = build(
+        PlayerHandle::new(1),
+        s2,
+        timeouts[1],
+        [
+            (PlayerHandle::new(0), a1),
+            (PlayerHandle::new(2), a3),
+            (PlayerHandle::new(3), a4),
+            (PlayerHandle::new(4), a5),
+        ],
+    )?;
+    let mut sess3 = build(
+        PlayerHandle::new(2),
+        s3,
+        timeouts[2],
+        [
+            (PlayerHandle::new(0), a1),
+            (PlayerHandle::new(1), a2),
+            (PlayerHandle::new(3), a4),
+            (PlayerHandle::new(4), a5),
+        ],
+    )?;
+    let mut sess4 = build(
+        PlayerHandle::new(3),
+        s4,
+        timeouts[3],
+        [
+            (PlayerHandle::new(0), a1),
+            (PlayerHandle::new(1), a2),
+            (PlayerHandle::new(2), a3),
+            (PlayerHandle::new(4), a5),
+        ],
+    )?;
+    let mut sess5 = build(
+        PlayerHandle::new(4),
+        s5,
+        timeouts[4],
+        [
+            (PlayerHandle::new(0), a1),
+            (PlayerHandle::new(1), a2),
+            (PlayerHandle::new(2), a3),
+            (PlayerHandle::new(3), a4),
+        ],
+    )?;
+
+    synchronize_five_sessions(
+        &mut sess1, &mut sess2, &mut sess3, &mut sess4, &mut sess5, &clock, 800,
+    );
+    let _ = drain_events(&mut sess1);
+    let _ = drain_events(&mut sess2);
+    let _ = drain_events(&mut sess3);
+    let _ = drain_events(&mut sess4);
+    let _ = drain_events(&mut sess5);
+
+    Ok((
+        sess1, sess2, sess3, sess4, sess5, blocked, a1, a2, a3, a4, a5, clock,
+    ))
+}
+
+/// Synchronizes five sessions deterministically. Returns when all five are in
+/// `Running` state, or panics if synchronization does not complete in
+/// `iterations` iterations. The 5-player analog of [`synchronize_four_sessions`].
+fn synchronize_five_sessions(
+    sess1: &mut P2PSession<StubConfig>,
+    sess2: &mut P2PSession<StubConfig>,
+    sess3: &mut P2PSession<StubConfig>,
+    sess4: &mut P2PSession<StubConfig>,
+    sess5: &mut P2PSession<StubConfig>,
+    clock: &TestClock,
+    iterations: usize,
+) {
+    for _ in 0..iterations {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+        sess3.poll_remote_clients();
+        sess4.poll_remote_clients();
+        sess5.poll_remote_clients();
+        if sess1.current_state() == SessionState::Running
+            && sess2.current_state() == SessionState::Running
+            && sess3.current_state() == SessionState::Running
+            && sess4.current_state() == SessionState::Running
+            && sess5.current_state() == SessionState::Running
+        {
+            return;
+        }
+        clock.advance(POLL_INTERVAL_DETERMINISTIC);
+    }
+    panic!(
+        "Five sessions failed to synchronize: sess1={:?}, sess2={:?}, sess3={:?}, sess4={:?}, sess5={:?}",
+        sess1.current_state(),
+        sess2.current_state(),
+        sess3.current_state(),
+        sess4.current_state(),
+        sess5.current_state()
+    );
+}
+
+/// Polls five sessions and advances virtual time by
+/// `POLL_INTERVAL_DETERMINISTIC * iterations`. The 5-player analog of
+/// [`poll_four`].
+fn poll_five(
+    sess1: &mut P2PSession<StubConfig>,
+    sess2: &mut P2PSession<StubConfig>,
+    sess3: &mut P2PSession<StubConfig>,
+    sess4: &mut P2PSession<StubConfig>,
+    sess5: &mut P2PSession<StubConfig>,
+    clock: &TestClock,
+    iterations: usize,
+) {
+    for _ in 0..iterations {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+        sess3.poll_remote_clients();
+        sess4.poll_remote_clients();
+        sess5.poll_remote_clients();
+        clock.advance(POLL_INTERVAL_DETERMINISTIC);
+    }
+}
+
 #[test]
 fn p2p_n4_relay_clobber_dropped_slot_freeze_frame_converges_across_survivors(
 ) -> Result<(), FortressError> {
@@ -3564,6 +3758,296 @@ fn p2p_n4_double_failure_relay_dropped_slot_converges_across_survivors() -> Resu
     assert!(
         !queryable_mismatch,
         "expected D's confirmed inputs to MATCH across A and C on every queryable \
+         frame (the freeze frame converged); got {input_probe:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn p2p_n5_double_failure_relay_two_relays_dropped_slot_converges_across_survivors(
+) -> Result<(), FortressError> {
+    // LONG symmetric timeouts so NO auto-timeout fires; every prune is an
+    // explicit `remove_player`. SMALL prediction window (4) so A can burn its
+    // whole window and (absent the HOLD) DISCARD frames below `F` before the
+    // relays' low lands.
+    let long = Duration::from_secs(20);
+    let (
+        mut sess_a,
+        mut sess_b,
+        mut sess_c,
+        mut sess_d,
+        mut sess_c2,
+        blocked,
+        a_addr,
+        b_addr,
+        c_addr,
+        d_addr,
+        c2_addr,
+        clock,
+    ) = build_filtered_five_player_sessions_with_timeouts_and_prediction([long; 5], 4)?;
+
+    let mut stub_a = GameStub::new();
+    let mut stub_b = GameStub::new();
+    let mut stub_c = GameStub::new();
+    let mut stub_d = GameStub::new();
+    let mut stub_c2 = GameStub::new();
+
+    let mut states_a: BTreeMap<i32, StateStub> = BTreeMap::new();
+    let mut states_c: BTreeMap<i32, StateStub> = BTreeMap::new();
+    let mut states_c2: BTreeMap<i32, StateStub> = BTreeMap::new();
+    let mut sink_b: BTreeMap<i32, StateStub> = BTreeMap::new();
+    let mut sink_d: BTreeMap<i32, StateStub> = BTreeMap::new();
+
+    let h_a = PlayerHandle::new(0);
+    let h_b = PlayerHandle::new(1);
+    let h_c = PlayerHandle::new(2);
+    let h_d = PlayerHandle::new(3);
+    let h_c2 = PlayerHandle::new(4);
+
+    // --- Phase 1: warmup, all links open so all five confirm together. ---
+    let warmup_frames = 6_u32;
+    for i in 0..warmup_frames {
+        poll_five(
+            &mut sess_a,
+            &mut sess_b,
+            &mut sess_c,
+            &mut sess_d,
+            &mut sess_c2,
+            &clock,
+            3,
+        );
+        try_advance_recording(&mut sess_a, &mut stub_a, h_a, i, &mut states_a)?;
+        try_advance_recording(&mut sess_b, &mut stub_b, h_b, i + 1000, &mut sink_b)?;
+        try_advance_recording(&mut sess_c, &mut stub_c, h_c, i + 2000, &mut states_c)?;
+        try_advance_recording(&mut sess_d, &mut stub_d, h_d, i + 3000, &mut sink_d)?;
+        try_advance_recording(&mut sess_c2, &mut stub_c2, h_c2, i + 4000, &mut states_c2)?;
+    }
+    poll_five(
+        &mut sess_a,
+        &mut sess_b,
+        &mut sess_c,
+        &mut sess_d,
+        &mut sess_c2,
+        &clock,
+        8,
+    );
+
+    // --- Phase 2: build the D-receipt gradient B(low=F) < {A,C,C2}(high≈M). ---
+    blocked.block(d_addr, b_addr);
+    let climb = 16_u32;
+    for i in 0..climb {
+        poll_five(
+            &mut sess_a,
+            &mut sess_b,
+            &mut sess_c,
+            &mut sess_d,
+            &mut sess_c2,
+            &clock,
+            2,
+        );
+        try_advance_recording(&mut sess_a, &mut stub_a, h_a, 100 + i, &mut states_a)?;
+        try_advance_recording(&mut sess_b, &mut stub_b, h_b, 1100 + i, &mut sink_b)?;
+        try_advance_recording(&mut sess_c, &mut stub_c, h_c, 2100 + i, &mut states_c)?;
+        try_advance_recording(&mut sess_d, &mut stub_d, h_d, 3100 + i, &mut sink_d)?;
+        try_advance_recording(&mut sess_c2, &mut stub_c2, h_c2, 4100 + i, &mut states_c2)?;
+    }
+    poll_five(
+        &mut sess_a,
+        &mut sess_b,
+        &mut sess_c,
+        &mut sess_d,
+        &mut sess_c2,
+        &clock,
+        4,
+    );
+
+    // --- Phase 3: arm the DOUBLE FAILURE across BOTH relays (all via explicit
+    // removals; no timeout). ---
+    blocked.block(d_addr, c_addr);
+    blocked.block(d_addr, c2_addr);
+    blocked.block(c_addr, a_addr);
+    blocked.block(a_addr, c_addr);
+    blocked.block(c2_addr, a_addr);
+    blocked.block(a_addr, c2_addr);
+    blocked.block(b_addr, a_addr);
+    blocked.block(a_addr, b_addr);
+
+    // B freezes D at F and gossips {disconnected, F} to C AND C2 (B -> C, B -> C2
+    // open); both adopt F. B -> A is cut so A does NOT adopt F here.
+    sess_b.remove_player(h_d).unwrap();
+    // B's endpoint on A goes terminal → PRUNED from A's D fold. A's running
+    // remotes are now {C, C2, D} = 3 running → relay topology engaged with TWO
+    // folded relays (one ABOVE the floor).
+    sess_a.remove_player(h_b).unwrap();
+
+    // --- Phase 4: A confirms/records D HIGH; the multi-relay HOLD must engage so
+    // A never discards the contested window. ---
+    let mut a_dropped_b = false;
+    let mut a_dropped_d_p4 = false;
+    let mut a_stall_error: Option<FortressError> = None;
+    for _ in 0..140 {
+        sess_a.poll_remote_clients();
+        sess_b.poll_remote_clients();
+        sess_c.poll_remote_clients();
+        sess_c2.poll_remote_clients();
+        clock.advance(POLL_INTERVAL_DETERMINISTIC);
+
+        match try_advance_recording(&mut sess_a, &mut stub_a, h_a, 500, &mut states_a) {
+            Ok(_) => {},
+            Err(e) => {
+                if a_stall_error.is_none() {
+                    a_stall_error = Some(e);
+                }
+            },
+        }
+        try_advance_recording(&mut sess_b, &mut stub_b, h_b, 1500, &mut sink_b)?;
+        try_advance_recording(&mut sess_c, &mut stub_c, h_c, 2500, &mut states_c)?;
+        try_advance_recording(&mut sess_c2, &mut stub_c2, h_c2, 4500, &mut states_c2)?;
+
+        for e in sess_a.events() {
+            if let FortressEvent::PeerDropped { handle, .. } = e {
+                if handle == h_b {
+                    a_dropped_b = true;
+                }
+                if handle == h_d {
+                    a_dropped_d_p4 = true;
+                }
+            }
+        }
+    }
+
+    // --- Phase 5: re-open BOTH relays. Their relayed {disconnected, F} lands on
+    // A (arming a below-window rollback the S20 clamp survives) and their
+    // `FloorReply`s answer A's round with F, so A converges. ---
+    blocked.unblock(c_addr, a_addr);
+    blocked.unblock(a_addr, c_addr);
+    blocked.unblock(c2_addr, a_addr);
+    blocked.unblock(a_addr, c2_addr);
+
+    let mut a_dropped_d_p5 = false;
+    for _ in 0..200 {
+        sess_a.poll_remote_clients();
+        sess_c.poll_remote_clients();
+        sess_c2.poll_remote_clients();
+        clock.advance(POLL_INTERVAL_DETERMINISTIC);
+
+        match try_advance_recording(&mut sess_a, &mut stub_a, h_a, 700, &mut states_a) {
+            Ok(_) => {},
+            Err(e) => {
+                if a_stall_error.is_none() {
+                    a_stall_error = Some(e);
+                }
+            },
+        }
+        try_advance_recording(&mut sess_c, &mut stub_c, h_c, 2700, &mut states_c)?;
+        try_advance_recording(&mut sess_c2, &mut stub_c2, h_c2, 4700, &mut states_c2)?;
+
+        if sess_a
+            .events()
+            .any(|e| matches!(e, FortressEvent::PeerDropped { handle, .. } if handle == h_d))
+        {
+            a_dropped_d_p5 = true;
+        }
+    }
+
+    let a_dropped_d = a_dropped_d_p4 || a_dropped_d_p5;
+
+    // --- Byte oracle (F4 pattern, TWO relay witnesses): over the shared
+    // confirmed range A vs C AND A vs C2 must agree. ---
+    let confirmed_bound = sess_a
+        .confirmed_frame()
+        .as_i32()
+        .min(sess_c.confirmed_frame().as_i32())
+        .min(sess_c2.confirmed_frame().as_i32());
+    let mut compared = 0_u32;
+    let mut divergences: Vec<(i32, &'static str, StateStub, StateStub)> = Vec::new();
+    for (&frame, &state_a) in &states_a {
+        if frame > confirmed_bound {
+            continue;
+        }
+        if let Some(&state_c) = states_c.get(&frame) {
+            compared += 1;
+            if state_a != state_c {
+                divergences.push((frame, "A!=C", state_a, state_c));
+            }
+        }
+        if let Some(&state_c2) = states_c2.get(&frame) {
+            compared += 1;
+            if state_a != state_c2 {
+                divergences.push((frame, "A!=C2", state_a, state_c2));
+            }
+        }
+    }
+
+    // PROBE: D's confirmed INPUT (handle 3) on A vs C vs C2 at sample in-window
+    // frames must MATCH (the freeze converged) — the decisive signature that this
+    // is the silent state-only divergence, not a plain input split.
+    let mut input_probe: Vec<(i32, Option<u32>, Option<u32>, Option<u32>)> = Vec::new();
+    let mut queryable_matches = 0_u32;
+    let mut queryable_mismatch = false;
+    for &pf in &[60_i32, 110, 160] {
+        if pf > confirmed_bound {
+            continue;
+        }
+        let da = sess_a
+            .confirmed_inputs_for_frame(Frame::new(pf))
+            .ok()
+            .and_then(|v| v.get(3).map(|i| i.inp));
+        let dc = sess_c
+            .confirmed_inputs_for_frame(Frame::new(pf))
+            .ok()
+            .and_then(|v| v.get(3).map(|i| i.inp));
+        let dc2 = sess_c2
+            .confirmed_inputs_for_frame(Frame::new(pf))
+            .ok()
+            .and_then(|v| v.get(3).map(|i| i.inp));
+        // Only frames queryable on ALL THREE peers count toward the non-vacuous
+        // match (a discarded frame yields `None` and proves nothing).
+        if da.is_some() && dc.is_some() && dc2.is_some() {
+            if da == dc && da == dc2 {
+                queryable_matches += 1;
+            } else {
+                queryable_mismatch = true;
+            }
+        }
+        input_probe.push((pf, da, dc, dc2));
+    }
+
+    assert!(
+        compared > 0,
+        "no confirmed frames were compared across survivors (bound={confirmed_bound}); \
+         the N=5 double-failure-relay choreography did not produce overlapping confirmed history"
+    );
+    assert!(
+        a_dropped_d_p5 && !a_dropped_d_p4,
+        "expected A to learn D's disconnect ONLY via the late relay (p4={a_dropped_d_p4}, \
+         p5={a_dropped_d_p5}); the double-failure ordering did not hold \
+         (bound={confirmed_bound}, a_dropped_b={a_dropped_b})"
+    );
+    assert!(
+        a_stall_error.is_none(),
+        "expected A to stay live via the S20 clamp, but advance_frame errored: \
+         {a_stall_error:?} (bound={confirmed_bound})"
+    );
+    // POSITIVE CONVERGENCE GUARD (the S55 fix at N=5, two relays): an EMPTY
+    // `divergences` is GREEN; a regression repopulates it and flips this RED.
+    assert!(
+        divergences.is_empty(),
+        "N=5 double-failure-relay REGRESSED: confirmed state diverged across survivors \
+         (bound={confirmed_bound}, compared={compared}, a_dropped_d={a_dropped_d}, \
+         a_stall_error={a_stall_error:?}, divergences={divergences:?}). The multi-relay \
+         floor-round HOLD should keep A's confirmed bound at F until BOTH relays' rounds \
+         are fresh, so the contested window is never discarded."
+    );
+    assert!(
+        queryable_matches > 0,
+        "input probe was vacuous: no sampled frame was queryable on all of A, C, C2 \
+         (all discarded from the input ring) — got {input_probe:?} (bound={confirmed_bound})"
+    );
+    assert!(
+        !queryable_mismatch,
+        "expected D's confirmed inputs to MATCH across A, C, C2 on every queryable \
          frame (the freeze frame converged); got {input_probe:?}"
     );
 
@@ -6852,4 +7336,646 @@ fn p2p_n0_nudge_does_not_starve_pending_retransmission_after_blackout() -> Resul
     );
 
     Ok(())
+}
+
+// ============================================================================
+// Integration-level N-peer hot-join joiner lifecycle (toward fold-below-`S`)
+// ============================================================================
+//
+// THE MECHANISM (traced, for context): an N-peer hot-join JOINER applies a
+// snapshot at frame `S` and inherits a "carried-dead" slot (a peer that died
+// before the snapshot) frozen at the coordinator's captured view
+// `f_carried < S`. This sits stably. The fold-below-`S` fail-closed violation
+// fires inside `disconnect_player_at_frames` (`src/sessions/p2p_session.rs`)
+// ONLY when a relay delivers a freeze STRICTLY BELOW `f_carried` (hence below
+// `S`) for the carried-dead slot: a LOWERING `update_player_disconnects` fold
+// converges `converged < S = npeer_joiner_baseline`, and the joiner — whose
+// entire history starts at `S` — structurally cannot re-roll or re-simulate
+// below its only saved state, so it fails closed (leave `Running`, surface
+// `NotSynchronized`, tear down terminally). The authoritative coverage of that
+// fail-closed behavior is the in-crate unit guard
+// `npeer_quad_committed_joiner_fold_below_snapshot_baseline_fails_closed_for_rejoin`,
+// which injects the below-`S` claim via a private cache seam.
+//
+// WHAT THIS MODULE LANDS (the reusable harness + the two legs reachable over a
+// genuine `FilterBusSocket` wire — every prune an explicit `remove_player`, no
+// seam injection, no `set_peer_connect_status_for_tests`, no private-field
+// writes): (1) a real `start_hot_join_session` N-peer joiner driven to
+// `Running` over the wire (the first such integration test — the full N-peer
+// joiner-drive lifecycle previously lived ONLY in `src/` unit tests on the
+// in-process `MeshBus`); (2) that committed joiner genuinely CARRYING a
+// dead slot disconnected BELOW its snapshot baseline `S` (the foundational leg
+// of the corner), proven via the PUBLIC per-slot `InputStatus` threaded into
+// each `AdvanceFrame` request (`local_connect_status` is private).
+//
+// WHAT REMAINS OPEN (the fold-below-`S` violation TRIGGER, not landed here): a
+// genuine wire delivery of a below-`f_carried` freeze to the committed joiner.
+// Roles for the intended N>=5 double-failure relay (num_players=5): A=h0
+// coordinator/HOST holding the dead slot HIGH and serving; B=h1 RELAY holding
+// it LOW and reachable to the joiner; C=h2 the joiner's re-filled slot; D=h3
+// the carried-dead slot (dies asymmetrically A-high/B-low); E=h4 a second
+// survivor. The obstruction (empirically demonstrated — see `progress/
+// session-58-…`): any RUNNING relay reporting the dead slot LOW is folded by
+// the coordinator, and the S32 freeze barrier / S55 floor-round then HOLD the
+// coordinator's `confirmed_frame()` at that low — which is exactly what stops
+// the coordinator from reaching `confirmed_frame() >= S` to SERVE the joiner at
+// `S` (the delayed-adoption staging wedges the coordinator below `S`, joiner
+// stuck `HotJoining`). Excluding the relay from the coordinator's fold (so it
+// can serve) means removing/reserving it — but then the snapshot carries that
+// slot reserved, contradicting "a live remote still delivering the low to the
+// joiner." Reconciling "excluded from the coordinator's roster" with "live
+// deliverer on the joiner" is the open roster-accounting problem; whether the
+// seam-injected bytes are reachable over a genuine wire to a committed joiner
+// is, at present, an OPEN question (the unit guard is sound defense-in-depth
+// either way).
+#[cfg(feature = "hot-join")]
+mod npeer_hot_join_joiner_integration {
+    use super::{protocol_config, FilterBusSocket};
+    use crate::common::stubs::{GameStub, StubConfig, StubInput};
+    use crate::common::{BlockedLinks, RoutingBus, TestClock, POLL_INTERVAL_DETERMINISTIC};
+    use fortress_rollback::{
+        DesyncDetection, DisconnectBehavior, FortressError, FortressEvent, FortressRequest, Frame,
+        InputStatus, P2PSession, PlayerHandle, PlayerType, SessionBuilder, SessionState,
+    };
+    use std::collections::BTreeMap;
+    use std::net::SocketAddr;
+    use web_time::Duration;
+
+    /// Handles, in roster order: A=host(0), B=relay(1), C=joiner-slot(2),
+    /// D=carried-dead(3), E=survivor(4).
+    const H_A: PlayerHandle = PlayerHandle::new(0);
+    const H_B: PlayerHandle = PlayerHandle::new(1);
+    const H_C: PlayerHandle = PlayerHandle::new(2);
+    const H_D: PlayerHandle = PlayerHandle::new(3);
+    const H_E: PlayerHandle = PlayerHandle::new(4);
+
+    /// Returns the five mesh addresses (index-aligned to handles 0..5).
+    fn mesh_addrs() -> [SocketAddr; 5] {
+        [
+            ([127, 0, 0, 1], 50001).into(),
+            ([127, 0, 0, 1], 50002).into(),
+            ([127, 0, 0, 1], 50003).into(),
+            ([127, 0, 0, 1], 50004).into(),
+            ([127, 0, 0, 1], 50005).into(),
+        ]
+    }
+
+    /// The five live full-mesh sessions plus the wire handle and addresses.
+    /// A is the hot-join coordinator (`with_hot_join(true)`); the rest are plain
+    /// survivors. LONG symmetric timeouts so NO auto-timeout ever fires — every
+    /// prune in the choreography is an explicit `remove_player`. Sockets are
+    /// [`FilterBusSocket`]s over a shared [`RoutingBus`], so (a) directional loss
+    /// is toggleable mid-run via `blocked`, and (b) a fresh joiner can re-attach at
+    /// C's vacated address after C drops (the hot-join rejoin needs both — neither
+    /// `FilterSocket`/`ChannelSocket` nor a plain `BusSocket` alone suffices).
+    struct Mesh5 {
+        a: P2PSession<StubConfig>,
+        b: P2PSession<StubConfig>,
+        e: P2PSession<StubConfig>,
+        /// C is `Option` so the test can `drop` it (vacating its socket/address)
+        /// before re-attaching the joiner at the same address.
+        c: Option<P2PSession<StubConfig>>,
+        /// D is `Option` so the test can `drop` it after D dies (vacating its
+        /// address — D is never rejoined, it stays carried-dead).
+        d: Option<P2PSession<StubConfig>>,
+        stub_a: GameStub,
+        stub_b: GameStub,
+        stub_c: GameStub,
+        stub_d: GameStub,
+        stub_e: GameStub,
+        bus: RoutingBus,
+        blocked: BlockedLinks,
+        addrs: [SocketAddr; 5],
+        clock: TestClock,
+    }
+
+    /// Builds + synchronizes the five-player hot-join mesh. A=h0 is the
+    /// coordinator; the snapshot serve uses `EveryFrame` saving (StubConfig
+    /// default) and input delay 0 (default), so the public `start_hot_join_session`
+    /// works for the joiner that re-fills C's slot.
+    // The five sessions bind to single-char roster locals `a`..`e` (mirroring the
+    // `Mesh5` fields and the `H_A`..`H_E` handles) — intentional and clearer than
+    // `sess_a`..`sess_e` for a fixed five-peer roster.
+    #[allow(clippy::many_single_char_names)]
+    fn build_mesh5() -> Result<Mesh5, FortressError> {
+        let clock = TestClock::new();
+        let bus = RoutingBus::new();
+        let blocked = BlockedLinks::new();
+        let addrs = mesh_addrs();
+        let pc = protocol_config(&clock);
+        let long = Duration::from_secs(20);
+
+        // The coordinator A: hot-join enabled.
+        let a = {
+            let mut builder = SessionBuilder::<StubConfig>::new()
+                .with_protocol_config(pc.clone())
+                .with_num_players(5)?
+                .with_hot_join(true)
+                .with_desync_detection_mode(DesyncDetection::On { interval: 2 })
+                .with_disconnect_behavior(DisconnectBehavior::ContinueWithout)
+                .with_disconnect_timeout(long)
+                .with_disconnect_notify_delay(Duration::from_millis(100))
+                .add_player(PlayerType::Local, H_A)?;
+            for (h, idx) in [(H_B, 1), (H_C, 2), (H_D, 3), (H_E, 4)] {
+                builder = builder.add_player(PlayerType::Remote(addrs[idx]), h)?;
+            }
+            builder.start_p2p_session(FilterBusSocket::new(&bus, addrs[0], blocked.clone()))?
+        };
+
+        let build_survivor = |local: PlayerHandle,
+                              local_idx: usize,
+                              remotes: [(PlayerHandle, usize); 4]|
+         -> Result<P2PSession<StubConfig>, FortressError> {
+            let mut builder = SessionBuilder::<StubConfig>::new()
+                .with_protocol_config(pc.clone())
+                .with_num_players(5)?
+                .with_desync_detection_mode(DesyncDetection::On { interval: 2 })
+                .with_disconnect_behavior(DisconnectBehavior::ContinueWithout)
+                .with_disconnect_timeout(long)
+                .with_disconnect_notify_delay(Duration::from_millis(100))
+                .add_player(PlayerType::Local, local)?;
+            for (h, idx) in remotes {
+                builder = builder.add_player(PlayerType::Remote(addrs[idx]), h)?;
+            }
+            builder.start_p2p_session(FilterBusSocket::new(
+                &bus,
+                addrs[local_idx],
+                blocked.clone(),
+            ))
+        };
+
+        let b = build_survivor(H_B, 1, [(H_A, 0), (H_C, 2), (H_D, 3), (H_E, 4)])?;
+        let c = build_survivor(H_C, 2, [(H_A, 0), (H_B, 1), (H_D, 3), (H_E, 4)])?;
+        let d = build_survivor(H_D, 3, [(H_A, 0), (H_B, 1), (H_C, 2), (H_E, 4)])?;
+        let e = build_survivor(H_E, 4, [(H_A, 0), (H_B, 1), (H_C, 2), (H_D, 3)])?;
+
+        let mut mesh = Mesh5 {
+            a,
+            b,
+            e,
+            c: Some(c),
+            d: Some(d),
+            stub_a: GameStub::new(),
+            stub_b: GameStub::new(),
+            stub_c: GameStub::new(),
+            stub_d: GameStub::new(),
+            stub_e: GameStub::new(),
+            bus,
+            blocked,
+            addrs,
+            clock,
+        };
+        mesh.synchronize(1200);
+        let _ = mesh.a.events().count();
+        let _ = mesh.b.events().count();
+        if let Some(c) = mesh.c.as_mut() {
+            let _ = c.events().count();
+        }
+        if let Some(d) = mesh.d.as_mut() {
+            let _ = d.events().count();
+        }
+        let _ = mesh.e.events().count();
+        Ok(mesh)
+    }
+
+    impl Mesh5 {
+        fn synchronize(&mut self, iterations: usize) {
+            for _ in 0..iterations {
+                self.poll_all(1);
+                if self.a.current_state() == SessionState::Running
+                    && self.b.current_state() == SessionState::Running
+                    && self
+                        .c
+                        .as_ref()
+                        .is_none_or(|c| c.current_state() == SessionState::Running)
+                    && self
+                        .d
+                        .as_ref()
+                        .is_none_or(|d| d.current_state() == SessionState::Running)
+                    && self.e.current_state() == SessionState::Running
+                {
+                    return;
+                }
+            }
+            panic!(
+                "five hot-join mesh sessions failed to synchronize: A={:?} B={:?} C={:?} D={:?} E={:?}",
+                self.a.current_state(),
+                self.b.current_state(),
+                self.c.as_ref().map(P2PSession::current_state),
+                self.d.as_ref().map(P2PSession::current_state),
+                self.e.current_state()
+            );
+        }
+
+        /// Polls all currently-live sessions (A, B, D, E, and C if present)
+        /// `iterations` times, advancing the clock each iteration.
+        fn poll_all(&mut self, iterations: usize) {
+            for _ in 0..iterations {
+                self.a.poll_remote_clients();
+                self.b.poll_remote_clients();
+                self.e.poll_remote_clients();
+                if let Some(c) = self.c.as_mut() {
+                    c.poll_remote_clients();
+                }
+                if let Some(d) = self.d.as_mut() {
+                    d.poll_remote_clients();
+                }
+                self.clock.advance(POLL_INTERVAL_DETERMINISTIC);
+            }
+        }
+
+        /// Advances every currently-live survivor one frame on distinct,
+        /// per-peer input streams (so any frozen value is frame-sensitive, never
+        /// vacuously byte-equal). `base + handle` keeps the streams distinct.
+        fn advance_all(&mut self, base: u32) {
+            try_advance(&mut self.a, &mut self.stub_a, H_A, base);
+            try_advance(&mut self.b, &mut self.stub_b, H_B, base + 100);
+            try_advance(&mut self.e, &mut self.stub_e, H_E, base + 400);
+            if let Some(c) = self.c.as_mut() {
+                try_advance(c, &mut self.stub_c, H_C, base + 200);
+            }
+            if let Some(d) = self.d.as_mut() {
+                try_advance(d, &mut self.stub_d, H_D, base + 300);
+            }
+        }
+
+        /// Moves D out and drops it (vacating D's address; D never rejoins).
+        fn drop_d(&mut self) {
+            if let Some(d) = self.d.take() {
+                drop(d);
+            }
+        }
+
+        /// Settles in-flight inputs (poll-only rounds) so every live peer's
+        /// receipt of every other converges — a subsequent drop then freezes the
+        /// slot at ONE frame mesh-wide.
+        fn settle(&mut self, polls: usize) {
+            self.poll_all(polls);
+        }
+    }
+
+    /// A real N-peer hot-join joiner re-filling C's slot (local handle 2),
+    /// registering the full roster — including the carried-DEAD slot D at D's
+    /// address (a rejoiner knows the session shape, not who is alive; its
+    /// endpoint toward the dead address simply never synchronizes, and the
+    /// snapshot's carried statuses tell it the slot is frozen). Built through the
+    /// PUBLIC `start_hot_join_session` (S35 guard lift) — no test bypass.
+    struct Joiner {
+        session: P2PSession<StubConfig>,
+        stub: GameStub,
+        events: Vec<FortressEvent<StubConfig>>,
+        /// Per-frame `(value, InputStatus)` the joiner surfaces for the
+        /// carried-dead slot D in its `AdvanceFrame` requests (last write per
+        /// frame is the post-rollback value). A public proxy for "the joiner
+        /// carries D disconnected": `local_connect_status` is private, but the
+        /// per-slot status threaded into every `AdvanceFrame` is observable.
+        d_slot: BTreeMap<i32, (u32, InputStatus)>,
+    }
+
+    impl Joiner {
+        /// Builds the joiner at C's (vacated) address over a fresh
+        /// [`FilterBusSocket`] sharing the mesh bus + blocked-links handle.
+        fn build(mesh: &Mesh5) -> Result<Self, FortressError> {
+            let addrs = mesh.addrs;
+            let socket = FilterBusSocket::new(&mesh.bus, addrs[2], mesh.blocked.clone());
+            let session = SessionBuilder::<StubConfig>::new()
+                .with_protocol_config(protocol_config(&mesh.clock))
+                .with_num_players(5)?
+                .with_desync_detection_mode(DesyncDetection::On { interval: 2 })
+                .with_disconnect_behavior(DisconnectBehavior::ContinueWithout)
+                .add_player(PlayerType::Remote(addrs[0]), H_A)?
+                .add_player(PlayerType::Remote(addrs[1]), H_B)?
+                .add_player(PlayerType::Local, H_C)?
+                .add_player(PlayerType::Remote(addrs[3]), H_D)?
+                .add_player(PlayerType::Remote(addrs[4]), H_E)?
+                .start_hot_join_session(socket, addrs[0])?;
+            Ok(Self {
+                session,
+                stub: GameStub::new(),
+                events: Vec::new(),
+                d_slot: BTreeMap::new(),
+            })
+        }
+
+        fn poll(&mut self) {
+            self.session.poll_remote_clients();
+            self.events.extend(self.session.events());
+        }
+
+        /// Applies the joiner's advance requests into its stub, recording the
+        /// D-slot `(value, status)` from each `AdvanceFrame` (re-simulations
+        /// re-key the same frame, so the last write per frame is post-rollback).
+        fn apply_recording(&mut self, requests: fortress_rollback::RequestVec<StubConfig>) {
+            const D: usize = 3;
+            for request in requests {
+                match request {
+                    FortressRequest::LoadGameState { cell, .. } => {
+                        self.stub.gs = cell.load().expect("joiner load cell");
+                    },
+                    FortressRequest::SaveGameState { cell, frame } => {
+                        let checksum = crate::common::calculate_hash(&self.stub.gs);
+                        cell.save(frame, Some(self.stub.gs), Some(checksum as u128));
+                    },
+                    FortressRequest::AdvanceFrame { inputs } => {
+                        let d = inputs.get(D).map(|&(input, status)| (input.inp, status));
+                        self.stub.gs.advance_frame_pub(inputs);
+                        if let Some(vs) = d {
+                            self.d_slot.insert(self.stub.gs.frame, vs);
+                        }
+                    },
+                }
+            }
+        }
+
+        /// Drives one local-input + advance on the joiner, recording D's slot.
+        /// Tolerates the prediction cap (the fold still ran).
+        fn advance_recording(&mut self, value: u32) {
+            match self.session.add_local_input(H_C, StubInput { inp: value }) {
+                Ok(()) => {},
+                Err(FortressError::PredictionThreshold | FortressError::NotSynchronized) => return,
+                Err(other) => panic!("joiner add_local_input error: {other:?}"),
+            }
+            match self.session.advance_frame() {
+                Ok(requests) => self.apply_recording(requests),
+                Err(FortressError::PredictionThreshold | FortressError::NotSynchronized) => {},
+                Err(other) => panic!("joiner advance_frame error: {other:?}"),
+            }
+        }
+    }
+
+    /// Advances a live survivor one frame with a deterministic local input,
+    /// applying the resulting requests into `stub`. Tolerates the prediction cap
+    /// and `NotSynchronized` (the fold still ran inside `advance_frame`).
+    fn try_advance(
+        session: &mut P2PSession<StubConfig>,
+        stub: &mut GameStub,
+        handle: PlayerHandle,
+        value: u32,
+    ) {
+        match session.add_local_input(handle, StubInput { inp: value }) {
+            Ok(()) => {},
+            Err(FortressError::PredictionThreshold | FortressError::NotSynchronized) => return,
+            Err(other) => panic!("unexpected add_local_input error: {other:?}"),
+        }
+        match session.advance_frame() {
+            Ok(requests) => stub.handle_requests(requests),
+            Err(FortressError::PredictionThreshold | FortressError::NotSynchronized) => {},
+            Err(other) => panic!(
+                "unexpected advance_frame error for handle {handle:?} at current {:?}: {other:?}",
+                session.current_frame()
+            ),
+        }
+    }
+
+    /// Drops slot D mesh-wide (symmetric freeze) and frees D's session, leaving
+    /// D carried-dead. The surviving mesh then advances so the eventual snapshot
+    /// frame `S` sits strictly above D's freeze frame (so a joiner inherits D
+    /// disconnected BELOW its baseline `S`). D is NEVER rejoined.
+    ///
+    /// Returns an UPPER BOUND on D's freeze frame: the coordinator A's
+    /// `current_frame` at the moment of the drop. A froze D at its own received
+    /// frame for D, which cannot exceed A's current frame — so any later
+    /// snapshot frame `S` strictly above this witness is provably strictly above
+    /// D's freeze. The caller asserts `S > witness` to make "below `S`" rigorous
+    /// rather than merely staged.
+    fn drop_d_symmetric(mesh: &mut Mesh5) -> Frame {
+        mesh.settle(8);
+        mesh.a.remove_player(H_D).expect("A removes D");
+        mesh.b.remove_player(H_D).expect("B removes D");
+        mesh.e.remove_player(H_D).expect("E removes D");
+        if let Some(c) = mesh.c.as_mut() {
+            c.remove_player(H_D).expect("C removes D");
+        }
+        // A froze D at <= A's current frame; capture that upper bound before the
+        // mesh advances past it.
+        let d_freeze_upper_bound = mesh.a.current_frame();
+        // Free D's session: its address goes quiet, its slot stays frozen
+        // mesh-wide. D never rejoins (it remains carried-dead).
+        mesh.drop_d();
+        let _ = mesh.a.events().count();
+        let _ = mesh.b.events().count();
+        let _ = mesh.e.events().count();
+
+        // The surviving live mesh (A, B, C, E) keeps advancing with D frozen, so
+        // S climbs strictly above D's freeze frame.
+        for i in 0..5_u32 {
+            mesh.poll_all(3);
+            mesh.advance_all(40 + i);
+        }
+        d_freeze_upper_bound
+    }
+
+    /// Drops slot C cleanly on every live survivor (explicit `remove_player`),
+    /// then frees C's session so its address is vacant for the rejoiner. The
+    /// hot-join coordinator A re-reserves the slot. Asserts A re-armed the slot.
+    fn drop_c_cleanly(mesh: &mut Mesh5) {
+        mesh.settle(8);
+        mesh.a.remove_player(H_C).expect("A removes C");
+        mesh.b.remove_player(H_C).expect("B removes C");
+        mesh.e.remove_player(H_C).expect("E removes C");
+        if let Some(d) = mesh.d.as_mut() {
+            d.remove_player(H_C).expect("D removes C");
+        }
+        let c = mesh.c.take().expect("C present before drop");
+        drop(c);
+        let _ = mesh.a.events().count();
+        let _ = mesh.b.events().count();
+        let _ = mesh.e.events().count();
+        if let Some(d) = mesh.d.as_mut() {
+            let _ = d.events().count();
+        }
+        // Let the drop converge mesh-wide.
+        for _ in 0..6 {
+            mesh.poll_all(3);
+            mesh.advance_all(70);
+        }
+    }
+
+    /// Drives a joiner from "constructed" to "Running real-from-F" over the wire,
+    /// keeping the live survivors advancing so the serve can capture + commit.
+    /// Returns the snapshot frame `S` (the frame the joiner loads). Asserts the
+    /// first post-commit `advance_frame()` is exactly
+    /// `[LoadGameState(S), AdvanceFrame(bridge)]`.
+    fn drive_joiner_to_running(mesh: &mut Mesh5, joiner: &mut Joiner) -> Frame {
+        let mut reached = false;
+        for i in 0..1200_u32 {
+            mesh.poll_all(1);
+            joiner.poll();
+            if i % 3 == 2 {
+                mesh.advance_all(80 + (i % 8));
+            }
+            if joiner.session.current_state() == SessionState::Running {
+                reached = true;
+                break;
+            }
+        }
+        assert!(
+            reached,
+            "joiner reached Running over the wire (state {:?})",
+            joiner.session.current_state()
+        );
+        drive_first_advance(joiner)
+    }
+
+    /// The joiner's first post-commit `advance_frame()`: asserts it is exactly
+    /// `[LoadGameState(S), AdvanceFrame(bridge)]`, applies it (recording D), and
+    /// returns the snapshot frame `S`.
+    fn drive_first_advance(joiner: &mut Joiner) -> Frame {
+        let requests = joiner.session.advance_frame().expect("post-commit advance");
+        let mut load_frame = None;
+        let mut load_count = 0;
+        let mut advance_count = 0;
+        for request in &*requests {
+            match request {
+                FortressRequest::LoadGameState { frame, .. } => {
+                    load_count += 1;
+                    load_frame = Some(*frame);
+                },
+                FortressRequest::AdvanceFrame { .. } => advance_count += 1,
+                FortressRequest::SaveGameState { .. } => {},
+            }
+        }
+        assert_eq!(load_count, 1, "exactly one LoadGameState on first advance");
+        assert_eq!(advance_count, 1, "exactly one bridge AdvanceFrame");
+        let serve_s = load_frame.expect("a snapshot frame was loaded");
+        joiner.apply_recording(requests);
+        serve_s
+    }
+
+    /// Runs the live mesh + joiner forward together for `rounds`, advancing the
+    /// joiner with distinct inputs (recording D's slot) so the joiner settles
+    /// into deep post-join operation and its carried-dead D status is observable.
+    fn run_mesh_and_joiner(mesh: &mut Mesh5, joiner: &mut Joiner, rounds: u32) {
+        for k in 0..rounds {
+            mesh.poll_all(2);
+            joiner.poll();
+            // Advance every round; the prediction cap self-throttles (advance
+            // helpers early-return at the cap), and frequent advances let the
+            // joiner confirm — and thus record D's carried status on — many
+            // distinct post-join frames rather than re-simulating a tiny window.
+            mesh.advance_all(90 + (k % 8));
+            joiner.advance_recording(95 + (k % 8));
+        }
+    }
+
+    #[test]
+    fn npeer_hot_join_five_player_mesh_builds_and_synchronizes() -> Result<(), FortressError> {
+        let mesh = build_mesh5()?;
+        assert_eq!(mesh.a.num_players(), 5);
+        assert_eq!(mesh.a.current_state(), SessionState::Running);
+        assert_eq!(mesh.e.current_state(), SessionState::Running);
+        assert_eq!(
+            mesh.c.as_ref().map(P2PSession::current_state),
+            Some(SessionState::Running)
+        );
+        // The wire handle is shared and directional toggling works.
+        assert!(!mesh.blocked.is_blocked_pub(mesh.addrs[0], mesh.addrs[1]));
+        Ok(())
+    }
+
+    /// The reusable integration joiner-drive. Warm up the 5-peer mesh, drop C
+    /// cleanly, drive a real public `start_hot_join_session` joiner to `Running`
+    /// over the wire, and assert the first post-commit advance is exactly the
+    /// `[LoadGameState(S), AdvanceFrame(bridge)]` batch. The first integration
+    /// test that exercises the N-peer joiner-drive lifecycle over a genuine wire
+    /// (previously `src/`-unit-test / `MeshBus`-only).
+    #[test]
+    fn npeer_hot_join_joiner_drives_to_running_over_filtered_wire() -> Result<(), FortressError> {
+        let mut mesh = build_mesh5()?;
+
+        // Warm up so the mesh has confirmed history.
+        for i in 0..8_u32 {
+            mesh.poll_all(3);
+            mesh.advance_all(i);
+        }
+
+        drop_c_cleanly(&mut mesh);
+        assert!(mesh.c.is_none(), "C vacated its slot");
+
+        let mut joiner = Joiner::build(&mesh)?;
+        assert_eq!(joiner.session.current_state(), SessionState::HotJoining);
+
+        let serve_s = drive_joiner_to_running(&mut mesh, &mut joiner);
+        assert!(serve_s.as_i32() >= 0, "snapshot frame is real");
+        assert_eq!(
+            joiner.session.current_state(),
+            SessionState::Running,
+            "joiner is Running after the load+bridge"
+        );
+        assert!(
+            joiner.session.current_frame().as_i32() > serve_s.as_i32(),
+            "joiner advanced past the snapshot frame (real from F={serve_s:?})"
+        );
+        Ok(())
+    }
+
+    /// The foundational leg of the fold-below-`S` corner: stage the carried-dead
+    /// slot D (died mesh-wide before the serve) so the committed joiner inherits
+    /// it disconnected and frozen strictly BELOW its snapshot baseline `S`, over
+    /// a genuine wire. Proven via the PUBLIC per-slot `InputStatus` threaded into
+    /// the joiner's `AdvanceFrame` requests: every post-join frame surfaces D as
+    /// `Disconnected` with a single constant (genuinely frozen) value. This is
+    /// the stable carried-below-`S` state the (unlanded) violation trigger would
+    /// then lower further — see the module header for why that delivery is the
+    /// open future-work delta.
+    #[test]
+    fn npeer_hot_join_joiner_commits_carrying_dead_slot_below_snapshot_baseline(
+    ) -> Result<(), FortressError> {
+        let mut mesh = build_mesh5()?;
+        for i in 0..6_u32 {
+            mesh.poll_all(3);
+            mesh.advance_all(i);
+        }
+
+        let d_freeze_upper_bound = drop_d_symmetric(&mut mesh);
+        drop_c_cleanly(&mut mesh);
+
+        let mut joiner = Joiner::build(&mesh)?;
+        let serve_s = drive_joiner_to_running(&mut mesh, &mut joiner);
+        run_mesh_and_joiner(&mut mesh, &mut joiner, 90);
+
+        // "Below S" is rigorous, not merely staged: D's freeze is <= the witness
+        // (A's frame when it froze D), and the snapshot baseline S is strictly
+        // above that witness — so D is carried frozen strictly below S.
+        assert!(
+            serve_s.as_i32() > d_freeze_upper_bound.as_i32(),
+            "snapshot baseline S={serve_s:?} must sit strictly above D's freeze \
+             (upper bound {d_freeze_upper_bound:?}) — else 'below S' is unproven"
+        );
+
+        // The joiner must surface D as Disconnected on every frame it recorded,
+        // and that frozen value must be constant (a genuine frozen slot). A floor
+        // of >= 10 recorded frames keeps the constant-value check non-vacuous (a
+        // single-frame sample could not distinguish frozen from coincidental).
+        assert!(
+            joiner.d_slot.len() >= 10,
+            "joiner recorded too few D-slot statuses ({}) — vacuous staging",
+            joiner.d_slot.len()
+        );
+        let frozen_values: std::collections::BTreeSet<u32> =
+            joiner.d_slot.values().map(|&(v, _)| v).collect();
+        assert_eq!(
+            frozen_values.len(),
+            1,
+            "D's carried value must be frozen (constant) across all {} recorded post-join \
+             frames, got {frozen_values:?}",
+            joiner.d_slot.len()
+        );
+        for (frame, (value, status)) in &joiner.d_slot {
+            assert_eq!(
+                *status,
+                InputStatus::Disconnected,
+                "joiner must carry D Disconnected at frame {frame} (value {value})"
+            );
+        }
+        // Sanity: the joiner is deep in post-join operation, advancing past S.
+        assert!(
+            joiner.session.current_frame().as_i32() > serve_s.as_i32(),
+            "joiner advanced its current frame past S={serve_s:?} (deep post-join), got {:?} \
+             (confirmed {:?})",
+            joiner.session.current_frame(),
+            joiner.session.confirmed_frame(),
+        );
+        Ok(())
+    }
 }

--- a/wiki/API-Contracts.md
+++ b/wiki/API-Contracts.md
@@ -107,9 +107,9 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidRequest("Player handle already in use")` - handle duplicate
-- `InvalidRequest("...handle should be between 0 and num_players")` - invalid player handle
-- `InvalidRequest("...handle should be num_players or higher")` - invalid spectator handle
+- `InvalidRequestStructured { kind: PlayerHandleInUse { handle } }` - handle duplicate
+- `InvalidRequestStructured { kind: InvalidLocalPlayerHandle { handle, num_players } }` / `InvalidRequestStructured { kind: InvalidRemotePlayerHandle { handle, num_players } }` - invalid Local/Remote handle (`handle.0 >= num_players`)
+- `InvalidRequestStructured { kind: InvalidSpectatorHandle { handle, num_players } }` - invalid spectator handle (`handle.0 < num_players`)
 
 **Panics:** Never
 
@@ -164,7 +164,7 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidRequest("FPS should be higher than 0")` - if `fps = 0`
+- `InvalidRequestStructured { kind: ZeroFps }` - if `fps = 0`
 
 **Panics:** Never
 
@@ -246,7 +246,7 @@ Each API is documented with:
 
 ---
 
-### `start_p2p_session(self, socket: impl NonBlockingSocket<T::Address>) -> Result<P2PSession<T>, FortressError>`
+### `start_p2p_session(self, socket: impl NonBlockingSocket<T::Address> + 'static) -> Result<P2PSession<T>, FortressError>`
 
 ```rust
 /// Consume builder and create a P2P session.
@@ -265,7 +265,7 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidRequest("Not enough players have been added...")` - missing players
+- `InvalidRequestStructured { kind: NotEnoughPlayers { expected, actual } }` - not all player handles `0..num_players` have been registered
 
 **Panics:** Never
 
@@ -277,7 +277,7 @@ Each API is documented with:
 
 ---
 
-### `start_spectator_session(self, host_addr: T::Address, socket: impl NonBlockingSocket<T::Address>) -> Option<SpectatorSession<T>>`
+### `start_spectator_session(self, host_addr: T::Address, socket: impl NonBlockingSocket<T::Address> + 'static) -> Option<SpectatorSession<T>>`
 
 ```rust
 /// Create a spectator session connected to a host.
@@ -321,7 +321,7 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidRequest("Check distance too big")` - if `check_distance >= max_prediction`
+- `InvalidRequestStructured { kind: CheckDistanceTooLarge { check_dist, max_prediction } }` - if `check_distance >= max_prediction`
 
 **Panics:** Never
 
@@ -406,8 +406,7 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidPlayerHandle` - handle not registered or not local
-- `InvalidRequest("Prediction threshold reached")` - too far ahead
+- `InvalidRequestStructured { kind: NotLocalPlayer { handle } }` - handle is not a registered local player
 
 **Panics:** Never
 
@@ -504,13 +503,13 @@ Each API is documented with:
 /// Get network statistics for a remote player.
 ```
 
-**Pre:** `handle` is a remote player
+**Pre:** `handle` is a remote player or spectator
 
 **Post:** Returns stats (ping, bandwidth, etc.)
 
 **Errors:**
 
-- `InvalidPlayerHandle` - not a remote player
+- `InvalidRequestStructured { kind: NotRemotePlayerOrSpectator { handle } }` - handle is neither a remote player nor a spectator
 - `NotSynchronized` - stats not yet available
 
 **Panics:** Never
@@ -571,7 +570,7 @@ Each API is documented with:
 - `InvalidRequestStructured { kind: DisconnectInvalidHandle { handle } }` - handle not registered, or refers to a spectator
 - `InvalidRequestStructured { kind: DisconnectLocalPlayer { handle } }` - handle refers to a local player
 - `InvalidRequestStructured { kind: PlayerAlreadyRemoved { handle } }` - handle is already marked disconnected (either via a prior `remove_player` call, via auto-removal under `DisconnectBehavior::ContinueWithout`, or via a previous explicit `disconnect_player` call)
-- `InternalErrorStructured { kind: DisconnectStatusNotFound { handle } | IndexOutOfBounds { .. } }` - internal-invariant violation (a registered handle has no corresponding input queue or connection-status entry); should not occur in correct code, treat as a library bug
+- `InternalErrorStructured { kind: DisconnectStatusNotFound { handle } | IndexOutOfBounds(..) }` - internal-invariant violation (a registered handle has no corresponding input queue or connection-status entry); should not occur in correct code, treat as a library bug
 
 **Panics:** Never
 
@@ -717,7 +716,8 @@ Each API is documented with:
 
 **Errors:**
 
-- `InvalidRequest` on checksum mismatch (desync detected)
+- `MismatchedChecksum { current_frame, mismatched_frames }` on checksum mismatch (desync detected during resimulation)
+- `InvalidRequestStructured { kind: MissingLocalInput }` - not all players provided input
 
 **Panics:** Never
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -134,6 +134,8 @@ pub enum PlayerType<A> {
 pub enum SessionState {
     Synchronizing, // Establishing connection with remotes
     Running,       // Synchronized and accepting input
+    #[cfg(feature = "hot-join")]
+    HotJoining,    // Applying a state snapshot to (re)join a running session
 }
 ```
 
@@ -638,7 +640,7 @@ Before dropping a session, verify:
 
 **Important:** There are two distinct state types in Fortress Rollback:
 
-- **`SessionState`** (2 states): The high-level session state visible to users
+- **`SessionState`** (2 states by default; a third `HotJoining` state exists with the `hot-join` feature): The high-level session state visible to users
   - `Synchronizing` — Establishing connection with remotes
   - `Running` — Synchronized and accepting input
 
@@ -742,6 +744,9 @@ graph TD
     QUALITY["QualityReport<br/>(Frame advantage)"]
     QREPLY["QualityReply<br/>(Response to report)"]
     CHECKSUM["ChecksumReport<br/>(Desync detection)"]
+    FLOORREQ["FloorRequest<br/>(N&ge;4 relay floor round)"]
+    FLOORREP["FloorReply<br/>(Per-slot pessimistic floors)"]
+    KEEPALIVE["KeepAlive<br/>(Idle connection upkeep)"]
 
     MSG --> HEADER
     MSG --> BODY
@@ -751,7 +756,12 @@ graph TD
     BODY --> QUALITY
     BODY --> QREPLY
     BODY --> CHECKSUM
+    BODY --> FLOORREQ
+    BODY --> FLOORREP
+    BODY --> KEEPALIVE
 ```
+
+Hot-join builds (the `hot-join` feature) additionally carry join-lifecycle bodies (`JoinRequest`, `StateSnapshot`, `StateSnapshotAck`, `ReactivateSlot`, `ReactivateSlotAck`, `JoinCommitted`, `JoinAborted`).
 
 ### Time Synchronization
 
@@ -863,6 +873,7 @@ use fortress_rollback::Frame;
 pub struct ConnectionStatus {
     pub disconnected: bool,  // Is the player disconnected?
     pub last_frame: Frame,   // Last frame we received input for
+    pub epoch: u16,          // Per-slot generation; bumped on each connect<->disconnect transition
 }
 ```
 
@@ -982,8 +993,8 @@ The protocol is UDP-based (unreliable) but handles:
 
 Regular packets maintain connection:
 
-- `running_retry_interval` (configurable, default 200ms): interval for resending inputs and quality reports
-- `QualityReport` sent every `running_retry_interval`
+- `running_retry_interval` (configurable, default 200ms): interval for resending unacknowledged inputs
+- `QualityReport` sent every `quality_report_interval` (configurable, default 200ms)
 - Disconnect after `disconnect_timeout` (configurable, default 2000ms)
 
 ---

--- a/wiki/Determinism-Model.md
+++ b/wiki/Determinism-Model.md
@@ -131,7 +131,7 @@ fn spawn_enemy(state: &mut GameState, rng: &mut SeededRng) {
 
 **Implementation:**
 
-- ✅ `bincode` with default configuration (little-endian, fixed-size integers)
+- ✅ `bincode` configured with `standard().with_little_endian().with_fixed_int_encoding()` (fixed-size integers are an explicit override of bincode's variable-int default, ensuring identical serialized bytes across platforms)
 - ✅ Input types require `Serialize + Deserialize`
 - ✅ No platform-specific serialization
 
@@ -154,7 +154,7 @@ pub trait Config: 'static {
 
 - ✅ `#![forbid(unsafe_code)]` prevents uninitialized memory access
 - ✅ All arrays initialized with default values
-- ✅ Input queues initialized with `BLANK_INPUT`
+- ✅ Input queues initialized with blank inputs via `PlayerInput::blank_input(Frame::NULL)`
 
 ### DETER-6: Integer Arithmetic Consistency
 

--- a/wiki/Formal-Specification.md
+++ b/wiki/Formal-Specification.md
@@ -116,7 +116,10 @@ InputStatus = Confirmed | Predicted | Disconnected
 ```
 ConnectionStatus = {
     disconnected: Bool,
-    last_frame: Frame
+    last_frame: Frame,
+    epoch: ℕ            -- u16 monotonic per-slot generation, bumped on each
+                       -- connected<->disconnected transition; rides the
+                       -- connect-status gossip on every Input packet
 }
 ```
 
@@ -197,11 +200,11 @@ less than the current frame. When `first_incorrect_frame >= current_frame`,
 This invariant captures the guard in `adjust_gamestate()`:
 
 ```rust
-if frame_to_load >= current_frame {
+if load_target >= current_frame {
     // skip_rollback path
     return Ok(());
 }
-// Only reach load_frame if frame_to_load < current_frame
+// Only reach load_frame if load_target < current_frame
 ```
 
 ### INV-9a: Message Causality
@@ -304,7 +307,7 @@ POST:
     RETURNS Ok(inputs[frame mod 128])
 
 ERROR:
-    frame > last_added_frame → MissingInput
+    frame mismatch (no confirmed input at slot) → NoConfirmedInput (FortressError::InvalidRequestStructured)
 ```
 
 #### reset_prediction()
@@ -357,7 +360,7 @@ POST:
     RETURNS input_queues[handle].add_input(input)
 ```
 
-#### synchronized_inputs(connect_status) → Vec&lt;(Input, InputStatus)&gt;
+#### synchronized_inputs(connect_status) → Option&lt;Vec&lt;(Input, InputStatus)&gt;&gt;
 
 ```
 POST:
@@ -400,8 +403,8 @@ POST:
     RETURNS Ok(LoadGameState { frame, cell })
 
 ERROR:
-    frame = NULL_FRAME → InvalidFrame("cannot load NULL_FRAME")
-    frame >= current_frame → InvalidFrame("must load frame in the past")
+    frame = NULL_FRAME → InvalidFrameStructured(NullFrame)        -- "cannot load NULL_FRAME"
+    frame >= current_frame → InvalidFrameStructured(NotInPast)    -- "must load frame in the past (current: …)"
 ```
 
 #### skip_rollback()
@@ -426,7 +429,8 @@ COMMENT:
         first_incorrect_frame = 0, current_frame = 0
 
     Production code (p2p_session.rs, adjust_gamestate):
-        if frame_to_load >= current_frame {
+        let load_target = frame_to_load.max(window_floor); // clamp UP to prediction-window floor
+        if load_target >= current_frame {
             self.sync_layer.reset_prediction();
             return Ok(());  // Skip rollback
         }
@@ -498,6 +502,17 @@ MessageBody =
     | QualityReport { frame_advantage: i16, ping: u128 }
     | QualityReply { pong: u128 }
     | ChecksumReport { checksum: u128, frame: Frame }
+    | KeepAlive
+    | FloorRequest { round_seq: u32 }                    -- floor-round protocol (N>=4 double-failure-relay convergence)
+    | FloorReply { round_seq: u32, floors: Vec<Frame> }  -- relay's per-slot pessimistic floors
+    -- The following are only present with cfg(feature = "hot-join"):
+    | JoinRequest { player_handle: usize }
+    | StateSnapshot { ... }
+    | StateSnapshotAck { ... }
+    | ReactivateSlot { ... }
+    | ReactivateSlotAck { ... }
+    | JoinCommitted { ... }
+    | JoinAborted { frame: Frame }
 ```
 
 ---
@@ -639,8 +654,8 @@ MessageBody =
 | Protocol state machine        | TLA+ | ✅ Implemented (`specs/tla/NetworkProtocol.tla`)  |
 | LIVE-1 (sync convergence)     | TLA+ | ✅ Implemented (`specs/tla/NetworkProtocol.tla`)  |
 | SAFE-4 (rollback consistency) | TLA+ | ✅ Implemented (`specs/tla/Rollback.tla`)         |
-| Frame arithmetic              | Z3   | ✅ Implemented (`tests/test_z3_verification.rs`)  |
-| Queue index math              | Z3   | ✅ Implemented (`tests/test_z3_verification.rs`)  |
+| Frame arithmetic              | Z3   | ✅ Implemented (`tests/verification/z3.rs`)       |
+| Queue index math              | Z3   | ✅ Implemented (`tests/verification/z3.rs`)       |
 | Concurrency (GameStateCell)   | Loom | ✅ Implemented (`loom-tests/`)                    |
 | Time synchronization          | TLA+ | ✅ Implemented (`specs/tla/TimeSync.tla`)         |
 | Checksum exchange             | TLA+ | ✅ Implemented (`specs/tla/ChecksumExchange.tla`) |

--- a/wiki/Fortress-vs-GGRS.md
+++ b/wiki/Fortress-vs-GGRS.md
@@ -116,7 +116,7 @@ InvalidFrame { frame: Frame(0), reason: "must load frame in the past" }
 **Fix:**
 
 - Created new `fortress_rollback::hash` module with FNV-1a deterministic hashing
-- Window-based checksum computation using last 64 frames ensures frames are always available for both peers
+- Checksums are tracked per frame in a bounded history (`max_checksum_history`, default 32) and compared at the desync-detection interval (default `interval: 60`), so the compared frame is available on both peers
 
 ---
 
@@ -133,7 +133,7 @@ InvalidFrame { frame: Frame(0), reason: "must load frame in the past" }
 ```rust
 // Explicit spectator validation
 impl PlayerHandle {
-    pub fn is_spectator_for(&self, num_players: usize) -> bool {
+    pub const fn is_spectator_for(self, num_players: usize) -> bool {
         self.0 >= num_players
     }
 }
@@ -280,13 +280,15 @@ let range_value: u32 = rng.gen_range(1..100);
 
 ```rust
 use fortress_rollback::hash::{fnv1a_hash, DeterministicHasher};
+use std::hash::Hasher; // brings write()/finish() into scope
 
 // Hash any hashable data deterministically
 let checksum = fnv1a_hash(&game_state);
 
 // Or use the hasher directly
+let data: &[u8] = b"some bytes";
 let mut hasher = DeterministicHasher::new();
-hasher.write(&data);
+hasher.write(data);
 let hash = hasher.finish();
 ```
 
@@ -470,9 +472,9 @@ ChaosConfig::intercontinental() // High-latency stable connection
 
 ### Formal Verification
 
-- **7 TLA+ specifications** covering core protocols (Rollback, InputQueue, NetworkProtocol, TimeSync, ChecksumExchange, SpectatorSession, Concurrency)
-- **115 Kani proofs** for bounded model checking
-- **54 Z3 SMT proofs** for algorithmic correctness
+- **15 TLA+ specifications** covering core protocols (Rollback, InputQueue, NetworkProtocol, TimeSync, ChecksumExchange, SpectatorSession, Concurrency) as well as N-peer/freeze/failover protocols (DoubleFailureRelay, FrameAdvantageAggregation, FreezeConvergence, NPeerReactivation, NPeerServeFreezeConvergence, PeerDrop, SpectatorFailover, SpectatorReactivationEpoch)
+- **130 Kani proofs** for bounded model checking
+- **65 Z3 SMT proofs** for algorithmic correctness
 
 ### Testing
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -105,7 +105,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 >
 > - All `panic!` and `assert!` converted to recoverable errors
 > - Deterministic `BTreeMap`/`BTreeSet` instead of `HashMap`/`HashSet`
-> - ~1600 tests with ~92% code coverage
+> - ~2200 tests with ~92% code coverage
 > - TLA+, Z3, and Kani formal verification
 >
 > [Full comparison](Fortress-vs-GGRS)

--- a/wiki/Migration.md
+++ b/wiki/Migration.md
@@ -14,7 +14,7 @@ Fortress Rollback is the correctness-first, verified fork of the original `ggrs`
 - Ensure your `Config::Address` type implements `Ord` + `PartialOrd` (in addition to `Clone + Eq + Hash`).
 - Rename types: `GgrsError` → `FortressError`, `GgrsEvent` → `FortressEvent`, `GgrsRequest` → `FortressRequest`.
 - All examples/tests now import `fortress_rollback`; mirror that pattern in your code.
-- **New in Unreleased:** runtime input-delay adjustment (`set_input_delay`/`input_delay`), opt-in graceful peer drop (`DisconnectBehavior::ContinueWithout`, `with_disconnect_behavior`), explicit graceful removal (`remove_player`), and fail-closed redundant spectator divergence; exhaustive matches on `FortressEvent`, `FortressError`, `InvalidRequestKind`, and `InternalErrorKind` need new arms — see [Unreleased section](#unreleased-runtime-input-delay-disconnect-behavior-graceful-peer-removal-and-spectator-divergence).
+- **New in Unreleased:** runtime input-delay adjustment (`set_input_delay`/`input_delay`), opt-in graceful peer drop (`DisconnectBehavior::ContinueWithout`, `with_disconnect_behavior`), explicit graceful removal (`remove_player`), and fail-closed redundant spectator divergence; exhaustive matches on `FortressEvent`, `FortressError`, `InvalidRequestKind`, `InternalErrorKind`, `SerializationErrorKind`, `RleDecodeReason`, and `DeltaDecodeReason` need new arms — see [Unreleased section](#unreleased-runtime-input-delay-disconnect-behavior-graceful-peer-removal-and-spectator-divergence).
 
 ## Dependency Changes
 
@@ -194,6 +194,8 @@ The `sync-send` feature flag remains compatible. Fortress Rollback adds several 
 | `loom`               | Concurrency testing                    | ✅               |
 | `z3-verification`    | Formal verification tests              | ✅               |
 | `graphical-examples` | Interactive demos                      | ✅               |
+| `hot-join`           | Peers can join/rejoin a running session via a state snapshot (requires `Config::State: Serialize + DeserializeOwned`) | ✅               |
+| `z3-verification-bundled` | `z3-verification` with a bundled Z3 build (no system Z3 needed) | ✅               |
 
 > **Note:** The `json` feature enables `to_json()` and `to_json_pretty()` methods on telemetry types.
 > Without this feature, the `serde_json` dependency is not included, reducing the default dependency count.

--- a/wiki/Replay.md
+++ b/wiki/Replay.md
@@ -211,7 +211,7 @@ while !session.is_complete() {
 | `num_players` | Number of players in the recorded match |
 | `frames` | `Vec<Vec<I>>` -- inputs per frame, one entry per player |
 | `checksums` | `Vec<Option<u128>>` -- per-frame checksums for validation |
-| `metadata` | `ReplayMetadata` -- version, player count, frame count |
+| `metadata` | `ReplayMetadata` -- library version, player count, total frame count, and skipped-frame count |
 | `to_bytes()` | Serialize to bytes (deterministic bincode codec) |
 | `from_bytes(&[u8])` | Deserialize from bytes and validate the result |
 | `from_bytes_with_config(&[u8], ReplayDecodeConfig)` | Deserialize with a caller-defined byte limit or validation setting |

--- a/wiki/Spec-Divergences.md
+++ b/wiki/Spec-Divergences.md
@@ -32,9 +32,9 @@ This document lists intentional divergences between formal specifications and pr
 
 | Constant             | Kani Value | Production Value | Justification                                                                                                                                        |
 | -------------------- | ---------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `INPUT_QUEUE_LENGTH` | 8          | 128              | Kani's symbolic execution is exponential in array size. 8 elements is sufficient to prove circular buffer invariants (wrap-around, bounds checking). |
+| `INPUT_QUEUE_LENGTH` | 7          | 128              | Kani's symbolic execution is exponential in array size. 7 elements is sufficient to prove circular buffer invariants (wrap-around, bounds checking). |
 
-**Verification Strategy:** The invariants are size-independent; proving them for 8 elements implies they hold for 128.
+**Verification Strategy:** The invariants are size-independent; proving them for 7 elements implies they hold for 128.
 
 ### 3. Z3 SMT Constants
 
@@ -166,7 +166,7 @@ The invariants proven in TLA+, Kani, and Z3 are **size-independent**:
 1. **TLA+**: Uses small constants (e.g., `QUEUE_LENGTH=3`) for model checking tractability.
    The invariants (INV-4: length bounded, INV-5: valid indices) hold for ANY `QUEUE_LENGTH >= 2`.
 
-2. **Kani**: Uses `INPUT_QUEUE_LENGTH=8` for symbolic execution tractability.
+2. **Kani**: Uses `INPUT_QUEUE_LENGTH=7` for symbolic execution tractability.
    Circular buffer arithmetic and bounds checking are independent of actual size.
 
 3. **Z3**: Uses default values (128) but proves properties that hold for any valid size.

--- a/wiki/Telemetry.md
+++ b/wiki/Telemetry.md
@@ -303,8 +303,11 @@ sequenceDiagram
         Session->>Telemetry: on_frame_advance(frame)
     end
 
-    Game->>Session: network_stats(player)
-    Session->>Telemetry: on_network_stats(player, stats)
+    Game->>Session: poll_remote_clients()
+    loop For each running remote endpoint
+        Session->>Telemetry: on_network_stats(player, stats)
+    end
+    Note over Session: The public network_stats(player) getter<br/>returns stats to the caller and does not<br/>invoke the telemetry observer.
 ```
 
 ---

--- a/wiki/User-Guide.md
+++ b/wiki/User-Guide.md
@@ -913,7 +913,7 @@ Rollback networking works best under certain network conditions. Understanding t
 - Frequent rollbacks
 - Noticeable input delay recommended (2-3 frames)
 - Use `SyncConfig::high_latency()` preset
-- Consider increasing `max_prediction_frames`
+- Consider increasing the prediction window via `with_max_prediction_window`
 
 **Very High Latency (>200ms RTT)**
 
@@ -1561,7 +1561,10 @@ use fortress_rollback::{network::codec, Message, NonBlockingSocket};
 
 const MAX_MESSAGES_PER_POLL: usize = 64;
 
-struct MyCustomSocket { /* ... */ }
+struct MyCustomSocket {
+    // Raw packets queued by your transport, drained in bounded batches below.
+    incoming: std::collections::VecDeque<(MyAddress, Vec<u8>)>,
+}
 
 impl NonBlockingSocket<MyAddress> for MyCustomSocket {
     fn send_to(&mut self, msg: &Message, addr: &MyAddress) {
@@ -1570,7 +1573,9 @@ impl NonBlockingSocket<MyAddress> for MyCustomSocket {
 
     fn receive_all_messages(&mut self) -> Vec<(MyAddress, Message)> {
         // Return a bounded batch and leave excess packets for a future poll
-        self.drain_received_messages_bounded(MAX_MESSAGES_PER_POLL)
+        let batch_len = self.incoming.len().min(MAX_MESSAGES_PER_POLL);
+        self.incoming
+            .drain(..batch_len)
             .filter_map(|(addr, bytes)| {
                 codec::decode_message(&bytes).ok().map(|(msg, _consumed)| (addr, msg))
             })
@@ -2353,6 +2358,8 @@ const MAX_MESSAGES_PER_POLL: usize = 64;
 
 struct MyWebSocketTransport {
     // Your WebSocket implementation
+    // Raw packets queued by your transport, drained in bounded batches below.
+    incoming: std::collections::VecDeque<(MyPeerId, Vec<u8>)>,
 }
 
 impl NonBlockingSocket<MyPeerId> for MyWebSocketTransport {
@@ -2364,7 +2371,9 @@ impl NonBlockingSocket<MyPeerId> for MyWebSocketTransport {
 
     fn receive_all_messages(&mut self) -> Vec<(MyPeerId, Message)> {
         // Return a bounded batch and leave excess packets for a future poll
-        self.drain_received_messages_bounded(MAX_MESSAGES_PER_POLL)
+        let batch_len = self.incoming.len().min(MAX_MESSAGES_PER_POLL);
+        self.incoming
+            .drain(..batch_len)
             .filter_map(|(peer, bytes)| {
                 codec::decode_message(&bytes).ok().map(|(msg, _consumed)| (peer, msg))
             })


### PR DESCRIPTION
## Description

This PR improves stability and convergence in 3+ player sessions, especially during peer drops and relay-heavy topologies.

User-facing highlights:

- Fixes silent divergence after staggered peer-drop detection by enforcing a safer shared freeze barrier.
- Adds a floor-round (`FloorRequest` / `FloorReply`) so survivors do not confirm past relay-agreed freeze floors.
- Prevents mesh-agreement stalls by sending periodic connect-status nudges while waiting for drop agreement.
- Fixes prediction-window behavior so rollback starts at the first missing frame, avoiding missed resimulation windows.
- Restores per-session violation observer routing across `P2PSession`, `SyncTestSession`, and `SpectatorSession`.
- Expands formal verification coverage with new TLA+ n-peer freeze-convergence specs/configs.
- Updates user and architecture docs to match the new behavior.

Compatibility note:

- Protocol wire format now includes new floor-round messages, so peers in the same live session must run compatible builds.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation (changes to documentation only)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] 🔧 CI/Build (changes to CI configuration or build process)

## Checklist

### Required

- [ ] I have read the [CONTRIBUTING guide](../docs/contributing.md)
- [ ] I have followed the **zero-panic policy**:
  - No `unwrap()` in production code
  - No `expect()` in production code
  - No `panic!()` or `todo!()`
  - All fallible operations return `Result`
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have run `cargo fmt && cargo clippy --workspace --all-targets --features tokio,json` with no warnings
- [ ] I have run `cargo nextest run` and all tests pass

### If Applicable

- [x] I have updated the documentation accordingly
- [x] I have added an entry to `CHANGELOG.md` for user-facing changes
- [ ] I have updated relevant examples in the `examples/` directory
- [ ] My changes generate no new compiler warnings

## Testing

**Tests added/modified:**

- `tests/sessions/peer_drop.rs` (multi-peer drop convergence and relay scenarios)

**Manual testing performed:**

- Added and checked TLA+ n-peer serve/freeze convergence models under `specs/tla/NPeerServeFreezeConvergence*`.
- Verified spec registration updates in `specs/tla/README.md` and script coverage.

## Related Issues

- (None linked)

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes touch core rollback networking (confirmed-frame barrier, wire protocol, input-queue prediction) where bugs cause silent desync or session stalls; violation routing is lower risk but spans all session entry points.
> 
> **Overview**
> **3+ player stability** tightens how survivors agree on freeze floors and confirmed frames after staggered drops: `confirmed_frame()` follows mesh gossip (with connect-status nudges when idle), prediction episodes start at the **first missing** input frame (avoiding silent divergence), and the protocol adds **`FloorRequest` / `FloorReply`** for relay floor rounds — **peers in one session need compatible builds**.
> 
> **Violation observers** now match the documented API: `push_violation_observer` / `ScopedObserverGuard` make `report_violation!` use a thread-local stack; P2P, sync-test, and spectator sessions install the configured observer on public entry points (including construction), with tests that fail if scoping is removed.
> 
> **Verification & tooling:** new **`NPeerServeFreezeConvergence.tla`** (and GateBlind/Witness cfgs) models the hot-join serve gate vs per-survivor freeze convergence; `verify-tla.sh` registers it; integration tests gain **`create_filtered_channel_mesh`** for N≥5 asymmetric loss; docs/specs/changelog/README align with hot-join, epochs, and structured errors; minor CI/doc fixes (lychee URL pattern, shared `CARGO_TARGET_DIR` in markdown-code tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49406793792a777a3e3a16306d399a32790b4fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->