### PR TITLE
Hardening: DST simulation fleet (M0/M1) + wire-exact bandwidth accounting (D1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,52 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Pre-existing:** `NetworkStats::kbps_sent` now reflects the true serialized wire size of each
-  outbound packet instead of `std::mem::size_of_val(&Message)` — the constant in-memory size of the
-  `Message` enum, which is identical for every variant (dominated by the largest one) and independent
-  of the actual payload, since `Vec` contents live on the heap. The old accounting charged a bare
-  `KeepAlive` the same as a fully-loaded `Input`, so the reported send bandwidth was fiction (both
-  systematically wrong and payload-blind). Sending is now metered with a new alloc-free arithmetic
-  `Message::encoded_len()` that is byte-exact against the codec (a property test asserts
-  `encoded_len() == codec::encode(&msg).len()` for arbitrary messages of every variant). The
-  `+ UDP_HEADER_SIZE` per-packet estimate is unchanged; only the payload term is corrected.
-- **Pre-existing:** Closed a permanent whole-mesh confirmation deadlock at 3 or more players (the
-  no-drop sibling of the 0.9.0 gossip-mute fix), found by the new deterministic whole-mesh
-  simulation fleet on its first four-player run. Connect-status gossip rides only `Input` messages;
-  if a peer sent its entire initial prediction window's inputs before hearing a third peer's first
-  input (transient startup loss, jitter, or reordering is enough), its last gossip left that slot's
-  view at `Frame::NULL` in every receiver's cache. Once every peer exhausted its prediction window
-  (`current - confirmed >= max_prediction`) with fully-acked send queues, no peer ever sent another
-  `Input` — `KeepAlive`, `QualityReport`, and `InputAck` carry no connect status — so the stale
-  caches never refreshed and the whole mesh deadlocked **permanently** at `confirmed_frame() ==
-  Frame::NULL` on a perfectly healed network, with every session `Running` and no error or event
-  (an application-visible infinite freeze). The connect-status nudge introduced in 0.9.0 closed
-  exactly this gossip-mute mechanism but only while a locally-detected drop awaited mesh agreement;
-  it now also arms when **both** legs of the deadlock signature hold: the prediction window is
-  exhausted AND the mesh-gossip fold pins confirmation strictly below what locally-received inputs
-  alone would allow (gossip, not receipts, is the binding constraint). While armed, each input-idle
-  endpoint re-sends one status-bearing duplicate input per keepalive interval (the existing nudge
-  wire shape — receivers already treat it as a stale retransmission; no wire-format change), so
-  every peer's contribution to the others' folds catches up to its real receipts and confirmation
-  releases. A healthy mesh's normal one-gossip-delivery pacing lag never exhausts the prediction
-  window, receipt-bound stalls (a peer's inputs genuinely missing) still belong exclusively to
-  pending-output retransmission, and reserved hot-join endpoints are never nudged (a duplicate
-  `Input` injected into the join handshake interferes with the joiner's deferred input processing),
-  so actively-advancing sessions' packet streams are unchanged. Two-player sessions were never
-  affected (the fold collapses to the local receipt).
-- **Pre-existing:** `NetworkStats::ping` (the quality-report round-trip time) is now measured on the
-  protocol's monotonic clock — honoring an injected `ProtocolConfig::clock` — instead of the system
-  wall clock. Wall-clock adjustments (NTP steps, VM snapshot restores) can no longer corrupt the
-  reported RTT, and sessions driven by a virtual clock (deterministic tests and simulations) now
-  measure virtual network latency exactly and reproducibly instead of leaking wall-clock scheduling
-  noise. The previous behavior of silently skipping a quality report or RTT update while the system
-  clock was in an abnormal state is gone entirely (a monotonic elapsed reading cannot fail). The wire
-  format is unchanged — the peer echoes the timestamp verbatim, so mixed builds across this change
-  interoperate — and as a consequence `js-sys` is no longer a dependency on `wasm32` targets (its
-  only use was reading the wall clock for these timestamps).
-
 ## [0.9.0] - 2026-06-22
 
 ### Added
@@ -171,6 +125,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pre-existing:** `NetworkStats::kbps_sent` now reflects the true serialized wire size of each
+  outbound packet instead of `std::mem::size_of_val(&Message)` — the constant in-memory size of the
+  `Message` enum, which is identical for every variant (dominated by the largest one) and independent
+  of the actual payload, since `Vec` contents live on the heap. The old accounting charged a bare
+  `KeepAlive` the same as a fully-loaded `Input`, so the reported send bandwidth was fiction (both
+  systematically wrong and payload-blind). Sending is now metered with a new alloc-free arithmetic
+  `Message::encoded_len()` that is byte-exact against the codec (a property test asserts
+  `encoded_len() == codec::encode(&msg).len()` for arbitrary messages of every variant). The
+  `+ UDP_HEADER_SIZE` per-packet estimate is unchanged; only the payload term is corrected.
+- **Pre-existing:** Closed a permanent whole-mesh confirmation deadlock at 3 or more players (the
+  no-drop sibling of the 0.9.0 gossip-mute fix), found by the new deterministic whole-mesh
+  simulation fleet on its first four-player run. Connect-status gossip rides only `Input` messages;
+  if a peer sent its entire initial prediction window's inputs before hearing a third peer's first
+  input (transient startup loss, jitter, or reordering is enough), its last gossip left that slot's
+  view at `Frame::NULL` in every receiver's cache. Once every peer exhausted its prediction window
+  (`current - confirmed >= max_prediction`) with fully-acked send queues, no peer ever sent another
+  `Input` — `KeepAlive`, `QualityReport`, and `InputAck` carry no connect status — so the stale
+  caches never refreshed and the whole mesh deadlocked **permanently** at `confirmed_frame() ==
+  Frame::NULL` on a perfectly healed network, with every session `Running` and no error or event
+  (an application-visible infinite freeze). The connect-status nudge introduced in 0.9.0 closed
+  exactly this gossip-mute mechanism but only while a locally-detected drop awaited mesh agreement;
+  it now also arms when **both** legs of the deadlock signature hold: the prediction window is
+  exhausted AND the mesh-gossip fold pins confirmation strictly below what locally-received inputs
+  alone would allow (gossip, not receipts, is the binding constraint). While armed, each input-idle
+  endpoint re-sends one status-bearing duplicate input per keepalive interval (the existing nudge
+  wire shape — receivers already treat it as a stale retransmission; no wire-format change), so
+  every peer's contribution to the others' folds catches up to its real receipts and confirmation
+  releases. A healthy mesh's normal one-gossip-delivery pacing lag never exhausts the prediction
+  window, receipt-bound stalls (a peer's inputs genuinely missing) still belong exclusively to
+  pending-output retransmission, and reserved hot-join endpoints are never nudged (a duplicate
+  `Input` injected into the join handshake interferes with the joiner's deferred input processing),
+  so actively-advancing sessions' packet streams are unchanged. Two-player sessions were never
+  affected (the fold collapses to the local receipt).
+- **Pre-existing:** `NetworkStats::ping` (the quality-report round-trip time) is now measured on the
+  protocol's monotonic clock — honoring an injected `ProtocolConfig::clock` — instead of the system
+  wall clock. Wall-clock adjustments (NTP steps, VM snapshot restores) can no longer corrupt the
+  reported RTT, and sessions driven by a virtual clock (deterministic tests and simulations) now
+  measure virtual network latency exactly and reproducibly instead of leaking wall-clock scheduling
+  noise. The previous behavior of silently skipping a quality report or RTT update while the system
+  clock was in an abnormal state is gone entirely (a monotonic elapsed reading cannot fail). The wire
+  format is unchanged — the peer echoes the timestamp verbatim, so mixed builds across this change
+  interoperate — and as a consequence `js-sys` is no longer a dependency on `wasm32` targets (its
+  only use was reading the wall clock for these timestamps).
 - `SessionBuilder::with_violation_observer` now routes specification violations to the
   configured observer for **every** session type — `P2PSession`, `SyncTestSession`, and `SpectatorSession`.
   Previously `P2PSession` and `SyncTestSession` emitted every specification violation through the global

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,15 +125,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Pre-existing:** `NetworkStats::kbps_sent` now reflects the true serialized wire size of each
-  outbound packet instead of `std::mem::size_of_val(&Message)` — the constant in-memory size of the
-  `Message` enum, which is identical for every variant (dominated by the largest one) and independent
-  of the actual payload, since `Vec` contents live on the heap. The old accounting charged a bare
-  `KeepAlive` the same as a fully-loaded `Input`, so the reported send bandwidth was fiction (both
-  systematically wrong and payload-blind). Sending is now metered with a new alloc-free arithmetic
+- **Pre-existing:** `NetworkStats::kbps_sent` is now accurate on both axes it was previously wrong on.
+  (1) *Payload size:* it accounted `std::mem::size_of_val(&Message)` — the constant in-memory size of
+  the `Message` enum, identical for every variant (dominated by the largest one) and independent of
+  the actual payload, since `Vec` contents live on the heap, so a bare `KeepAlive` was charged the
+  same as a fully-loaded `Input`. Sending is now metered with a new alloc-free arithmetic
   `Message::encoded_len()` that is byte-exact against the codec (a property test asserts
-  `encoded_len() == codec::encode(&msg).len()` for arbitrary messages of every variant). The
-  `+ UDP_HEADER_SIZE` per-packet estimate is unchanged; only the payload term is corrected.
+  `encoded_len() == codec::encode(&msg).len()` for arbitrary messages of every variant). (2) *Unit:*
+  the field is documented and named as kilobits per second, but the rate was computed as
+  `bytes / seconds / 1024` — kibibytes per second, off by the 8x byte-vs-bit factor. It is now
+  computed as bits (x8) per second / 1000, matching the documented unit. The `+ UDP_HEADER_SIZE`
+  per-packet header estimate is unchanged. Net effect: reported values change (they were previously
+  fiction); code that hard-coded a calibration against the old numbers should re-baseline.
 - **Pre-existing:** Closed a permanent whole-mesh confirmation deadlock at 3 or more players (the
   no-drop sibling of the 0.9.0 gossip-mute fix), found by the new deterministic whole-mesh
   simulation fleet on its first four-player run. Connect-status gossip rides only `Input` messages;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pre-existing:** Closed a permanent whole-mesh confirmation deadlock at 3 or more players (the
+  no-drop sibling of the 0.9.0 gossip-mute fix), found by the new deterministic whole-mesh
+  simulation fleet on its first four-player run. Connect-status gossip rides only `Input` messages;
+  if a peer sent its entire initial prediction window's inputs before hearing a third peer's first
+  input (transient startup loss, jitter, or reordering is enough), its last gossip left that slot's
+  view at `Frame::NULL` in every receiver's cache. Once every peer exhausted its prediction window
+  (`current - confirmed >= max_prediction`) with fully-acked send queues, no peer ever sent another
+  `Input` — `KeepAlive`, `QualityReport`, and `InputAck` carry no connect status — so the stale
+  caches never refreshed and the whole mesh deadlocked **permanently** at `confirmed_frame() ==
+  Frame::NULL` on a perfectly healed network, with every session `Running` and no error or event
+  (an application-visible infinite freeze). The connect-status nudge introduced in 0.9.0 closed
+  exactly this gossip-mute mechanism but only while a locally-detected drop awaited mesh agreement;
+  it now also arms when **both** legs of the deadlock signature hold: the prediction window is
+  exhausted AND the mesh-gossip fold pins confirmation strictly below what locally-received inputs
+  alone would allow (gossip, not receipts, is the binding constraint). While armed, each input-idle
+  endpoint re-sends one status-bearing duplicate input per keepalive interval (the existing nudge
+  wire shape — receivers already treat it as a stale retransmission; no wire-format change), so
+  every peer's contribution to the others' folds catches up to its real receipts and confirmation
+  releases. A healthy mesh's normal one-gossip-delivery pacing lag never exhausts the prediction
+  window, receipt-bound stalls (a peer's inputs genuinely missing) still belong exclusively to
+  pending-output retransmission, and reserved hot-join endpoints are never nudged (a duplicate
+  `Input` injected into the join handshake interferes with the joiner's deferred input processing),
+  so actively-advancing sessions' packet streams are unchanged. Two-player sessions were never
+  affected (the fold collapses to the local receipt).
+- **Pre-existing:** `NetworkStats::ping` (the quality-report round-trip time) is now measured on the
+  protocol's monotonic clock — honoring an injected `ProtocolConfig::clock` — instead of the system
+  wall clock. Wall-clock adjustments (NTP steps, VM snapshot restores) can no longer corrupt the
+  reported RTT, and sessions driven by a virtual clock (deterministic tests and simulations) now
+  measure virtual network latency exactly and reproducibly instead of leaking wall-clock scheduling
+  noise. The previous behavior of silently skipping a quality report or RTT update while the system
+  clock was in an abnormal state is gone entirely (a monotonic elapsed reading cannot fail). The wire
+  format is unchanged — the peer echoes the timestamp verbatim, so mixed builds across this change
+  interoperate — and as a consequence `js-sys` is no longer a dependency on `wasm32` targets (its
+  only use was reading the wall clock for these timestamps).
+
 ## [0.9.0] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pre-existing:** `NetworkStats::kbps_sent` now reflects the true serialized wire size of each
+  outbound packet instead of `std::mem::size_of_val(&Message)` — the constant in-memory size of the
+  `Message` enum, which is identical for every variant (dominated by the largest one) and independent
+  of the actual payload, since `Vec` contents live on the heap. The old accounting charged a bare
+  `KeepAlive` the same as a fully-loaded `Input`, so the reported send bandwidth was fiction (both
+  systematically wrong and payload-blind). Sending is now metered with a new alloc-free arithmetic
+  `Message::encoded_len()` that is byte-exact against the codec (a property test asserts
+  `encoded_len() == codec::encode(&msg).len()` for arbitrary messages of every variant). The
+  `+ UDP_HEADER_SIZE` per-packet estimate is unchanged; only the payload term is corrected.
 - **Pre-existing:** Closed a permanent whole-mesh confirmation deadlock at 3 or more players (the
   no-drop sibling of the 0.9.0 gossip-mute fix), found by the new deterministic whole-mesh
   simulation fleet on its first four-player run. Connect-status gossip rides only `Input` messages;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,6 @@ dependencies = [
  "bincode",
  "clap",
  "criterion",
- "js-sys",
  "loom",
  "macroquad",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,17 +374,17 @@ tokio = { version = "1.52", features = ["net", "io-util", "sync", "rt", "macros"
 [target.'cfg(loom)'.dependencies]
 loom = "0.7"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3"
-
 [dev-dependencies]
 serial_test = "3.5"
 clap = { version = "4.6", features = ["derive"] }
 tracing-subscriber = "0.3"
 tracing-log = "0.2"
 proptest = "1.11"
-# JSON parsing for tests (also enables the "json" feature for telemetry tests)
-serde_json = "1.0"
+# JSON parsing for tests (also enables the "json" feature for telemetry tests).
+# float_roundtrip: simulation-schedule corpus artifacts embed f64 fault rates
+# and must round-trip losslessly (an ULP shift changes seeded RNG threshold
+# comparisons and breaks replay determinism).
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 # Benchmarking
 criterion = { version = "0.8", features = ["html_reports"] }
 # Macro utilities for data-driven tests

--- a/src/network/codec.rs
+++ b/src/network/codec.rs
@@ -1092,6 +1092,252 @@ mod tests {
         }
     }
 
+    /// A `ConnectionStatus` with arbitrary field values (used by the wire-size
+    /// property strategies for both `Input` and `StateSnapshot`).
+    fn arb_connection_status() -> impl proptest::strategy::Strategy<Value = ConnectionStatus> {
+        use proptest::prelude::*;
+        (any::<bool>(), any::<i32>(), any::<u16>()).prop_map(|(disconnected, frame, epoch)| {
+            ConnectionStatus {
+                disconnected,
+                last_frame: Frame::new(frame),
+                epoch,
+            }
+        })
+    }
+
+    /// A strategy producing an arbitrary [`Message`] of any body variant with
+    /// arbitrary field values and (bounded) collection lengths, covering the
+    /// hot-join variants when the feature is enabled.
+    fn arb_message() -> impl proptest::strategy::Strategy<Value = Message> {
+        use proptest::collection::vec as pvec;
+        use proptest::prelude::*;
+        use proptest::strategy::{BoxedStrategy, Union};
+
+        // `bodies` is only pushed to under the hot-join feature; without it the
+        // `vec!` literal is the complete set.
+        #[cfg_attr(not(feature = "hot-join"), allow(unused_mut))]
+        let mut bodies: Vec<BoxedStrategy<MessageBody>> = vec![
+            any::<u32>()
+                .prop_map(|random_request| MessageBody::SyncRequest(SyncRequest { random_request }))
+                .boxed(),
+            any::<u32>()
+                .prop_map(|random_reply| MessageBody::SyncReply(SyncReply { random_reply }))
+                .boxed(),
+            (
+                pvec(arb_connection_status(), 0..8),
+                any::<bool>(),
+                any::<i32>(),
+                any::<i32>(),
+                pvec(any::<u8>(), 0..64),
+            )
+                .prop_map(
+                    |(peer_connect_status, disconnect_requested, start, ack, bytes)| {
+                        MessageBody::Input(Input {
+                            peer_connect_status,
+                            disconnect_requested,
+                            start_frame: Frame::new(start),
+                            ack_frame: Frame::new(ack),
+                            bytes,
+                        })
+                    },
+                )
+                .boxed(),
+            any::<i32>()
+                .prop_map(|f| {
+                    MessageBody::InputAck(InputAck {
+                        ack_frame: Frame::new(f),
+                    })
+                })
+                .boxed(),
+            (any::<i16>(), any::<u128>())
+                .prop_map(|(frame_advantage, ping)| {
+                    MessageBody::QualityReport(QualityReport {
+                        frame_advantage,
+                        ping,
+                    })
+                })
+                .boxed(),
+            any::<u128>()
+                .prop_map(|pong| MessageBody::QualityReply(QualityReply { pong }))
+                .boxed(),
+            (any::<u128>(), any::<i32>())
+                .prop_map(|(checksum, f)| {
+                    MessageBody::ChecksumReport(ChecksumReport {
+                        checksum,
+                        frame: Frame::new(f),
+                    })
+                })
+                .boxed(),
+            Just(MessageBody::KeepAlive).boxed(),
+            any::<u32>()
+                .prop_map(|round_seq| MessageBody::FloorRequest(FloorRequest { round_seq }))
+                .boxed(),
+            (any::<u32>(), pvec(any::<i32>().prop_map(Frame::new), 0..8))
+                .prop_map(|(round_seq, floors)| {
+                    MessageBody::FloorReply(FloorReply { round_seq, floors })
+                })
+                .boxed(),
+        ];
+
+        #[cfg(feature = "hot-join")]
+        {
+            use crate::network::messages::{
+                JoinAborted, JoinCommitted, JoinRequest, ReactivateSlot, ReactivateSlotAck,
+                StateSnapshot, StateSnapshotAck,
+            };
+            bodies.push(
+                any::<usize>()
+                    .prop_map(|player_handle| {
+                        MessageBody::JoinRequest(JoinRequest { player_handle })
+                    })
+                    .boxed(),
+            );
+            bodies.push(
+                (
+                    any::<i32>(),
+                    any::<usize>(),
+                    pvec(any::<u8>(), 0..64),
+                    pvec(any::<u8>(), 0..32),
+                    pvec(arb_connection_status(), 0..8),
+                    proptest::option::of(any::<u128>()),
+                )
+                    .prop_map(
+                        |(
+                            f,
+                            num_players,
+                            state_bytes,
+                            bridge_inputs,
+                            bridge_statuses,
+                            checksum,
+                        )| {
+                            MessageBody::StateSnapshot(StateSnapshot {
+                                frame: Frame::new(f),
+                                num_players,
+                                state_bytes,
+                                bridge_inputs,
+                                bridge_statuses,
+                                checksum,
+                            })
+                        },
+                    )
+                    .boxed(),
+            );
+            bodies.push(
+                any::<i32>()
+                    .prop_map(|f| {
+                        MessageBody::StateSnapshotAck(StateSnapshotAck {
+                            frame: Frame::new(f),
+                        })
+                    })
+                    .boxed(),
+            );
+            bodies.push(
+                (any::<usize>(), any::<i32>())
+                    .prop_map(|(handle, f)| {
+                        MessageBody::ReactivateSlot(ReactivateSlot {
+                            handle,
+                            frame: Frame::new(f),
+                        })
+                    })
+                    .boxed(),
+            );
+            bodies.push(
+                (any::<usize>(), any::<i32>())
+                    .prop_map(|(handle, f)| {
+                        MessageBody::ReactivateSlotAck(ReactivateSlotAck {
+                            handle,
+                            frame: Frame::new(f),
+                        })
+                    })
+                    .boxed(),
+            );
+            bodies.push(
+                (any::<usize>(), any::<i32>())
+                    .prop_map(|(handle, f)| {
+                        MessageBody::JoinCommitted(JoinCommitted {
+                            handle,
+                            frame: Frame::new(f),
+                        })
+                    })
+                    .boxed(),
+            );
+            bodies.push(
+                (any::<usize>(), any::<i32>())
+                    .prop_map(|(handle, f)| {
+                        MessageBody::JoinAborted(JoinAborted {
+                            handle,
+                            frame: Frame::new(f),
+                        })
+                    })
+                    .boxed(),
+            );
+        }
+
+        (any::<u16>(), Union::new(bodies)).prop_map(|(magic, body)| Message {
+            header: MessageHeader { magic },
+            body,
+        })
+    }
+
+    proptest::proptest! {
+        /// The D1 regression artifact: `Message::encoded_len` is arithmetic and
+        /// alloc-free, so it can silently drift from the real wire format if a
+        /// field width or the codec configuration ever changes. This asserts it
+        /// equals the exact serialized byte count for arbitrary messages of every
+        /// variant — the property that makes it a trustworthy bandwidth meter.
+        #[test]
+        fn encoded_len_matches_exact_wire_bytes(msg in arb_message()) {
+            let encoded = encode(&msg).expect("arbitrary message must encode");
+            proptest::prop_assert_eq!(
+                msg.encoded_len(),
+                encoded.len(),
+                "encoded_len diverged from wire bytes for {:?}",
+                msg
+            );
+        }
+    }
+
+    /// Documents why D1 was a real defect: the old accounting charged
+    /// `std::mem::size_of_val(&msg)` — the constant in-memory `Message` size,
+    /// which is identical for a bare `KeepAlive` and a fully-loaded `Input`
+    /// because `Vec` payloads live on the heap. Wire size differs by hundreds of
+    /// bytes; `encoded_len` reports the truth.
+    #[test]
+    fn size_of_val_is_constant_while_wire_size_is_not_d1() {
+        let tiny = Message {
+            header: MessageHeader { magic: 0 },
+            body: MessageBody::KeepAlive,
+        };
+        let heavy = Message {
+            header: MessageHeader { magic: 0 },
+            body: MessageBody::Input(Input {
+                peer_connect_status: vec![ConnectionStatus::default(); 16],
+                disconnect_requested: false,
+                start_frame: Frame::new(10_000),
+                ack_frame: Frame::new(9_999),
+                bytes: vec![0xAB; 128],
+            }),
+        };
+
+        // The old metric: identical for both, regardless of payload.
+        assert_eq!(
+            std::mem::size_of_val(&tiny),
+            std::mem::size_of_val(&heavy),
+            "in-memory size is payload-independent — the D1 fiction"
+        );
+
+        // The truth: wire footprints differ by hundreds of bytes, and
+        // `encoded_len` matches the serialized length exactly for each.
+        assert_eq!(tiny.encoded_len(), encode(&tiny).unwrap().len());
+        assert_eq!(heavy.encoded_len(), encode(&heavy).unwrap().len());
+        assert!(
+            heavy.encoded_len() > tiny.encoded_len() + 200,
+            "loaded Input must dwarf KeepAlive on the wire ({} vs {})",
+            heavy.encoded_len(),
+            tiny.encoded_len()
+        );
+    }
+
     #[test]
     fn decode_message_roundtrips_input_without_generic_vec_decode() {
         let original = Message {

--- a/src/network/messages.rs
+++ b/src/network/messages.rs
@@ -37,6 +37,14 @@ pub struct ConnectionStatus {
     pub epoch: u16,
 }
 
+impl ConnectionStatus {
+    /// Exact number of bytes a `ConnectionStatus` serializes to under the crate's
+    /// bincode configuration (little-endian, fixed-int): `disconnected` (`bool`, 1) +
+    /// `last_frame` ([`Frame`] = `i32`, 4) + `epoch` (`u16`, 2). Kept honest by
+    /// [`Message::encoded_len`]'s wire-exactness property test.
+    pub(crate) const WIRE_LEN: usize = 1 + 4 + 2;
+}
+
 impl Default for ConnectionStatus {
     fn default() -> Self {
         Self {
@@ -392,6 +400,91 @@ pub(crate) enum MessageBody {
 pub struct Message {
     pub(crate) header: MessageHeader,
     pub(crate) body: MessageBody,
+}
+
+impl MessageBody {
+    /// The exact number of bytes this body serializes to under the crate's bincode
+    /// configuration (little-endian, fixed-int), computed arithmetically without
+    /// allocating or serializing.
+    ///
+    /// Wire-exactness (`encoded_len == codec::encode(..).len()`) is asserted for
+    /// every variant by [`Message::encoded_len`]'s property test, so this stays
+    /// honest if the codec configuration or any field ever changes. The `match`
+    /// is wildcard-free: adding a `MessageBody` variant fails to compile until it
+    /// is accounted here.
+    pub(crate) fn encoded_len(&self) -> usize {
+        // Fixed bincode widths under `standard().with_little_endian().with_fixed_int_encoding()`.
+        const DISCRIMINANT: usize = 4; // enum variant tag (u32)
+        const FRAME: usize = 4; // Frame(i32)
+        const LEN_PREFIX: usize = 8; // collection length (usize -> u64 with fixed-int)
+
+        let payload = match self {
+            Self::SyncRequest(_) => 4, // random_request: u32
+            Self::SyncReply(_) => 4,   // random_reply: u32
+            Self::Input(input) => {
+                LEN_PREFIX
+                    + input.peer_connect_status.len() * ConnectionStatus::WIRE_LEN
+                    + 1 // disconnect_requested: bool
+                    + FRAME // start_frame
+                    + FRAME // ack_frame
+                    + LEN_PREFIX
+                    + input.bytes.len() // bytes: Vec<u8>
+            },
+            Self::InputAck(_) => FRAME,            // ack_frame
+            Self::QualityReport(_) => 2 + 16,      // frame_advantage: i16, ping: u128
+            Self::QualityReply(_) => 16,           // pong: u128
+            Self::ChecksumReport(_) => 16 + FRAME, // checksum: u128, frame
+            Self::KeepAlive => 0,
+            Self::FloorRequest(_) => 4, // round_seq: u32
+            Self::FloorReply(reply) => {
+                4 // round_seq: u32
+                    + LEN_PREFIX
+                    + reply.floors.len() * FRAME // floors: Vec<Frame>
+            },
+            #[cfg(feature = "hot-join")]
+            Self::JoinRequest(_) => 8, // player_handle: usize
+            #[cfg(feature = "hot-join")]
+            Self::StateSnapshot(snapshot) => {
+                FRAME // frame
+                    + 8 // num_players: usize
+                    + LEN_PREFIX
+                    + snapshot.state_bytes.len()
+                    + LEN_PREFIX
+                    + snapshot.bridge_inputs.len()
+                    + LEN_PREFIX
+                    + snapshot.bridge_statuses.len() * ConnectionStatus::WIRE_LEN
+                    + 1 // Option tag
+                    + snapshot.checksum.map_or(0, |_| 16) // Some(u128)
+            },
+            #[cfg(feature = "hot-join")]
+            Self::StateSnapshotAck(_) => FRAME, // frame
+            #[cfg(feature = "hot-join")]
+            Self::ReactivateSlot(_) => 8 + FRAME, // handle: usize, frame
+            #[cfg(feature = "hot-join")]
+            Self::ReactivateSlotAck(_) => 8 + FRAME, // handle: usize, frame
+            #[cfg(feature = "hot-join")]
+            Self::JoinCommitted(_) => 8 + FRAME, // handle: usize, frame
+            #[cfg(feature = "hot-join")]
+            Self::JoinAborted(_) => 8 + FRAME, // handle: usize, frame
+        };
+
+        DISCRIMINANT + payload
+    }
+}
+
+impl Message {
+    /// The exact number of bytes this message serializes to on the wire under the
+    /// crate's bincode configuration: the [`MessageHeader`] (`magic`: `u16`, 2
+    /// bytes) plus the [`MessageBody`] ([`MessageBody::encoded_len`]).
+    ///
+    /// This is the true payload size a [`NonBlockingSocket`](crate::NonBlockingSocket)
+    /// transmits, used for bandwidth accounting. It is computed arithmetically
+    /// (alloc-free) and kept wire-exact by a property test against
+    /// [`codec::encode`](crate::network::codec::encode).
+    pub(crate) fn encoded_len(&self) -> usize {
+        const HEADER: usize = 2; // MessageHeader { magic: u16 }
+        HEADER + self.body.encoded_len()
+    }
 }
 
 #[cfg(test)]

--- a/src/network/network_stats.rs
+++ b/src/network/network_stats.rs
@@ -10,7 +10,10 @@ pub struct NetworkStats {
     pub send_queue_len: usize,
     /// The roundtrip packet transmission time as calculated by Fortress Rollback.
     pub ping: u128,
-    /// The estimated bandwidth used between the two clients, in kilobits per second.
+    /// The estimated outbound bandwidth to this peer, in **kilobits per second**
+    /// (bits ÷ 1000). Computed from the wire-exact serialized size of every sent
+    /// packet plus an estimated per-packet UDP/IP header, averaged over the time
+    /// since synchronization.
     pub kbps_sent: usize,
 
     /// The number of frames Fortress Rollback calculates that the local client is behind the remote client at this instant in time.

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -1778,7 +1778,11 @@ impl<T: Config> UdpProtocol<T> {
 
         self.packets_sent += 1;
         self.last_send_time = self.now();
-        self.bytes_sent += std::mem::size_of_val(&msg);
+        // Wire-exact payload bytes (D1 fix): the previous `size_of_val(&msg)`
+        // measured the constant in-memory `Message` enum size, not what the
+        // socket serializes, so `kbps_sent` was fiction. `Message::encoded_len`
+        // matches `codec::encode(&msg).len()` exactly (property-tested).
+        self.bytes_sent += msg.encoded_len();
 
         // add the packet to the back of the send queue
         self.send_queue.push_back(msg);

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -824,13 +824,21 @@ impl<T: Config> UdpProtocol<T> {
         }
 
         let total_bytes_sent = self.bytes_sent + (self.packets_sent * UDP_HEADER_SIZE);
-        let bps = total_bytes_sent / seconds as usize;
-        //let upd_overhead = (self.packets_sent * UDP_HEADER_SIZE) / self.bytes_sent;
+        // `kbps_sent` is documented and named as **kilobits per second**. The
+        // previous `bytes / seconds / 1024` produced kibibytes/sec — wrong by the
+        // 8× byte<->bit factor against the field's own unit. Correct it to bits
+        // (x8) over elapsed seconds, per SI kilo (/1000, the standard base for
+        // network bit-rates). Now that D1 makes `bytes_sent` wire-exact this rate
+        // is finally meaningful. `u64` with a saturating multiply avoids overflow
+        // on long sessions; the divisions then bring it back into `usize` range.
+        let kbps_sent =
+            usize::try_from((total_bytes_sent as u64).saturating_mul(8) / seconds / 1000)
+                .unwrap_or(usize::MAX);
 
         Ok(NetworkStats {
             ping: self.round_trip_time,
             send_queue_len: self.pending_output.len(),
-            kbps_sent: bps / 1024,
+            kbps_sent,
             local_frames_behind: self.local_frame_advantage,
             remote_frames_behind: self.remote_frame_advantage,
             // Checksum fields are populated by P2PSession::network_stats()

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -220,8 +220,11 @@ where
     /// Using Instant (monotonic clock) instead of wall-clock time ensures reliable
     /// duration measurements even if the system clock is adjusted.
     stats_start_time: Instant,
-    packets_sent: usize,
-    bytes_sent: usize,
+    // `u64` (not `usize`) so these lifetime counters cannot wrap on 32-bit
+    // targets (notably `wasm32`): a `usize` `bytes_sent` would overflow after
+    // ~4 GiB of cumulative traffic and corrupt `network_stats()`.
+    packets_sent: u64,
+    bytes_sent: u64,
     round_trip_time: u128,
     /// Origin instant for quality-report `ping` timestamps, captured from the
     /// protocol clock at endpoint construction. The peer echoes `ping` back
@@ -823,17 +826,20 @@ impl<T: Config> UdpProtocol<T> {
             return Err(FortressError::NotSynchronized);
         }
 
-        let total_bytes_sent = self.bytes_sent + (self.packets_sent * UDP_HEADER_SIZE);
+        // All-`u64` so the sum cannot overflow on 32-bit targets before the rate
+        // math runs (`bytes_sent`/`packets_sent` are already `u64`).
+        let total_bytes_sent = self
+            .bytes_sent
+            .saturating_add(self.packets_sent.saturating_mul(UDP_HEADER_SIZE as u64));
         // `kbps_sent` is documented and named as **kilobits per second**. The
         // previous `bytes / seconds / 1024` produced kibibytes/sec — wrong by the
         // 8× byte<->bit factor against the field's own unit. Correct it to bits
         // (x8) over elapsed seconds, per SI kilo (/1000, the standard base for
         // network bit-rates). Now that D1 makes `bytes_sent` wire-exact this rate
-        // is finally meaningful. `u64` with a saturating multiply avoids overflow
-        // on long sessions; the divisions then bring it back into `usize` range.
-        let kbps_sent =
-            usize::try_from((total_bytes_sent as u64).saturating_mul(8) / seconds / 1000)
-                .unwrap_or(usize::MAX);
+        // is finally meaningful. Saturating multiply avoids overflow on long
+        // sessions; the divisions then bring it back into `usize` range.
+        let kbps_sent = usize::try_from(total_bytes_sent.saturating_mul(8) / seconds / 1000)
+            .unwrap_or(usize::MAX);
 
         Ok(NetworkStats {
             ping: self.round_trip_time,
@@ -1784,13 +1790,15 @@ impl<T: Config> UdpProtocol<T> {
         let header = MessageHeader { magic: self.magic };
         let msg = Message { header, body };
 
-        self.packets_sent += 1;
+        self.packets_sent = self.packets_sent.saturating_add(1);
         self.last_send_time = self.now();
         // Wire-exact payload bytes (D1 fix): the previous `size_of_val(&msg)`
         // measured the constant in-memory `Message` enum size, not what the
         // socket serializes, so `kbps_sent` was fiction. `Message::encoded_len`
         // matches `codec::encode(&msg).len()` exactly (property-tested).
-        self.bytes_sent += msg.encoded_len();
+        // Saturating so the lifetime counter degrades to a ceiling rather than
+        // wrapping (or panicking under overflow-checks) on any target.
+        self.bytes_sent = self.bytes_sent.saturating_add(msg.encoded_len() as u64);
 
         // add the packet to the back of the send queue
         self.send_queue.push_back(msg);

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -47,58 +47,6 @@ use super::network_stats::NetworkStats;
 
 const UDP_HEADER_SIZE: usize = 28; // Size of IP + UDP headers
 
-/// Returns the current wall-clock time as milliseconds since UNIX_EPOCH.
-///
-/// This function returns `Some(millis)` under normal conditions, or `None` if the system
-/// clock is in an invalid state (e.g., before UNIX_EPOCH due to NTP adjustments, VM snapshots,
-/// or misconfigured clocks).
-///
-/// # When to use
-/// Use this ONLY when you need wall-clock time that can be compared across different machines
-/// (e.g., for ping/pong RTT calculation). For local elapsed time measurements, prefer using
-/// `Instant` which is guaranteed monotonic.
-///
-/// # Returns
-/// - `Some(millis)` - The current time in milliseconds since UNIX_EPOCH
-/// - `None` - If the system clock is before UNIX_EPOCH (abnormal condition)
-fn millis_since_epoch() -> Option<u128> {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
-            Ok(duration) => Some(duration.as_millis()),
-            Err(_) => {
-                // System time is before UNIX_EPOCH - this can happen due to:
-                // - NTP adjustments moving clock backwards
-                // - VM snapshots with stale time
-                // - Misconfigured system clocks
-                // Report via telemetry and return None so callers can handle appropriately.
-                report_violation!(
-                    ViolationSeverity::Warning,
-                    ViolationKind::InternalError,
-                    "System time is before UNIX_EPOCH - clock may have gone backwards"
-                );
-                None
-            },
-        }
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        // In WASM, Date.getTime() returns milliseconds since epoch as a f64.
-        // It can technically be negative for dates before 1970, but this is rare.
-        let time = js_sys::Date::new_0().get_time();
-        if time >= 0.0 {
-            Some(time as u128)
-        } else {
-            report_violation!(
-                ViolationSeverity::Warning,
-                ViolationKind::InternalError,
-                "WASM Date.getTime() returned negative value - clock may be misconfigured"
-            );
-            None
-        }
-    }
-}
-
 /// UDP protocol handler for peer-to-peer communication.
 ///
 /// # Note
@@ -275,6 +223,15 @@ where
     packets_sent: usize,
     bytes_sent: usize,
     round_trip_time: u128,
+    /// Origin instant for quality-report `ping` timestamps, captured from the
+    /// protocol clock at endpoint construction. The peer echoes `ping` back
+    /// verbatim ([`Self::on_quality_report`]), so timestamps are only ever
+    /// compared against this endpoint's own clock — a session-local monotonic
+    /// origin is sufficient. Deriving it from [`Self::now`] honors an injected
+    /// [`ProtocolConfig::clock`] (deterministic simulation) and is immune to
+    /// the wall-clock adjustments (NTP steps, VM snapshot restores) that could
+    /// corrupt RTT when this was derived from `SystemTime`.
+    ping_epoch_base: Instant,
     last_send_time: Instant,
     last_recv_time: Instant,
 
@@ -763,6 +720,7 @@ impl<T: Config> UdpProtocol<T> {
             packets_sent: 0,
             bytes_sent: 0,
             round_trip_time: 0,
+            ping_epoch_base: now,
             last_send_time: now,
             last_recv_time: now,
 
@@ -805,6 +763,18 @@ impl<T: Config> UdpProtocol<T> {
             Some(clock_fn) => clock_fn(),
             None => Instant::now(),
         }
+    }
+
+    /// Returns milliseconds elapsed on the protocol clock since this endpoint
+    /// was constructed — the timestamp basis for quality-report pings (see
+    /// [`Self::ping_epoch_base`]).
+    ///
+    /// Saturates to zero if the clock reads earlier than the construction
+    /// instant (impossible for a monotonic clock; defensive for injected ones).
+    fn ping_millis(&self) -> u128 {
+        self.now()
+            .saturating_duration_since(self.ping_epoch_base)
+            .as_millis()
     }
 
     pub(crate) fn update_local_frame_advantage(&mut self, local_frame: Frame) {
@@ -1780,13 +1750,10 @@ impl<T: Config> UdpProtocol<T> {
     fn send_quality_report(&mut self) {
         self.running_last_quality_report = self.now();
 
-        // Get wall-clock time for ping calculation.
-        // If the system clock is in an abnormal state, skip sending this quality report.
-        // The peer will request another one later, and hopefully the clock will be fixed by then.
-        let Some(ping_timestamp) = millis_since_epoch() else {
-            trace!("Skipping quality report due to invalid system clock");
-            return;
-        };
+        // Timestamp from the (injectable) protocol clock. The peer echoes it
+        // back verbatim, so it is only ever compared against this endpoint's
+        // own clock in `on_quality_reply` — no wall-clock source is needed.
+        let ping_timestamp = self.ping_millis();
 
         // Clamp to i16 range and convert - the clamp guarantees this won't fail,
         // but we use unwrap_or as defense-in-depth
@@ -2272,16 +2239,11 @@ impl<T: Config> UdpProtocol<T> {
 
     /// Upon receiving a `QualityReply`, update network stats.
     fn on_quality_reply(&mut self, body: &QualityReply) {
-        // Get current wall-clock time to calculate RTT.
-        // If the system clock is in an abnormal state, skip this RTT update.
-        // The next quality report cycle will try again.
-        let Some(millis) = millis_since_epoch() else {
-            trace!("Skipping RTT update due to invalid system clock");
-            return;
-        };
-        // Use saturating subtraction to handle edge cases where system time
-        // may have drifted between the ping and pong (e.g., NTP adjustments).
-        // A 0 RTT is harmless - it will be corrected on the next quality report.
+        let millis = self.ping_millis();
+        // Saturating: a pong is normally an echo of this endpoint's own earlier
+        // ping (never in the future), but a stale packet from a previous
+        // endpoint era could carry an arbitrary value. A 0 RTT is harmless -
+        // it will be corrected on the next quality report.
         self.round_trip_time = millis.saturating_sub(body.pong);
     }
 
@@ -6400,117 +6362,113 @@ mod tests {
     }
 
     // ==========================================
-    // Time Utility Tests
+    // Ping Clock Tests
     // ==========================================
 
-    #[test]
-    fn millis_since_epoch_returns_some_under_normal_conditions() {
-        // Under normal conditions, millis_since_epoch should return Some with a valid timestamp
-        let millis = millis_since_epoch();
-        assert!(
-            millis.is_some(),
-            "millis_since_epoch should return Some under normal conditions"
-        );
+    /// Builds a `ProtocolConfig` whose clock reads `base + offset_ms`,
+    /// returning the shared offset handle so tests can advance virtual time.
+    fn injected_clock_config() -> (ProtocolConfig, Arc<std::sync::atomic::AtomicU64>) {
+        let base = Instant::now();
+        let offset_ms = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let offset = Arc::clone(&offset_ms);
+        let config = ProtocolConfig {
+            clock: Some(Arc::new(move || {
+                base + Duration::from_millis(offset.load(std::sync::atomic::Ordering::Relaxed))
+            })),
+            ..ProtocolConfig::default()
+        };
+        (config, offset_ms)
     }
 
     #[test]
-    fn millis_since_epoch_returns_reasonable_value() {
-        // The function should return a value representing milliseconds since UNIX_EPOCH.
-        // As of 2020, this is at least 1577836800000 (Jan 1, 2020 00:00:00 UTC).
-        // As of 2030, it would be around 1893456000000.
-        let millis = millis_since_epoch().expect("Should return Some under normal conditions");
-
-        // Should be at least year 2020 timestamp
-        assert!(
-            millis >= 1_577_836_800_000,
-            "Time should be after year 2020"
+    fn ping_millis_starts_at_zero_with_injected_clock() {
+        let (config, _offset) = injected_clock_config();
+        let protocol: UdpProtocol<TestConfig> = create_protocol_with_config(
+            vec![PlayerHandle::new(0)],
+            2,
+            1,
+            8,
+            SyncConfig::default(),
+            config,
         );
-
-        // Should not be unreasonably far in the future (year 2100)
-        assert!(
-            millis < 4_102_444_800_000,
-            "Time should be before year 2100"
-        );
+        assert_eq!(protocol.ping_millis(), 0);
     }
 
     #[test]
-    fn millis_since_epoch_is_monotonically_non_decreasing_in_short_term() {
-        // Within a single execution context, time should not go backwards
-        let first = millis_since_epoch().expect("Should return Some");
-        let second = millis_since_epoch().expect("Should return Some");
+    fn ping_millis_tracks_injected_clock_exactly() {
+        let (config, offset) = injected_clock_config();
+        let protocol: UdpProtocol<TestConfig> = create_protocol_with_config(
+            vec![PlayerHandle::new(0)],
+            2,
+            1,
+            8,
+            SyncConfig::default(),
+            config,
+        );
 
-        // Second call should be >= first (could be equal if very fast)
+        offset.store(1_234, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(protocol.ping_millis(), 1_234);
+
+        offset.store(10_000, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(protocol.ping_millis(), 10_000);
+    }
+
+    #[test]
+    fn ping_millis_without_injected_clock_is_monotonic() {
+        let protocol: UdpProtocol<TestConfig> = create_protocol_with_config(
+            vec![PlayerHandle::new(0)],
+            2,
+            1,
+            8,
+            SyncConfig::default(),
+            ProtocolConfig::default(),
+        );
+
+        let first = protocol.ping_millis();
+        let second = protocol.ping_millis();
         assert!(
             second >= first,
-            "Time should not go backwards within same execution"
+            "monotonic clock must not go backwards (first={first}, second={second})"
         );
     }
 
     #[test]
-    fn millis_since_epoch_advances_over_time() {
-        let first = millis_since_epoch().expect("Should return Some");
-
-        // `millis_since_epoch` reads the real system clock at millisecond
-        // resolution, so a fixed `sleep` + strict `>` is flaky: two reads can
-        // legitimately land in the same millisecond on a coarse-resolution
-        // clock or a heavily loaded CI runner. Instead, poll (bounded) until
-        // the clock actually ticks — guaranteed to happen on any real clock,
-        // so this asserts the "advances over time" property without depending
-        // on a single sleep being long enough.
-        let mut second = first;
-        for _ in 0..1000 {
-            second = millis_since_epoch().expect("Should return Some");
-            if second > first {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(1));
-        }
-        assert!(
-            second > first,
-            "millis_since_epoch should advance within ~1s (first={first}, second={second})"
+    fn on_quality_reply_updates_rtt_from_injected_clock() {
+        let (config, offset) = injected_clock_config();
+        let mut protocol: UdpProtocol<TestConfig> = create_protocol_with_config(
+            vec![PlayerHandle::new(0)],
+            2,
+            1,
+            8,
+            SyncConfig::default(),
+            config,
         );
+
+        // Ping issued at t=100ms, reply processed at t=175ms => RTT 75ms.
+        offset.store(100, std::sync::atomic::Ordering::Relaxed);
+        let ping = protocol.ping_millis();
+        offset.store(175, std::sync::atomic::Ordering::Relaxed);
+        protocol.on_quality_reply(&QualityReply { pong: ping });
+
+        assert_eq!(protocol.round_trip_time, 75);
     }
 
-    /// Test documentation: The `millis_since_epoch` function gracefully handles
-    /// the case where system time is before UNIX_EPOCH by returning None and
-    /// reporting a violation. This cannot be easily tested without mocking,
-    /// but the code path is verified through code review. The test below
-    /// documents the expected behavior.
     #[test]
-    fn millis_since_epoch_documents_backwards_time_handling() {
-        // This test documents the behavior when time goes backwards.
-        // The actual scenario (SystemTime before UNIX_EPOCH) cannot be triggered
-        // in a unit test without mocking std::time::SystemTime.
-        //
-        // Expected behavior:
-        // 1. When SystemTime::now().duration_since(UNIX_EPOCH) returns Err
-        // 2. The function reports a ViolationKind::InternalError via telemetry
-        // 3. The function returns None to signal the abnormal condition
-        //
-        // Callers are responsible for handling None appropriately:
-        // - send_quality_report: Skips sending the report
-        // - on_quality_reply: Skips updating RTT
-        //
-        // This design ensures:
-        // - No incorrect fallback values (like 0) propagate through the system
-        // - Callers make explicit decisions about how to handle clock issues
-        // - The system degrades gracefully rather than using invalid data
-        //
-        // This is covered by:
-        // - Code review of the implementation
-        // - The fact that the code compiles with the error handling path
-        // - Integration tests that would fail if the function panicked
+    fn on_quality_reply_with_future_pong_saturates_to_zero() {
+        let (config, _offset) = injected_clock_config();
+        let mut protocol: UdpProtocol<TestConfig> = create_protocol_with_config(
+            vec![PlayerHandle::new(0)],
+            2,
+            1,
+            8,
+            SyncConfig::default(),
+            config,
+        );
 
-        // Simply verify the function works normally
-        let result = millis_since_epoch();
-        assert!(
-            result.is_some(),
-            "Under normal conditions, should return Some"
-        );
-        assert!(
-            result.unwrap() > 0,
-            "Under normal conditions, should return positive value"
-        );
+        // A pong larger than any timestamp this endpoint issued (e.g. a stale
+        // packet from a previous endpoint era) must clamp to 0, not underflow.
+        protocol.on_quality_reply(&QualityReply { pong: u128::MAX });
+        assert_eq!(protocol.round_trip_time, 0);
     }
 
     // ==========================================

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -5766,8 +5766,11 @@ impl<T: Config> P2PSession<T> {
 
     /// Diagnostics/testing surface (hidden; **not** part of the stable public
     /// API, like [`__internal`](crate::__internal)): renders this session's
-    /// per-slot local connect status and every running remote endpoint's
-    /// gossiped view of every slot — the exact inputs to the
+    /// per-slot local connect status and every remote endpoint's gossiped view
+    /// of every slot — each view labeled with the endpoint's `running` state
+    /// (non-running endpoints are included deliberately, since a stalled or
+    /// not-yet-synchronized peer's stale view is exactly what explains a
+    /// confirmed-frame hold). These are the inputs to the
     /// [`confirmed_frame`](Self::confirmed_frame) mesh fold. Used by the
     /// deterministic simulation harness to explain confirmed-frame holds.
     #[doc(hidden)]

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -1278,6 +1278,16 @@ impl<T: Config> P2PSession<T> {
         // the mesh agrees. Allocation-free.
         let nudge_needed = self.connect_status_nudge_needed();
         for remote_endpoint in self.player_reg.remotes.values_mut() {
+            // A reserved hot-join endpoint (the host↔joiner channel) is
+            // excluded from every confirmation fold, so nudging it cannot
+            // release any hold — and a duplicate `Input` injected into the
+            // join handshake (the endpoint is `Running` mid-dance) interferes
+            // with the joiner's deferred input processing. Never nudge it.
+            #[cfg(feature = "hot-join")]
+            if self.hot_join.endpoint_is_reserved(remote_endpoint) {
+                remote_endpoint.set_connect_status_nudge(false);
+                continue;
+            }
             remote_endpoint.set_connect_status_nudge(nudge_needed);
         }
 
@@ -5754,6 +5764,47 @@ impl<T: Config> P2PSession<T> {
         self.sync_layer.current_frame()
     }
 
+    /// Diagnostics/testing surface (hidden; **not** part of the stable public
+    /// API, like [`__internal`](crate::__internal)): renders this session's
+    /// per-slot local connect status and every running remote endpoint's
+    /// gossiped view of every slot — the exact inputs to the
+    /// [`confirmed_frame`](Self::confirmed_frame) mesh fold. Used by the
+    /// deterministic simulation harness to explain confirmed-frame holds.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn diagnostic_connect_status(&self) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        let _ = write!(out, "local=[");
+        for (idx, status) in self.local_connect_status.iter().enumerate() {
+            let _ = write!(
+                out,
+                "{}{}:{}{}",
+                if idx == 0 { "" } else { ", " },
+                idx,
+                if status.disconnected { "D" } else { "C" },
+                status.last_frame.as_i32()
+            );
+        }
+        let _ = write!(out, "]");
+        for (addr, endpoint) in &self.player_reg.remotes {
+            let _ = write!(out, " view[{:?} running={}]=[", addr, endpoint.is_running());
+            for idx in 0..self.num_players {
+                let status = endpoint.peer_connect_status(PlayerHandle::new(idx));
+                let _ = write!(
+                    out,
+                    "{}{}:{}{}",
+                    if idx == 0 { "" } else { ", " },
+                    idx,
+                    if status.disconnected { "D" } else { "C" },
+                    status.last_frame.as_i32()
+                );
+            }
+            let _ = write!(out, "]");
+        }
+        out
+    }
+
     /// Returns the maximum prediction window of a session.
     #[must_use]
     pub fn max_prediction(&self) -> usize {
@@ -8616,17 +8667,100 @@ impl<T: Config> P2PSession<T> {
     /// agreement can never be reached. Allocation-free; called once per
     /// [`Self::poll_remote_clients`].
     fn connect_status_nudge_needed(&self) -> bool {
-        self.local_connect_status
-            .iter()
-            .enumerate()
-            .any(|(idx, status)| {
-                let handle = PlayerHandle::new(idx);
-                // Local players can never be disconnected; the guard keeps the
-                // helper's contract honest if that ever changes.
-                status.disconnected
-                    && !self.player_reg.is_local_player(handle)
-                    && self.remote_slot_confirmed_bound(handle, status).is_some()
-            })
+        let drop_awaiting_agreement =
+            self.local_connect_status
+                .iter()
+                .enumerate()
+                .any(|(idx, status)| {
+                    let handle = PlayerHandle::new(idx);
+                    // Local players can never be disconnected; the guard keeps the
+                    // helper's contract honest if that ever changes.
+                    status.disconnected
+                        && !self.player_reg.is_local_player(handle)
+                        && self.remote_slot_confirmed_bound(handle, status).is_some()
+                });
+        drop_awaiting_agreement || self.gossip_holds_confirmation_below_receipts()
+    }
+
+    /// Cold-start / catch-up gossip hold (the no-drop sibling of the
+    /// drop-awaiting-agreement nudge arm): `true` when the mesh-gossip fold
+    /// pins [`confirmed_frame`](Self::confirmed_frame) **strictly below** the
+    /// local-receipt-only fold — i.e. every input needed to confirm further
+    /// has already been received locally, and only some running remote
+    /// endpoint's stale cached view of a slot (possibly its initial
+    /// `Frame::NULL`, never updated by any `Input` packet) holds confirmation
+    /// back.
+    ///
+    /// Why this needs a dedicated liveness carrier: connect-status gossip
+    /// rides only `Input` messages. At `N >= 3`, if a peer sends its entire
+    /// initial prediction window's inputs before hearing a third peer's first
+    /// input (transient startup loss/jitter/reorder is enough), its last
+    /// gossip leaves that slot's view at `Frame::NULL` in every receiver's
+    /// cache. Once **every** peer exhausts its prediction window
+    /// (`current - confirmed >= max_prediction`) with fully-acked send
+    /// queues, no peer ever sends another `Input` — `KeepAlive`,
+    /// `QualityReport`, and `InputAck` carry no connect status — so the stale
+    /// caches never refresh and the whole mesh deadlocks permanently at
+    /// `confirmed == NULL` on a perfectly healed network, every session
+    /// `Running`. (Found by the deterministic simulation fleet; the 0.9.0
+    /// nudge closed exactly this gossip-mute mechanism, but only while a
+    /// local drop awaited mesh agreement.)
+    ///
+    /// While this condition holds, each input-idle endpoint re-sends one
+    /// status-bearing duplicate input per keepalive interval (the existing
+    /// nudge wire shape — receivers treat it as a stale retransmission), so
+    /// every peer's contribution to the others' folds catches up to its real
+    /// receipts and the fold releases.
+    ///
+    /// The condition deliberately requires BOTH legs of the deadlock
+    /// signature:
+    ///
+    /// 1. **The prediction window is exhausted**
+    ///    (`current - confirmed >= max_prediction`): a healthy `N >= 3` mesh
+    ///    *permanently* paces `confirmed` roughly one gossip delivery behind
+    ///    the local receipts (GGPO `PollNPlayers` parity — see
+    ///    [`confirmed_frame`](Self::confirmed_frame)), so "gossip binds" alone
+    ///    is the ordinary steady state, not a stall; while the window has
+    ///    room, real input traffic flows and carries gossip organically.
+    ///    Only a session that can no longer advance has lost its carrier.
+    /// 2. **Gossip, not receipts, is what binds**
+    ///    (`confirmed < receipt_fold`): when confirmation is receipt-bound (a
+    ///    peer's inputs are genuinely missing locally) no nudge fires —
+    ///    pending-output retransmission owns that recovery path.
+    ///
+    /// At `N == 2` the fold never binds below the receipt (the peer's
+    /// gossiped self-claim always covers the inputs it sent), so this arm is
+    /// inert there. In lockstep (`max_prediction == 0`) leg 1 is satisfied
+    /// whenever confirmation stalls at all, which is exactly the intended
+    /// carrier semantics there.
+    fn gossip_holds_confirmation_below_receipts(&self) -> bool {
+        let confirmed = self.confirmed_frame();
+        let gap = self
+            .sync_layer
+            .current_frame()
+            .as_i32()
+            .saturating_sub(confirmed.as_i32());
+        let window = i32::try_from(self.max_prediction).unwrap_or(i32::MAX);
+        if gap < window {
+            return false;
+        }
+
+        let mut receipt_fold = Frame::new(i32::MAX);
+        for (idx, status) in self.local_connect_status.iter().enumerate() {
+            let handle = PlayerHandle::new(idx);
+            // Disconnected remote slots are the drop arm's business (their
+            // liveness carrier is the drop-awaiting-agreement nudge and the
+            // mesh-agreed exclusion); fold only connected slots plus local
+            // slots, mirroring the connected arms of `confirmed_frame`.
+            if status.disconnected && !self.player_reg.is_local_player(handle) {
+                continue;
+            }
+            receipt_fold = std::cmp::min(receipt_fold, status.last_frame);
+        }
+        if receipt_fold.as_i32() == i32::MAX {
+            return false;
+        }
+        confirmed < receipt_fold
     }
 
     /// Applies a freeze-frame convergence re-adjust to a RESERVED (or
@@ -9883,6 +10017,66 @@ mod tests {
         const _: () = assert!(DEFAULT_MAX_EVENT_QUEUE_SIZE <= 1000);
         // Verify at runtime the constant is what we expect
         assert_eq!(DEFAULT_MAX_EVENT_QUEUE_SIZE, 100);
+    }
+
+    /// Red-documentation test for defect D9 (PLAN.md §2): event-queue
+    /// overflow silently discards the oldest event — even a safety-critical
+    /// `Disconnected` — with **zero** telemetry: no violation, no counter,
+    /// nothing an application could use to learn an event was lost.
+    ///
+    /// This pins today's defective behavior so the defect is executable, not
+    /// just documented. When the M2 discard telemetry lands (rate-limited
+    /// Warning violation + `events_discarded_total` counter), the final
+    /// assertion flips to expect the violation instead.
+    #[test]
+    fn event_queue_overflow_discards_disconnected_event_with_zero_telemetry() {
+        let mut session = create_two_player_session();
+        let addr = test_addr(8080);
+        let observer = Arc::new(crate::telemetry::CollectingObserver::new());
+        let _guard = crate::telemetry::push_violation_observer(
+            Arc::clone(&observer) as Arc<dyn crate::telemetry::ViolationObserver>
+        );
+
+        // Canary: an undrained Disconnected event at the front of the queue.
+        session
+            .event_queue
+            .push_back(FortressEvent::Disconnected { addr });
+
+        // Churn wave: `max_event_queue_size` benign protocol events arrive
+        // before the application drains — the D9 scenario (a slow-draining
+        // app during a sync/churn burst).
+        for _ in 0..session.max_event_queue_size {
+            session.handle_event(
+                Event::Synchronizing {
+                    total: 10,
+                    count: 1,
+                    total_requests_sent: 1,
+                    elapsed_ms: 5,
+                },
+                Arc::from([PlayerHandle::new(1)]),
+                addr,
+            );
+        }
+
+        assert_eq!(
+            session.event_queue.len(),
+            session.max_event_queue_size,
+            "queue must be trimmed to its cap"
+        );
+        let disconnected_still_queued = session
+            .event_queue
+            .iter()
+            .any(|e| matches!(e, FortressEvent::Disconnected { .. }));
+        assert!(
+            !disconnected_still_queued,
+            "the Disconnected canary must have been evicted by the overflow trim"
+        );
+        // RED (defect D9): the loss is completely silent today.
+        assert!(
+            observer.violations().is_empty(),
+            "expected today's defective silent discard (no telemetry); observed violations: {:?}",
+            observer.violations()
+        );
     }
 
     // ==========================================

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -20,6 +20,7 @@ pub mod bus_socket;
 pub mod channel_socket;
 pub mod filter_socket;
 pub mod reorder_socket;
+pub mod sim_net;
 pub mod stubs;
 pub mod stubs_enum;
 pub mod test_clock;
@@ -41,6 +42,8 @@ pub use filter_socket::{
 };
 #[allow(unused_imports)]
 pub use reorder_socket::{create_reorder_mesh_triple, HeldLinks, ReorderSocket};
+#[allow(unused_imports)]
+pub use sim_net::{LinkPolicy, SimClockFn, SimNet, SimNetStats, SimSocket, UnattachedPolicy};
 #[allow(unused_imports)]
 pub use test_clock::TestClock;
 #[allow(unused_imports)]

--- a/tests/common/sim_net.rs
+++ b/tests/common/sim_net.rs
@@ -1,0 +1,985 @@
+//! Deterministic whole-mesh simulation network for DST-style testing.
+//!
+//! [`SimNet`] is the scheduler-controlled network fabric for the simulation
+//! harness (`tests/simulation.rs`): one central, seeded, virtual-time message
+//! switch that every peer's [`SimSocket`] sends through. It subsumes the
+//! per-socket test utilities for whole-mesh use:
+//!
+//! - [`ChannelSocket`](super::channel_socket::ChannelSocket): instant in-memory
+//!   delivery — `SimNet` adds per-directed-link faults on top.
+//! - `ChaosSocket`: per-socket loss/latency/jitter with its own RNG — `SimNet`
+//!   instead scopes every fault to a *directed link* `(from, to)` and rolls all
+//!   faults from **one** seeded RNG, so a whole mesh reproduces from a single
+//!   seed and asymmetric conditions (A→B lossy, B→A clean) are first-class.
+//! - `FilterSocket`/`BlockedLinks`: directional black-holes — `SimNet`'s
+//!   `set_blocked` covers this, mid-run, without wrapping sockets.
+//! - `ReorderSocket`/`HeldLinks`: hold-then-FIFO-release — `SimNet`'s
+//!   `set_holding` covers this per directed link.
+//! - `RoutingBus`/`BusSocket`: re-attach at a vacated address (hot-join) —
+//!   `SimNet`'s [`SimNet::attach`]/[`SimNet::detach`] plus
+//!   [`UnattachedPolicy::Buffer`] cover this.
+//!
+//! # Determinism contract
+//!
+//! With a fixed seed, a fixed virtual clock schedule, and a fixed sequence of
+//! `send`/`receive`/control calls, `SimNet` produces a byte-identical delivery
+//! trace. All internal maps are `BTreeMap`s, in-flight messages are ordered by
+//! `(deliver_at, unique sequence number)` (a total order), and every random
+//! roll comes from one seeded [`Pcg32`] consumed in call order. There is no
+//! wall-clock read anywhere: time comes exclusively from the injected clock.
+//!
+//! The payload type is generic so the fault machinery is unit-testable with
+//! plain values (`Message` has `pub(crate)` fields and cannot be constructed
+//! by integration tests); sessions use the [`Message`] instantiation via the
+//! [`NonBlockingSocket`] impl.
+
+// Test infrastructure: not every test binary uses every helper.
+#![allow(dead_code)]
+
+use fortress_rollback::rng::{Pcg32, SeedableRng};
+use fortress_rollback::{Message, NonBlockingSocket};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BinaryHeap, VecDeque};
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use web_time::Instant;
+
+/// Clock function shared with the sessions under test (same shape as
+/// `TestClock::as_protocol_clock`).
+pub type SimClockFn = Arc<dyn Fn() -> Instant + Send + Sync>;
+
+/// Upper bound on messages returned by a single `receive_all_messages` call,
+/// mirroring the built-in sockets' per-poll decode cap. Excess messages stay
+/// queued in the inbox for the next poll (never dropped).
+pub const MAX_RECEIVE_MESSAGES_PER_POLL: usize = 256;
+
+/// Fault policy for one directed link `(from, to)`.
+///
+/// All probabilities are in `0.0..=1.0` and are rolled per send, in a fixed
+/// order (burst, drop, duplicate, jitter), from the net-wide seeded RNG.
+/// Serializable so simulation schedules (which embed link policies) can be
+/// stored as reproducible corpus artifacts.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LinkPolicy {
+    /// Probability an individual send is dropped.
+    pub drop_rate: f64,
+    /// Probability an individual send is delivered twice (each copy rolls its
+    /// own jitter, so duplicates may arrive out of order).
+    pub dup_rate: f64,
+    /// Fixed one-way delivery delay.
+    pub base_delay: Duration,
+    /// Additional uniformly-random delay in `[0, jitter]` per delivered copy.
+    pub jitter: Duration,
+    /// Probability a send *starts* a loss burst (that send and the following
+    /// `burst_len - 1` sends on this link are dropped).
+    pub burst_rate: f64,
+    /// Total sends dropped per burst, including the send that triggered it.
+    pub burst_len: u32,
+}
+
+impl LinkPolicy {
+    /// A perfect link: no loss, no duplication, no delay.
+    #[must_use]
+    pub fn clean() -> Self {
+        Self {
+            drop_rate: 0.0,
+            dup_rate: 0.0,
+            base_delay: Duration::ZERO,
+            jitter: Duration::ZERO,
+            burst_rate: 0.0,
+            burst_len: 0,
+        }
+    }
+}
+
+impl Default for LinkPolicy {
+    fn default() -> Self {
+        Self::clean()
+    }
+}
+
+/// What happens to a message delivered to an address with no attached socket.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum UnattachedPolicy {
+    /// Silently discard, like real UDP to a dead port (counted in
+    /// [`SimNetStats::dropped_unattached`]). The default.
+    Drop,
+    /// Buffer in the destination inbox; a later [`SimNet::attach`] at that
+    /// address receives everything buffered while it was away (the
+    /// `RoutingBus` hot-join semantics).
+    Buffer,
+}
+
+/// Delivery/drop counters for premise assertions ("this schedule really did
+/// drop traffic") and debugging. All counts are message copies.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct SimNetStats {
+    /// `send_to` calls observed (before any fault roll).
+    pub sent: u64,
+    /// Copies placed into an inbox (including buffered-unattached copies).
+    pub delivered: u64,
+    /// Copies dropped by drop-rate or burst rolls.
+    pub dropped_by_policy: u64,
+    /// Copies dropped because the link was blocked.
+    pub dropped_blocked: u64,
+    /// Copies dropped on delivery because no socket was attached
+    /// (only under [`UnattachedPolicy::Drop`]).
+    pub dropped_unattached: u64,
+    /// Sends that produced a second copy.
+    pub duplicated: u64,
+    /// Sends captured by a holding link (delivered later on release).
+    pub held: u64,
+}
+
+/// Runtime state of one directed link.
+#[derive(Clone, Debug, Default)]
+struct LinkState {
+    policy: LinkPolicy,
+    /// Remaining sends to drop in the current loss burst.
+    burst_remaining: u32,
+    /// Black-hole: every send is dropped.
+    blocked: bool,
+    /// Capture-and-hold: sends bypass fault rolls and queue until release.
+    holding: bool,
+}
+
+impl LinkState {
+    fn with_policy(policy: LinkPolicy) -> Self {
+        Self {
+            policy,
+            burst_remaining: 0,
+            blocked: false,
+            holding: false,
+        }
+    }
+}
+
+/// An in-flight message copy, ordered by `(deliver_at, seq)`.
+///
+/// `seq` is unique per copy, so the ordering is total and same-instant copies
+/// deliver in global send order — the determinism backbone.
+struct InFlight<M> {
+    deliver_at: Instant,
+    seq: u64,
+    from: SocketAddr,
+    to: SocketAddr,
+    payload: M,
+}
+
+impl<M> PartialEq for InFlight<M> {
+    fn eq(&self, other: &Self) -> bool {
+        self.deliver_at == other.deliver_at && self.seq == other.seq
+    }
+}
+
+impl<M> Eq for InFlight<M> {}
+
+impl<M> PartialOrd for InFlight<M> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<M> Ord for InFlight<M> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.deliver_at
+            .cmp(&other.deliver_at)
+            .then(self.seq.cmp(&other.seq))
+    }
+}
+
+struct SimNetState<M> {
+    clock: SimClockFn,
+    rng: Pcg32,
+    /// Next unique in-flight sequence number.
+    seq: u64,
+    /// Policy applied to links that have no explicit state yet. Materialized
+    /// into a `LinkState` on a link's first send, so later changes to the
+    /// default do not retroactively affect links that already carried traffic
+    /// — set the default before traffic flows, use `set_link` afterwards.
+    default_policy: LinkPolicy,
+    links: BTreeMap<(SocketAddr, SocketAddr), LinkState>,
+    /// Messages captured by holding links, FIFO per directed link.
+    held: BTreeMap<(SocketAddr, SocketAddr), VecDeque<M>>,
+    /// Min-heap of scheduled deliveries (via `Reverse`).
+    in_flight: BinaryHeap<std::cmp::Reverse<InFlight<M>>>,
+    inboxes: BTreeMap<SocketAddr, VecDeque<(SocketAddr, M)>>,
+    unattached: UnattachedPolicy,
+    stats: SimNetStats,
+}
+
+impl<M: Clone> SimNetState<M> {
+    fn now(&self) -> Instant {
+        (self.clock)()
+    }
+
+    /// Uniform roll in `[0, 1)`.
+    fn roll_unit(&mut self) -> f64 {
+        f64::from(self.rng.next_u32()) / (f64::from(u32::MAX) + 1.0)
+    }
+
+    /// Uniform duration in `[0, max]` at millisecond granularity.
+    fn roll_jitter(&mut self, max: Duration) -> Duration {
+        let max_ms = max.as_millis();
+        if max_ms == 0 {
+            return Duration::ZERO;
+        }
+        // Modulo bias is irrelevant for fault injection; determinism is what
+        // matters. `max_ms + 1` keeps the range inclusive and fits u64 for
+        // any sane jitter configuration.
+        let bound = u64::try_from(max_ms + 1).unwrap_or(u64::MAX);
+        let ms = self.rng.next_u64() % bound;
+        Duration::from_millis(ms)
+    }
+
+    fn schedule(&mut self, from: SocketAddr, to: SocketAddr, payload: M, deliver_at: Instant) {
+        let seq = self.seq;
+        self.seq += 1;
+        self.in_flight.push(std::cmp::Reverse(InFlight {
+            deliver_at,
+            seq,
+            from,
+            to,
+            payload,
+        }));
+    }
+
+    fn send(&mut self, from: SocketAddr, to: SocketAddr, payload: M) {
+        self.stats.sent += 1;
+        let key = (from, to);
+        if !self.links.contains_key(&key) {
+            let state = LinkState::with_policy(self.default_policy.clone());
+            self.links.insert(key, state);
+        }
+
+        // Split borrows: read the link decision first, then roll RNG.
+        let (blocked, holding) = match self.links.get(&key) {
+            Some(link) => (link.blocked, link.holding),
+            None => (false, false),
+        };
+
+        if blocked {
+            self.stats.dropped_blocked += 1;
+            return;
+        }
+        if holding {
+            self.stats.held += 1;
+            self.held.entry(key).or_default().push_back(payload);
+            return;
+        }
+
+        // Burst state machine (mirrors the ChaosSocket semantics: the
+        // triggering send and the following `burst_len - 1` sends drop).
+        let in_burst = self
+            .links
+            .get(&key)
+            .is_some_and(|link| link.burst_remaining > 0);
+        if in_burst {
+            if let Some(link) = self.links.get_mut(&key) {
+                link.burst_remaining -= 1;
+            }
+            self.stats.dropped_by_policy += 1;
+            return;
+        }
+        let (burst_rate, burst_len, drop_rate, dup_rate, base_delay, jitter) =
+            match self.links.get(&key) {
+                Some(link) => (
+                    link.policy.burst_rate,
+                    link.policy.burst_len,
+                    link.policy.drop_rate,
+                    link.policy.dup_rate,
+                    link.policy.base_delay,
+                    link.policy.jitter,
+                ),
+                None => (0.0, 0, 0.0, 0.0, Duration::ZERO, Duration::ZERO),
+            };
+
+        if burst_rate > 0.0 && self.roll_unit() < burst_rate {
+            if let Some(link) = self.links.get_mut(&key) {
+                link.burst_remaining = burst_len.saturating_sub(1);
+            }
+            self.stats.dropped_by_policy += 1;
+            return;
+        }
+        if drop_rate > 0.0 && self.roll_unit() < drop_rate {
+            self.stats.dropped_by_policy += 1;
+            return;
+        }
+
+        let copies = if dup_rate > 0.0 && self.roll_unit() < dup_rate {
+            self.stats.duplicated += 1;
+            2
+        } else {
+            1
+        };
+
+        let now = self.now();
+        for _ in 0..copies {
+            let delay = base_delay + self.roll_jitter(jitter);
+            self.schedule(from, to, payload.clone(), now + delay);
+        }
+    }
+
+    /// Moves every due in-flight copy into its destination inbox.
+    fn pump(&mut self) {
+        let now = self.now();
+        while let Some(std::cmp::Reverse(head)) = self.in_flight.peek() {
+            if head.deliver_at > now {
+                break;
+            }
+            let Some(std::cmp::Reverse(msg)) = self.in_flight.pop() else {
+                break;
+            };
+            match self.inboxes.get_mut(&msg.to) {
+                Some(queue) => {
+                    queue.push_back((msg.from, msg.payload));
+                    self.stats.delivered += 1;
+                },
+                None => match self.unattached {
+                    UnattachedPolicy::Drop => self.stats.dropped_unattached += 1,
+                    UnattachedPolicy::Buffer => {
+                        self.inboxes
+                            .entry(msg.to)
+                            .or_default()
+                            .push_back((msg.from, msg.payload));
+                        self.stats.delivered += 1;
+                    },
+                },
+            }
+        }
+    }
+
+    fn receive(&mut self, addr: SocketAddr) -> Vec<(SocketAddr, M)> {
+        self.pump();
+        let Some(queue) = self.inboxes.get_mut(&addr) else {
+            return Vec::new();
+        };
+        let take = queue.len().min(MAX_RECEIVE_MESSAGES_PER_POLL);
+        queue.drain(..take).collect()
+    }
+
+    /// Flushes a link's held queue into delivery at the current instant,
+    /// preserving capture order (fresh sequence numbers keep FIFO).
+    fn release_held(&mut self, key: (SocketAddr, SocketAddr)) {
+        let Some(mut queue) = self.held.remove(&key) else {
+            return;
+        };
+        let now = self.now();
+        while let Some(payload) = queue.pop_front() {
+            self.schedule(key.0, key.1, payload, now);
+        }
+    }
+}
+
+/// Controller handle for the simulated network. Cheap to clone; all clones
+/// (and all [`SimSocket`]s) share the same state.
+pub struct SimNet<M = Message> {
+    state: Arc<Mutex<SimNetState<M>>>,
+}
+
+impl<M> Clone for SimNet<M> {
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+// Test infrastructure — a poisoned mutex is a test bug, not a recoverable
+// condition, so `.expect()` is appropriate here (ChannelSocket precedent).
+#[allow(clippy::expect_used)]
+impl<M: Clone> SimNet<M> {
+    /// Creates a network with the given fault seed and virtual clock.
+    ///
+    /// Starts with a clean default policy and [`UnattachedPolicy::Drop`].
+    #[must_use]
+    pub fn new(seed: u64, clock: SimClockFn) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(SimNetState {
+                clock,
+                rng: Pcg32::seed_from_u64(seed),
+                seq: 0,
+                default_policy: LinkPolicy::clean(),
+                links: BTreeMap::new(),
+                held: BTreeMap::new(),
+                in_flight: BinaryHeap::new(),
+                inboxes: BTreeMap::new(),
+                unattached: UnattachedPolicy::Drop,
+                stats: SimNetStats::default(),
+            })),
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, SimNetState<M>> {
+        self.state.lock().expect("SimNet mutex poisoned")
+    }
+
+    /// Attaches a socket at `addr`, creating an inbox for it.
+    ///
+    /// An existing inbox (from a previous attachment, or buffered
+    /// unattached-policy traffic) is preserved, so a hot-join re-attach at a
+    /// vacated address receives anything buffered for it.
+    #[must_use]
+    pub fn attach(&self, addr: SocketAddr) -> SimSocket<M> {
+        self.lock().inboxes.entry(addr).or_default();
+        SimSocket {
+            addr,
+            state: Arc::clone(&self.state),
+        }
+    }
+
+    /// Detaches the socket at `addr`, discarding its inbox. In-flight copies
+    /// destined for it follow the [`UnattachedPolicy`] at delivery time.
+    pub fn detach(&self, addr: SocketAddr) {
+        self.lock().inboxes.remove(&addr);
+    }
+
+    /// Sets the policy applied to links on their **first** send. Links that
+    /// already carried traffic keep their materialized state — use
+    /// [`Self::set_link`] to change those.
+    pub fn set_default_policy(&self, policy: LinkPolicy) {
+        self.lock().default_policy = policy;
+    }
+
+    /// Sets (or replaces) the fault policy for the directed link `from → to`,
+    /// preserving its blocked/holding toggles and resetting any burst in
+    /// progress.
+    pub fn set_link(&self, from: SocketAddr, to: SocketAddr, policy: LinkPolicy) {
+        let mut state = self.lock();
+        let link = state.links.entry((from, to)).or_default();
+        link.policy = policy;
+        link.burst_remaining = 0;
+    }
+
+    /// Sets the same policy on both directions between `a` and `b`.
+    pub fn set_link_symmetric(&self, a: SocketAddr, b: SocketAddr, policy: LinkPolicy) {
+        self.set_link(a, b, policy.clone());
+        self.set_link(b, a, policy);
+    }
+
+    /// Black-holes (or restores) the directed link `from → to`. Blocking is
+    /// asymmetric by design: the reverse direction is untouched.
+    pub fn set_blocked(&self, from: SocketAddr, to: SocketAddr, blocked: bool) {
+        let mut state = self.lock();
+        let link = state.links.entry((from, to)).or_default();
+        link.blocked = blocked;
+    }
+
+    /// Blocks every directed link between the two groups, in both directions
+    /// (a group partition / split brain). Restore with `set_blocked(.., false)`
+    /// per link or [`Self::heal_all`].
+    pub fn partition(&self, group_a: &[SocketAddr], group_b: &[SocketAddr]) {
+        for &a in group_a {
+            for &b in group_b {
+                self.set_blocked(a, b, true);
+                self.set_blocked(b, a, true);
+            }
+        }
+    }
+
+    /// Starts or stops capture-and-hold on the directed link `from → to`.
+    /// While holding, sends on the link queue (bypassing fault rolls); on
+    /// release they are delivered immediately, in capture order.
+    pub fn set_holding(&self, from: SocketAddr, to: SocketAddr, holding: bool) {
+        let mut state = self.lock();
+        let key = (from, to);
+        let link = state.links.entry(key).or_default();
+        link.holding = holding;
+        if !holding {
+            state.release_held(key);
+        }
+    }
+
+    /// Resets every link to clean/unblocked/released and the default policy
+    /// to clean. Buffered held messages are delivered (FIFO), in-flight
+    /// messages keep their scheduled delivery times.
+    pub fn heal_all(&self) {
+        let mut state = self.lock();
+        state.default_policy = LinkPolicy::clean();
+        let keys: Vec<(SocketAddr, SocketAddr)> = state.links.keys().copied().collect();
+        for key in keys {
+            if let Some(link) = state.links.get_mut(&key) {
+                link.policy = LinkPolicy::clean();
+                link.burst_remaining = 0;
+                link.blocked = false;
+                link.holding = false;
+            }
+            state.release_held(key);
+        }
+    }
+
+    /// Sets the policy for messages delivered to unattached addresses.
+    pub fn set_unattached_policy(&self, policy: UnattachedPolicy) {
+        self.lock().unattached = policy;
+    }
+
+    /// Snapshot of the delivery/drop counters.
+    #[must_use]
+    pub fn stats(&self) -> SimNetStats {
+        self.lock().stats
+    }
+}
+
+/// A peer-side socket attached to a [`SimNet`] at a fixed address.
+pub struct SimSocket<M = Message> {
+    addr: SocketAddr,
+    state: Arc<Mutex<SimNetState<M>>>,
+}
+
+// Test infrastructure — poisoned mutex is a test bug (see SimNet::lock).
+#[allow(clippy::expect_used)]
+impl<M: Clone> SimSocket<M> {
+    /// The address this socket is attached at.
+    #[must_use]
+    pub fn local_addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Sends a payload to `to` through the simulated network.
+    pub fn send_payload(&self, to: SocketAddr, payload: M) {
+        self.state
+            .lock()
+            .expect("SimNet mutex poisoned")
+            .send(self.addr, to, payload);
+    }
+
+    /// Receives every payload due for this socket (bounded per call by
+    /// [`MAX_RECEIVE_MESSAGES_PER_POLL`]; the remainder stays queued).
+    #[must_use]
+    pub fn recv_payloads(&self) -> Vec<(SocketAddr, M)> {
+        self.state
+            .lock()
+            .expect("SimNet mutex poisoned")
+            .receive(self.addr)
+    }
+}
+
+impl NonBlockingSocket<SocketAddr> for SimSocket<Message> {
+    fn send_to(&mut self, msg: &Message, addr: &SocketAddr) {
+        self.send_payload(*addr, msg.clone());
+    }
+
+    fn receive_all_messages(&mut self) -> Vec<(SocketAddr, Message)> {
+        self.recv_payloads()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+
+    fn addr(port: u16) -> SocketAddr {
+        ([127, 0, 0, 1], port).into()
+    }
+
+    /// A manually-advanceable clock (local, to avoid a dependency on
+    /// `test_clock` from within unit tests of a sibling module).
+    fn manual_clock() -> (SimClockFn, Arc<AtomicU64>) {
+        let base = Instant::now();
+        let offset_ms = Arc::new(AtomicU64::new(0));
+        let offset = Arc::clone(&offset_ms);
+        let clock: SimClockFn =
+            Arc::new(move || base + Duration::from_millis(offset.load(AtomicOrdering::Relaxed)));
+        (clock, offset_ms)
+    }
+
+    /// Drives `sends` identical send sequences through a fresh net and
+    /// returns the (receiver-observed) delivery trace.
+    fn run_trace(seed: u64, policy: LinkPolicy) -> Vec<(SocketAddr, u32)> {
+        let (clock, offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(seed, clock);
+        net.set_default_policy(policy);
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        let mut trace = Vec::new();
+        for step in 0..200u32 {
+            a.send_payload(addr(2), step);
+            b.send_payload(addr(1), 10_000 + step);
+            trace.extend(a.recv_payloads());
+            trace.extend(b.recv_payloads());
+            offset.fetch_add(16, AtomicOrdering::Relaxed);
+        }
+        // Drain: advance well past any jitter and collect the tail.
+        offset.fetch_add(10_000, AtomicOrdering::Relaxed);
+        trace.extend(a.recv_payloads());
+        trace.extend(b.recv_payloads());
+        trace
+    }
+
+    #[test]
+    fn same_seed_produces_identical_delivery_trace() {
+        let policy = LinkPolicy {
+            drop_rate: 0.2,
+            dup_rate: 0.1,
+            base_delay: Duration::from_millis(30),
+            jitter: Duration::from_millis(25),
+            burst_rate: 0.02,
+            burst_len: 4,
+        };
+        let first = run_trace(42, policy.clone());
+        let second = run_trace(42, policy.clone());
+        assert_eq!(first, second, "same seed must reproduce the exact trace");
+
+        let third = run_trace(43, policy);
+        assert_ne!(
+            first, third,
+            "a different seed should perturb a lossy/jittery trace"
+        );
+    }
+
+    #[test]
+    fn clean_link_delivers_everything_in_order() {
+        let (clock, _offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        for i in 0..10 {
+            a.send_payload(addr(2), i);
+        }
+        let received = b.recv_payloads();
+        let values: Vec<u32> = received.iter().map(|(_, v)| *v).collect();
+        assert_eq!(values, (0..10).collect::<Vec<_>>());
+        assert!(received.iter().all(|(from, _)| *from == addr(1)));
+
+        let stats = net.stats();
+        assert_eq!(stats.sent, 10);
+        assert_eq!(stats.delivered, 10);
+        assert_eq!(stats.dropped_by_policy, 0);
+    }
+
+    #[test]
+    fn link_faults_are_isolated_per_direction() {
+        let (clock, _offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        // A→B drops everything; B→A stays clean.
+        net.set_link(
+            addr(1),
+            addr(2),
+            LinkPolicy {
+                drop_rate: 1.0,
+                ..LinkPolicy::clean()
+            },
+        );
+
+        for i in 0..5 {
+            a.send_payload(addr(2), i);
+            b.send_payload(addr(1), 100 + i);
+        }
+        assert!(b.recv_payloads().is_empty(), "A→B must be fully dropped");
+        assert_eq!(
+            a.recv_payloads().len(),
+            5,
+            "B→A must be unaffected by the A→B policy"
+        );
+    }
+
+    #[test]
+    fn blocked_link_is_asymmetric_and_reversible() {
+        let (clock, _offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        net.set_blocked(addr(1), addr(2), true);
+        a.send_payload(addr(2), 1);
+        b.send_payload(addr(1), 2);
+        assert!(b.recv_payloads().is_empty(), "blocked direction drops");
+        assert_eq!(a.recv_payloads().len(), 1, "reverse direction flows");
+
+        net.set_blocked(addr(1), addr(2), false);
+        a.send_payload(addr(2), 3);
+        assert_eq!(b.recv_payloads().len(), 1, "unblocked link flows again");
+        assert_eq!(net.stats().dropped_blocked, 1);
+    }
+
+    #[test]
+    fn delayed_message_arrives_only_after_clock_advance() {
+        let (clock, offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        net.set_default_policy(LinkPolicy {
+            base_delay: Duration::from_millis(100),
+            ..LinkPolicy::clean()
+        });
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        a.send_payload(addr(2), 1);
+        assert!(b.recv_payloads().is_empty(), "not due yet");
+
+        offset.fetch_add(99, AtomicOrdering::Relaxed);
+        assert!(b.recv_payloads().is_empty(), "still 1ms early");
+
+        offset.fetch_add(1, AtomicOrdering::Relaxed);
+        assert_eq!(b.recv_payloads().len(), 1, "due exactly at base_delay");
+    }
+
+    #[test]
+    fn duplication_delivers_exactly_two_copies() {
+        let (clock, offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        net.set_default_policy(LinkPolicy {
+            dup_rate: 1.0,
+            ..LinkPolicy::clean()
+        });
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        a.send_payload(addr(2), 9);
+        offset.fetch_add(1, AtomicOrdering::Relaxed);
+        let received = b.recv_payloads();
+        assert_eq!(received.len(), 2, "dup_rate=1 must deliver two copies");
+        assert!(received.iter().all(|(_, v)| *v == 9));
+        assert_eq!(net.stats().duplicated, 1);
+    }
+
+    #[test]
+    fn hold_then_release_preserves_fifo_order() {
+        let (clock, _offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        net.set_holding(addr(1), addr(2), true);
+        for i in 0..5 {
+            a.send_payload(addr(2), i);
+        }
+        assert!(b.recv_payloads().is_empty(), "held messages must not leak");
+        assert_eq!(net.stats().held, 5);
+
+        net.set_holding(addr(1), addr(2), false);
+        let values: Vec<u32> = b.recv_payloads().into_iter().map(|(_, v)| v).collect();
+        assert_eq!(values, vec![0, 1, 2, 3, 4], "release must preserve order");
+    }
+
+    #[test]
+    fn hold_can_invert_arrival_order_across_links() {
+        let (clock, _offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+        let c = net.attach(addr(3));
+
+        // Hold A→C while A→B flows, then release: C sees "newer" traffic from
+        // B (relayed) before A's older direct messages — the cross-link
+        // reorder primitive.
+        net.set_holding(addr(1), addr(3), true);
+        a.send_payload(addr(3), 1); // old, held
+        a.send_payload(addr(2), 2); // flows to B
+        let via_b = b.recv_payloads();
+        assert_eq!(via_b.len(), 1);
+        b.send_payload(addr(3), 3); // newer, arrives first
+        assert_eq!(
+            c.recv_payloads()
+                .into_iter()
+                .map(|(_, v)| v)
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
+
+        net.set_holding(addr(1), addr(3), false);
+        assert_eq!(
+            c.recv_payloads()
+                .into_iter()
+                .map(|(_, v)| v)
+                .collect::<Vec<_>>(),
+            vec![1],
+            "held message arrives after the newer relayed one"
+        );
+    }
+
+    #[test]
+    fn detach_drops_and_reattach_receives_fresh_traffic() {
+        let (clock, _offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        let a = net.attach(addr(1));
+        let _b = net.attach(addr(2));
+
+        net.detach(addr(2));
+        a.send_payload(addr(2), 1);
+        // Force delivery attempt while detached (Drop policy).
+        let _ = a.recv_payloads();
+        assert_eq!(net.stats().dropped_unattached, 1);
+
+        let b2 = net.attach(addr(2));
+        a.send_payload(addr(2), 2);
+        assert_eq!(
+            b2.recv_payloads()
+                .into_iter()
+                .map(|(_, v)| v)
+                .collect::<Vec<_>>(),
+            vec![2],
+            "re-attached socket receives post-attach traffic only"
+        );
+    }
+
+    #[test]
+    fn buffer_policy_preserves_traffic_across_reattach() {
+        let (clock, _offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        net.set_unattached_policy(UnattachedPolicy::Buffer);
+        let a = net.attach(addr(1));
+
+        a.send_payload(addr(2), 1);
+        let _ = a.recv_payloads(); // pump delivery into the buffered inbox
+
+        let b = net.attach(addr(2));
+        assert_eq!(
+            b.recv_payloads()
+                .into_iter()
+                .map(|(_, v)| v)
+                .collect::<Vec<_>>(),
+            vec![1],
+            "buffered unattached traffic must survive until attach"
+        );
+    }
+
+    #[test]
+    fn receive_is_bounded_per_poll_and_never_loses_the_remainder() {
+        let (clock, _offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        let total = MAX_RECEIVE_MESSAGES_PER_POLL + 40;
+        for i in 0..total {
+            a.send_payload(addr(2), u32::try_from(i).unwrap());
+        }
+        let first = b.recv_payloads();
+        assert_eq!(first.len(), MAX_RECEIVE_MESSAGES_PER_POLL);
+        let second = b.recv_payloads();
+        assert_eq!(second.len(), 40, "remainder must arrive on the next poll");
+        assert_eq!(
+            second.first().map(|(_, v)| *v),
+            Some(u32::try_from(MAX_RECEIVE_MESSAGES_PER_POLL).unwrap()),
+            "remainder must continue in order"
+        );
+    }
+
+    #[test]
+    fn burst_drops_consecutive_sends() {
+        let (clock, _offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        net.set_default_policy(LinkPolicy {
+            burst_rate: 1.0, // every non-burst send starts a new burst
+            burst_len: 3,
+            ..LinkPolicy::clean()
+        });
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        for i in 0..9 {
+            a.send_payload(addr(2), i);
+        }
+        assert!(
+            b.recv_payloads().is_empty(),
+            "burst_rate=1 with burst_len=3 drops every send (back-to-back bursts)"
+        );
+        assert_eq!(net.stats().dropped_by_policy, 9);
+    }
+
+    #[test]
+    fn heal_all_restores_clean_links_and_flushes_held() {
+        let (clock, _offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        net.set_link(
+            addr(1),
+            addr(2),
+            LinkPolicy {
+                drop_rate: 1.0,
+                ..LinkPolicy::clean()
+            },
+        );
+        net.set_blocked(addr(2), addr(1), true);
+        net.set_holding(addr(1), addr(2), false);
+        a.send_payload(addr(2), 1); // dropped by policy
+        assert!(b.recv_payloads().is_empty());
+
+        net.heal_all();
+        a.send_payload(addr(2), 2);
+        b.send_payload(addr(1), 3);
+        assert_eq!(b.recv_payloads().len(), 1, "healed link delivers");
+        assert_eq!(a.recv_payloads().len(), 1, "healed block delivers");
+    }
+
+    /// End-to-end sanity: real P2P sessions synchronize and advance over
+    /// `SimSocket`s — the actual use case for this fabric.
+    #[test]
+    fn sessions_synchronize_over_sim_sockets() {
+        use super::super::stubs::{StubConfig, StubInput};
+        use super::super::test_clock::TestClock;
+        use fortress_rollback::{
+            PlayerHandle, PlayerType, ProtocolConfig, SessionBuilder, SessionState,
+        };
+
+        let clock = TestClock::new();
+        let net: SimNet<Message> = SimNet::new(99, clock.as_protocol_clock());
+        let a1 = addr(1);
+        let a2 = addr(2);
+        let s1 = net.attach(a1);
+        let s2 = net.attach(a2);
+
+        let protocol_config = |seed: u64| ProtocolConfig {
+            clock: Some(clock.as_protocol_clock()),
+            protocol_rng_seed: Some(seed),
+            ..ProtocolConfig::default()
+        };
+
+        let mut sess1 = SessionBuilder::<StubConfig>::new()
+            .with_protocol_config(protocol_config(1))
+            .add_player(PlayerType::Local, PlayerHandle::new(0))
+            .unwrap()
+            .add_player(PlayerType::Remote(a2), PlayerHandle::new(1))
+            .unwrap()
+            .start_p2p_session(s1)
+            .unwrap();
+
+        let mut sess2 = SessionBuilder::<StubConfig>::new()
+            .with_protocol_config(protocol_config(2))
+            .add_player(PlayerType::Remote(a1), PlayerHandle::new(0))
+            .unwrap()
+            .add_player(PlayerType::Local, PlayerHandle::new(1))
+            .unwrap()
+            .start_p2p_session(s2)
+            .unwrap();
+
+        let mut synchronized = false;
+        for _ in 0..500 {
+            sess1.poll_remote_clients();
+            sess2.poll_remote_clients();
+            if sess1.current_state() == SessionState::Running
+                && sess2.current_state() == SessionState::Running
+            {
+                synchronized = true;
+                break;
+            }
+            clock.advance(Duration::from_millis(50));
+        }
+        assert!(
+            synchronized,
+            "sessions must synchronize over SimNet. sess1: {:?}, sess2: {:?}",
+            sess1.current_state(),
+            sess2.current_state()
+        );
+
+        sess1
+            .add_local_input(PlayerHandle::new(0), StubInput { inp: 1 })
+            .unwrap();
+        sess2
+            .add_local_input(PlayerHandle::new(1), StubInput { inp: 2 })
+            .unwrap();
+        assert!(!sess1.advance_frame().unwrap().is_empty());
+        assert!(!sess2.advance_frame().unwrap().is_empty());
+    }
+}

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -10,6 +10,7 @@ mod common;
 
 // Network test modules
 mod network {
+    pub mod deterministic_ping;
     pub mod in_process_chaos;
     pub mod multi_process;
     pub mod resilience;

--- a/tests/network/deterministic_ping.rs
+++ b/tests/network/deterministic_ping.rs
@@ -1,0 +1,106 @@
+//! Deterministic RTT (ping) measurement tests.
+//!
+//! `NetworkStats::ping` must be derived from the injectable protocol clock
+//! ([`ProtocolConfig::clock`]) so that (a) in-process simulations measure
+//! *virtual* network latency rather than wall-clock scheduling noise, and
+//! (b) the reported value is bit-identical across repeated runs of the same
+//! virtual-time schedule. Both properties are prerequisites for deterministic
+//! whole-mesh simulation testing.
+//!
+//! The schedule below is fully virtual: each iteration polls both sessions
+//! and then advances the shared [`TestClock`] by one poll interval. A quality
+//! report queued by one session is answered by its peer within the same
+//! iteration (in-memory channel delivery), and the reply is processed by the
+//! sender on the *next* iteration — exactly one clock advance later. The
+//! round-trip time under virtual time is therefore exactly one poll interval.
+
+// Allow test-specific patterns that are appropriate for test code
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+use crate::common::stubs::StubConfig;
+use crate::common::{
+    create_channel_pair, synchronize_sessions_deterministic, SyncConfig, TestClock,
+    POLL_INTERVAL_DETERMINISTIC,
+};
+use fortress_rollback::{FortressError, PlayerHandle, PlayerType, ProtocolConfig, SessionBuilder};
+
+/// Number of poll+advance iterations to run after synchronization.
+///
+/// Must be large enough that (a) several quality-report rounds complete
+/// (default interval 200ms = 4 iterations at 50ms/step) and (b) more than
+/// one virtual second elapses so `network_stats` reports instead of
+/// returning `NotSynchronized` (its rate window needs `elapsed >= 1s`).
+const MEASUREMENT_ITERATIONS: usize = 40;
+
+/// Runs a fixed two-session schedule under fully virtual time and returns
+/// the final RTT each session reports for its remote peer.
+fn measure_ping_over_fixed_schedule() -> Result<(u128, u128), FortressError> {
+    let clock = TestClock::new();
+    let (s1, s2, a1, a2) = create_channel_pair();
+
+    let protocol_config = |seed: u64| ProtocolConfig {
+        clock: Some(clock.as_protocol_clock()),
+        protocol_rng_seed: Some(seed),
+        ..ProtocolConfig::default()
+    };
+
+    let mut sess1 = SessionBuilder::<StubConfig>::new()
+        .with_protocol_config(protocol_config(101))
+        .add_player(PlayerType::Local, PlayerHandle::new(0))?
+        .add_player(PlayerType::Remote(a2), PlayerHandle::new(1))?
+        .start_p2p_session(s1)?;
+
+    let mut sess2 = SessionBuilder::<StubConfig>::new()
+        .with_protocol_config(protocol_config(202))
+        .add_player(PlayerType::Local, PlayerHandle::new(1))?
+        .add_player(PlayerType::Remote(a1), PlayerHandle::new(0))?
+        .start_p2p_session(s2)?;
+
+    synchronize_sessions_deterministic(&mut sess1, &mut sess2, &clock, &SyncConfig::default())
+        .expect("sessions should synchronize under virtual time");
+
+    for _ in 0..MEASUREMENT_ITERATIONS {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+        clock.advance(POLL_INTERVAL_DETERMINISTIC);
+    }
+
+    let ping1 = sess1.network_stats(PlayerHandle::new(1))?.ping;
+    let ping2 = sess2.network_stats(PlayerHandle::new(0))?.ping;
+    Ok((ping1, ping2))
+}
+
+/// With an injected clock, the reported RTT must equal the *virtual* time
+/// between sending a quality report and processing its reply — exactly one
+/// poll interval under this schedule — not the (near-zero) wall-clock time
+/// the in-process channel actually takes.
+#[test]
+fn ping_with_injected_clock_reports_virtual_rtt() -> Result<(), FortressError> {
+    let expected = POLL_INTERVAL_DETERMINISTIC.as_millis();
+    let (ping1, ping2) = measure_ping_over_fixed_schedule()?;
+
+    assert_eq!(
+        ping1, expected,
+        "session 1 ping must reflect virtual time ({expected}ms), got {ping1}ms"
+    );
+    assert_eq!(
+        ping2, expected,
+        "session 2 ping must reflect virtual time ({expected}ms), got {ping2}ms"
+    );
+    Ok(())
+}
+
+/// The same virtual-time schedule must produce bit-identical RTT values on
+/// every run: ping measurement may not read any wall-clock source when a
+/// clock is injected.
+#[test]
+fn ping_with_injected_clock_is_identical_across_runs() -> Result<(), FortressError> {
+    let first = measure_ping_over_fixed_schedule()?;
+    let second = measure_ping_over_fixed_schedule()?;
+
+    assert_eq!(
+        first, second,
+        "identical virtual schedules must report identical ping values"
+    );
+    Ok(())
+}

--- a/tests/simulation.rs
+++ b/tests/simulation.rs
@@ -1,0 +1,29 @@
+//! Deterministic whole-mesh simulation tests (DST).
+//!
+//! FoundationDB/TigerBeetle-style simulation testing for Fortress Rollback:
+//! N real P2P sessions run in one process over a seeded, virtual-time
+//! simulated network ([`common::sim_net::SimNet`]), driven by materialized
+//! fault schedules and checked by a global invariant oracle (confirmed-prefix
+//! agreement, state agreement, in-band desync cross-check, liveness).
+//!
+//! Every failure reproduces from `(seed, SimConfig)` — see the
+//! `FORTRESS_SIM_REPRO` line printed on failure.
+
+// Allow test-specific patterns that are appropriate for test code
+#![allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::ip_constant
+)]
+
+// Shared test infrastructure
+#[path = "common/mod.rs"]
+mod common;
+
+// Simulation test modules
+mod simulation {
+    pub mod fleet;
+    pub mod harness;
+}

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1,0 +1,492 @@
+//! Simulation fleet: seeded whole-mesh runs checked by the global oracle.
+//!
+//! The PR smoke fleet runs a fixed seed set per mesh size on every PR. The
+//! meta-determinism and negative-control tests validate the harness itself:
+//! a harness whose invariants cannot fire, or whose runs are not reproducible,
+//! proves nothing.
+
+use super::harness::schedule::{
+    generate, BackgroundNoise, DropPolicy, Schedule, ScheduleEvent, SimConfig,
+    SCHEDULE_SCHEMA_VERSION,
+};
+use super::harness::{oracle::OracleFailure, run, RunOptions};
+use crate::common::sim_net::LinkPolicy;
+use std::time::Duration;
+
+/// Fixed PR-smoke seed set. Nightly fleets (later milestone) randomize seeds
+/// from the CI run id; the PR set is fixed so PR failures are reproducible
+/// verbatim from the log.
+const PR_SMOKE_SEEDS: [u64; 8] = [1, 2, 3, 5, 8, 13, 21, 34];
+
+fn run_smoke_fleet(n_players: usize) {
+    for seed in PR_SMOKE_SEEDS {
+        let schedule = generate(seed, SimConfig::smoke(n_players));
+        let report = run(&schedule, &RunOptions::default());
+        report.expect_pass(&schedule);
+    }
+}
+
+#[test]
+fn pr_smoke_two_player_mesh_holds_invariants() {
+    run_smoke_fleet(2);
+}
+
+#[test]
+fn pr_smoke_three_player_mesh_holds_invariants() {
+    run_smoke_fleet(3);
+}
+
+#[test]
+fn pr_smoke_four_player_mesh_holds_invariants() {
+    run_smoke_fleet(4);
+}
+
+/// Meta-determinism: the same schedule must produce a bit-identical trace.
+/// This guards the harness itself — any hidden wall-clock read, unseeded RNG,
+/// or iteration-order nondeterminism in session, net, or harness breaks it.
+#[test]
+fn same_schedule_produces_identical_trace() {
+    let schedule = generate(7, SimConfig::smoke(3));
+    let first = run(&schedule, &RunOptions::default());
+    let second = run(&schedule, &RunOptions::default());
+    assert_eq!(
+        first.trace_hash, second.trace_hash,
+        "same schedule must reproduce the exact trace (final_confirmed {:?} vs {:?})",
+        first.final_confirmed, second.final_confirmed
+    );
+    assert_eq!(first.final_confirmed, second.final_confirmed);
+    assert_eq!(first.net_stats, second.net_stats);
+}
+
+/// Negative control (real divergence): corrupting one peer's simulated state
+/// mid-run must trip BOTH detection layers — the oracle's recorded-state
+/// comparison and the library's in-band desync detector.
+#[test]
+fn oracle_and_inband_detector_catch_seeded_state_divergence() {
+    let schedule = generate(11, SimConfig::smoke(2));
+    let options = RunOptions {
+        corrupt_state_from: Some((1, 40)),
+        ..RunOptions::default()
+    };
+    let report = run(&schedule, &options);
+    assert!(
+        !report.verdict.passed(),
+        "a corrupted peer must fail the run"
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::StateDivergence { .. })),
+        "oracle state comparison must catch the divergence: {:?}",
+        report.verdict.failures
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::InbandDesyncDetected { .. })),
+        "the library's desync detection must also catch it: {:?}",
+        report.verdict.failures
+    );
+}
+
+/// Negative control (detector cross-check): corrupting only the *checksums*
+/// (states stay identical) must fire the in-band detector while the oracle's
+/// state comparison stays clean — the false-positive-detector direction of
+/// the cross-check.
+#[test]
+fn inband_detector_fires_on_checksum_lies_while_states_agree() {
+    let schedule = generate(13, SimConfig::smoke(2));
+    let options = RunOptions {
+        corrupt_checksum_from: Some((0, 40)),
+        ..RunOptions::default()
+    };
+    let report = run(&schedule, &options);
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::InbandDesyncDetected { .. })),
+        "checksum lies must fire the in-band detector: {:?}",
+        report.verdict.failures
+    );
+    assert!(
+        !report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::StateDivergence { .. })),
+        "states are identical — the oracle state comparison must stay clean: {:?}",
+        report.verdict.failures
+    );
+}
+
+/// Pinned regression: the cold-start gossip-mute mesh deadlock found by this
+/// fleet on its first four-player run (seed 1). Transient startup loss froze
+/// third-party connect-status caches at `Frame::NULL`; once every peer
+/// exhausted its prediction window with fully-acked send queues, no gossip
+/// carrier remained and the mesh deadlocked permanently at `confirmed == -1`
+/// on a healed network with every session `Running`. Fixed by generalizing
+/// the connect-status nudge to fire whenever the mesh-gossip fold holds
+/// confirmation below local receipts (`P2PSession::
+/// gossip_holds_confirmation_below_receipts`). Pinned separately from
+/// `PR_SMOKE_SEEDS` so seed-set evolution can never unpin it.
+#[test]
+fn regression_cold_start_gossip_stall_seed1_four_players() {
+    let schedule = generate(1, SimConfig::smoke(4));
+    let report = run(&schedule, &RunOptions::default());
+    report.expect_pass(&schedule);
+}
+
+/// Oracle-integrity negative control at N=16 (PLAN.md Part V): the Part III
+/// H-16P "green at 16" verdict is only meaningful if the oracle still has
+/// teeth at that scale — a corrupted peer in a 16-mesh must fail the run
+/// exactly as it does in the N=2 control. Guards against the oracle silently
+/// losing coverage as N grows (e.g., sampling or comparison short-circuits).
+#[test]
+#[ignore = "large-mesh oracle control; promote with the N=16 probes"]
+fn oracle_catches_seeded_divergence_in_sixteen_player_mesh() {
+    let schedule = generate(11, SimConfig::smoke(16));
+    let options = RunOptions {
+        corrupt_state_from: Some((7, 40)),
+        ..RunOptions::default()
+    };
+    let report = run(&schedule, &options);
+    assert!(
+        !report.verdict.passed(),
+        "a corrupted peer must fail an N=16 run"
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::StateDivergence { .. })),
+        "oracle state comparison must catch the divergence at N=16: {:?}",
+        report.verdict.failures
+    );
+}
+
+/// Meta-determinism at N=16: bit-identical trace reproduction must survive
+/// the largest supported mesh (guards the harness itself at scale).
+#[test]
+#[ignore = "large-mesh determinism control; promote with the N=16 probes"]
+fn same_schedule_produces_identical_trace_at_sixteen_players() {
+    let schedule = generate(7, SimConfig::smoke(16));
+    let first = run(&schedule, &RunOptions::default());
+    let second = run(&schedule, &RunOptions::default());
+    assert_eq!(
+        first.trace_hash, second.trace_hash,
+        "N=16 must reproduce bit-identically (final_confirmed {:?} vs {:?})",
+        first.final_confirmed, second.final_confirmed
+    );
+}
+
+/// Large-mesh probe fleets (N=12/16): the H-16P experiment rows. `#[ignore]`d
+/// until the fleet proves them sustainably green and CI budgets are
+/// recalibrated; run manually:
+///
+/// ```text
+/// cargo nextest run --no-capture --run-ignored ignored-only -E 'test(probe_smoke_fleet)'
+/// ```
+#[test]
+#[ignore = "large-mesh probe; promote to PR smoke after budget calibration"]
+fn probe_smoke_fleet_twelve_player_mesh_holds_invariants() {
+    run_smoke_fleet(12);
+}
+
+#[test]
+#[ignore = "large-mesh probe; promote to PR smoke after budget calibration"]
+fn probe_smoke_fleet_sixteen_player_mesh_holds_invariants() {
+    run_smoke_fleet(16);
+}
+
+/// H-TCP-lite transport-model probe (PLAN.md §13 H-TCP): a reliable,
+/// in-order, loss-free link profile (TCP / WebRTC-reliable model) with
+/// head-of-line-blocking stalls approximated by capture-and-FIFO-release
+/// holds. Zero jitter keeps `SimNet`'s per-link FIFO exact, so delivery is
+/// in-order — the TCP contract. Each 25-step hold (≈400ms virtual) models a
+/// retransmit stall far exceeding the 8-frame prediction window, so the
+/// session must stall-and-catch-up, never diverge.
+///
+/// Expected green: the protocol's correctness must not depend on loss or
+/// reordering being present. A failure here is a real transport-model bug.
+fn run_tcp_model_mesh(n: usize) {
+    let config = SimConfig {
+        n_players: n,
+        steps: 900,
+        ..SimConfig::smoke(n)
+    };
+    let fifo = LinkPolicy {
+        drop_rate: 0.0,
+        dup_rate: 0.0,
+        base_delay: Duration::from_millis(30),
+        jitter: Duration::ZERO,
+        burst_rate: 0.0,
+        burst_len: 0,
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, fifo.clone()));
+            }
+        }
+    }
+    // Three HOL stalls on distinct directed links, well before heal.
+    let hold_windows: [(usize, usize, u32); 3] = [(0, 1, 100), (1, 0, 250), (n - 1, 0, 400)];
+    let mut events = Vec::new();
+    for (from, to, start) in hold_windows {
+        events.push((
+            start,
+            ScheduleEvent::Hold {
+                from,
+                to,
+                holding: true,
+            },
+        ));
+        events.push((
+            start + 25,
+            ScheduleEvent::Hold {
+                from,
+                to,
+                holding: false,
+            },
+        ));
+    }
+    let heal_at = 650;
+    events.push((heal_at, ScheduleEvent::HealAll));
+    events.sort_by_key(|(step, _)| *step);
+    let schedule = Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        // Hand-built (not generator-derived); seeds recorded for provenance.
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    };
+    let report = run(&schedule, &RunOptions::default());
+    report.expect_pass(&schedule);
+}
+
+#[test]
+fn tcp_model_reliable_fifo_two_player_mesh_holds_invariants() {
+    run_tcp_model_mesh(2);
+}
+
+#[test]
+fn tcp_model_reliable_fifo_four_player_mesh_holds_invariants() {
+    run_tcp_model_mesh(4);
+}
+
+#[test]
+#[ignore = "large-mesh transport probe; promote after budget calibration"]
+fn tcp_model_reliable_fifo_sixteen_player_mesh_holds_invariants() {
+    run_tcp_model_mesh(16);
+}
+
+/// Builds the split-brain schedule: a clean 4-mesh symmetrically partitioned
+/// into halves {0,1} × {2,3} from step 100 until `HealAll` at step 650 —
+/// 550 steps ≈ 8.8 virtual seconds, far beyond the 2 s disconnect timeout,
+/// so both halves fully commit to dropping the other before the network
+/// heals.
+fn split_brain_schedule(policy: DropPolicy) -> Schedule {
+    let n = 4;
+    let config = SimConfig {
+        n_players: n,
+        steps: 900,
+        disconnect_behavior: policy,
+        noise: BackgroundNoise::Clean,
+        ..SimConfig::smoke(n)
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, LinkPolicy::clean()));
+            }
+        }
+    }
+    let mut events = Vec::new();
+    for &a in &[0usize, 1] {
+        for &b in &[2usize, 3] {
+            for (from, to) in [(a, b), (b, a)] {
+                events.push((
+                    100,
+                    ScheduleEvent::Block {
+                        from,
+                        to,
+                        blocked: true,
+                    },
+                ));
+            }
+        }
+    }
+    let heal_at = 650;
+    events.push((heal_at, ScheduleEvent::HealAll));
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
+/// Red-documentation test for defect D13 (PLAN.md Part IV): `Halt` is not
+/// fully fail-closed. Its rustdoc promises "no further frames advance once
+/// any peer drops", but when the disconnect lands, the dropped slots are
+/// excluded from the confirmation fold and the session confirms up to
+/// `max_prediction` further frames with **fabricated default inputs** in the
+/// dropped slots — divergently across the mesh. Observed on this schedule
+/// (partition {0,1}×{2,3} at step 100, timeout ≈ frame 95): peer 1 confirmed
+/// frames 96..=103 as `[3101, 3108, 0, 0]`… while peer 3 confirmed the same
+/// frames as `[0, 0, 3115, 3122]`…, and end-of-run confirmation is
+/// asymmetric even within a half (95 vs 103). This pins today's defective
+/// behavior; the divergence assertions flip when the M4 fix lands (the
+/// confirmed prefix must never extend past the last globally-agreed frame
+/// under `Halt`).
+#[test]
+fn partition_under_halt_confirms_fabricated_frames_divergently_d13() {
+    let schedule = split_brain_schedule(DropPolicy::Halt);
+    let report = run(&schedule, &RunOptions::default());
+    let failures = &report.verdict.failures;
+    // RED (defect D13): the confirmed prefix forks by max_prediction frames.
+    assert!(
+        failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::ConfirmedInputDivergence { .. })),
+        "expected today's defective fabricated-frame divergence: {failures:?}"
+    );
+    // Halt does end the session on every peer (that half of the contract
+    // holds): all four stall in Synchronizing and fail end-progress.
+    let stalled = failures
+        .iter()
+        .filter(|f| matches!(f, OracleFailure::EndProgress { .. }))
+        .count();
+    assert_eq!(
+        stalled, 4,
+        "all four peers must halt (EndProgress in Synchronizing): {failures:?}"
+    );
+    // The fabricated tail is bounded by the prediction window: no peer's
+    // confirmation may exceed another's by more than max_prediction.
+    let min = report.final_confirmed.iter().copied().min().unwrap_or(-1);
+    let max = report.final_confirmed.iter().copied().max().unwrap_or(-1);
+    assert!(
+        (max - min) as usize <= schedule.config.max_prediction,
+        "fabricated tail must be bounded by max_prediction ({} vs {}): {:?}",
+        max - min,
+        schedule.config.max_prediction,
+        report.final_confirmed
+    );
+}
+
+/// CAP documentation test, `ContinueWithout` side: the same partition FORKS
+/// the session — each half drops the other, freezes their slots, and keeps
+/// confirming on its own divergent timeline. Availability is chosen over
+/// consistency, permanently: dropped endpoints are terminal, so healing the
+/// network can never re-merge the halves. This pins the fork as documented,
+/// deliberate behavior (and records whether the library's own in-band desync
+/// detection can see across it).
+#[test]
+fn partition_under_continue_without_forks_into_divergent_halves() {
+    let schedule = split_brain_schedule(DropPolicy::ContinueWithout);
+    let report = run(&schedule, &RunOptions::default());
+    let failures = &report.verdict.failures;
+    assert!(
+        failures
+            .iter()
+            .any(|f| matches!(
+                f,
+                OracleFailure::ConfirmedInputDivergence { .. }
+                    | OracleFailure::StateDivergence { .. }
+            )),
+        "ContinueWithout must fork the mesh (divergence expected): {failures:?}\nfinal_confirmed={:?}",
+        report.final_confirmed
+    );
+    for (peer, confirmed) in report.final_confirmed.iter().enumerate() {
+        assert!(
+            *confirmed > 200,
+            "peer {peer} must keep confirming on its half of the fork \
+             (availability): final_confirmed={:?}\nfailures={failures:?}",
+            report.final_confirmed
+        );
+    }
+    let inband = failures
+        .iter()
+        .filter(|f| matches!(f, OracleFailure::InbandDesyncDetected { .. }))
+        .count();
+    assert_eq!(
+        inband, 0,
+        "documenting: the fork is invisible to in-band desync detection \
+         (ghost traffic from dropped endpoints is discarded): {failures:?}"
+    );
+}
+
+/// Diagnostic probe for a failing schedule: prints per-peer progress every 50
+/// steps. `#[ignore]`d — run manually while investigating a repro.
+#[test]
+#[ignore = "diagnostic probe; run manually against a repro seed"]
+fn diagnose_repro() {
+    use super::harness::diagnose;
+    let schedule = generate(1, SimConfig::smoke(4));
+    diagnose(&schedule);
+}
+
+/// Budget probe: measures the wall-clock cost of the largest supported mesh
+/// over a long schedule. `#[ignore]`d — run manually to (re)calibrate fleet
+/// sizes and CI budgets:
+///
+/// ```text
+/// cargo nextest run --no-capture --run-ignored ignored-only -E 'test(budget_probe)'
+/// ```
+#[test]
+#[ignore = "budget calibration probe; run manually"]
+// Deliberate diagnostic stdout: the measured wall time IS the deliverable.
+#[allow(clippy::print_stdout, clippy::disallowed_macros)]
+fn budget_probe_sixteen_player_long_schedule() {
+    let config = SimConfig {
+        n_players: 16,
+        steps: 5_000,
+        ..SimConfig::smoke(16)
+    };
+    let schedule = generate(99, config);
+    let started = std::time::Instant::now();
+    let report = run(&schedule, &RunOptions::default());
+    let elapsed = started.elapsed();
+    println!(
+        "budget probe: n=16 steps=5000 wall={elapsed:?} final_confirmed={:?} net={:?}",
+        report.final_confirmed, report.net_stats
+    );
+    report.expect_pass(&schedule);
+}
+
+#[test]
+#[ignore = "budget calibration probe; run manually"]
+// Deliberate diagnostic stdout: the measured wall time IS the deliverable.
+#[allow(clippy::print_stdout, clippy::disallowed_macros)]
+fn budget_probe_eight_player_long_schedule() {
+    let config = SimConfig {
+        n_players: 8,
+        steps: 5_000,
+        ..SimConfig::smoke(8)
+    };
+    let schedule = generate(99, config);
+    let started = std::time::Instant::now();
+    let report = run(&schedule, &RunOptions::default());
+    let elapsed = started.elapsed();
+    println!(
+        "budget probe: n=8 steps=5000 wall={elapsed:?} final_confirmed={:?} net={:?}",
+        report.final_confirmed, report.net_stats
+    );
+    report.expect_pass(&schedule);
+}

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -1,0 +1,395 @@
+//! Deterministic whole-mesh simulation harness.
+//!
+//! Runs N real [`P2PSession`]s in one process over a [`SimNet`] fabric under
+//! a single virtual clock, drives them with a materialized [`Schedule`], and
+//! checks global invariants with the [`Oracle`]. Everything reproduces from
+//! `(seed, SimConfig)`: sessions get seeded protocol RNGs, the network gets a
+//! seeded fault stream, inputs are a pure function of `(step, peer)`, and the
+//! step loop iterates peers in a fixed order.
+//!
+//! A run's [`RunReport::trace_hash`] folds every observable step artifact;
+//! two runs of the same schedule must produce identical hashes (checked by
+//! the meta-determinism test in the fleet).
+
+// Test infrastructure: not every test binary uses every helper.
+#![allow(dead_code)]
+
+pub mod oracle;
+pub mod schedule;
+
+use crate::common::sim_net::{SimNet, SimSocket};
+use crate::common::stubs::{StateStub, StubConfig, StubInput};
+use crate::common::test_clock::TestClock;
+use fortress_rollback::hash::fnv1a_hash;
+use fortress_rollback::telemetry::{CollectingObserver, ViolationSeverity};
+use fortress_rollback::{
+    DesyncDetection, FortressEvent, FortressRequest, Frame, GameStateCell, InputVec, Message,
+    P2PSession, PlayerHandle, PlayerType, ProtocolConfig, RequestVec, SessionBuilder, SessionState,
+};
+use oracle::{Oracle, Verdict};
+use schedule::{Schedule, ScheduleEvent};
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+/// Options for fault-injection *inside the harness itself* — used by the
+/// oracle's negative controls to prove the invariants actually fire.
+#[derive(Clone, Debug, Default)]
+pub struct RunOptions {
+    /// Corrupt `(peer, from_frame)`'s simulated **state** from that frame on
+    /// (a real divergence: state, checksums, and downstream frames all split).
+    pub corrupt_state_from: Option<(usize, i32)>,
+    /// Corrupt `(peer, from_frame)`'s saved **checksums only** (states stay
+    /// identical): exercises the in-band detector cross-check path.
+    pub corrupt_checksum_from: Option<(usize, i32)>,
+}
+
+/// Outcome of one simulation run.
+#[derive(Clone, Debug)]
+pub struct RunReport {
+    pub verdict: Verdict,
+    /// Deterministic digest of the run's observable trace.
+    pub trace_hash: u64,
+    /// Each peer's final confirmed frame.
+    pub final_confirmed: Vec<i32>,
+    /// Network delivery/drop counters.
+    pub net_stats: crate::common::sim_net::SimNetStats,
+}
+
+impl RunReport {
+    /// Panics with a reproducible failure report if the run failed.
+    #[track_caller]
+    pub fn expect_pass(&self, schedule: &Schedule) {
+        assert!(
+            self.verdict.passed(),
+            "simulation failed — reproduce with:\n  FORTRESS_SIM_REPRO seed={} n_players={} steps={} noise={:?}\nfinal_confirmed={:?}\nnet={:?}\nfailures ({}):\n{}",
+            schedule.seed,
+            schedule.config.n_players,
+            schedule.config.steps,
+            schedule.config.noise,
+            self.final_confirmed,
+            self.net_stats,
+            self.verdict.failures.len(),
+            self.verdict
+                .failures
+                .iter()
+                .map(|f| format!("  - {f:?}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+}
+
+/// The harness's game stub: `GameStub` semantics (shared `StateStub`
+/// transition) plus recording and the negative-control corruption hooks.
+struct SimGameStub {
+    gs: StateStub,
+    /// Post-advance state per frame; last write wins (rollback re-simulation
+    /// overwrites), so confirmed frames hold their final state.
+    recorded: BTreeMap<i32, StateStub>,
+    corrupt_state_from: Option<i32>,
+    corrupt_checksum_from: Option<i32>,
+}
+
+impl SimGameStub {
+    fn new() -> Self {
+        Self {
+            gs: StateStub { frame: 0, state: 0 },
+            recorded: BTreeMap::new(),
+            corrupt_state_from: None,
+            corrupt_checksum_from: None,
+        }
+    }
+
+    fn handle_requests(&mut self, requests: RequestVec<StubConfig>) {
+        for request in requests {
+            match request {
+                FortressRequest::LoadGameState { cell, .. } => self.load(&cell),
+                FortressRequest::SaveGameState { cell, frame } => self.save(&cell, frame),
+                FortressRequest::AdvanceFrame { inputs } => self.advance(&inputs),
+            }
+        }
+    }
+
+    fn save(&self, cell: &GameStateCell<StateStub>, frame: Frame) {
+        assert_eq!(self.gs.frame, frame.as_i32(), "save/state frame mismatch");
+        let real_checksum = u128::from(fnv1a_hash(&self.gs));
+        let checksum = match self.corrupt_checksum_from {
+            Some(from) if frame.as_i32() >= from => real_checksum ^ 0xDEAD_BEEF_CAFE_BABE_u128,
+            _ => real_checksum,
+        };
+        cell.save(frame, Some(self.gs), Some(checksum));
+    }
+
+    fn load(&mut self, cell: &GameStateCell<StateStub>) {
+        self.gs = cell.load().expect("harness stub: missing saved state");
+    }
+
+    fn advance(&mut self, inputs: &InputVec<StubInput>) {
+        // Same transition as GameStub/StateStub::advance_frame.
+        let total: u32 = inputs.iter().map(|(input, _)| input.inp).sum();
+        if total % 2 == 0 {
+            self.gs.state += 2;
+        } else {
+            self.gs.state -= 1;
+        }
+        self.gs.frame += 1;
+
+        if let Some(from) = self.corrupt_state_from {
+            if self.gs.frame >= from {
+                // A deterministic wrong turn: diverges the state transition
+                // from this frame onward, exactly like a real determinism bug.
+                self.gs.state ^= 1;
+            }
+        }
+        self.recorded.insert(self.gs.frame, self.gs);
+    }
+}
+
+struct PeerSlot {
+    session: P2PSession<StubConfig>,
+    game: SimGameStub,
+    observer: Arc<CollectingObserver>,
+    /// Highest frame whose confirmed inputs were sampled into the oracle.
+    sampled_confirmed: i32,
+}
+
+/// Pure per-peer input function: any deterministic mapping works; this one
+/// varies across both axes so prediction is frequently wrong (exercising
+/// rollback) and per-peer streams never collide.
+fn input_for(step: u32, peer: usize) -> StubInput {
+    let p = u32::try_from(peer).unwrap_or(0);
+    StubInput {
+        inp: step
+            .wrapping_mul(31)
+            .wrapping_add(p.wrapping_mul(7))
+            .wrapping_add(1),
+    }
+}
+
+/// Synthetic mesh addresses (never bound): `127.0.0.1:(20001 + i)`.
+fn peer_addr(i: usize) -> SocketAddr {
+    let port = 20001 + u16::try_from(i).expect("peer index fits in u16");
+    ([127, 0, 0, 1], port).into()
+}
+
+/// Folds one hashable item into the running trace digest.
+fn fold_trace<T: std::hash::Hash>(hash: &mut u64, item: &T) {
+    *hash = fnv1a_hash(&(*hash, fnv1a_hash(item)));
+}
+
+/// Per-step progress dump for the diagnostic path.
+// Deliberate diagnostic stdout: this path only runs under `--run-ignored`
+// manual investigation, where print output IS the deliverable.
+#[allow(clippy::print_stdout, clippy::disallowed_macros)]
+fn print_step_summary(step: u32, peers: &[PeerSlot], net: &SimNet<Message>) {
+    let summary: Vec<String> = peers
+        .iter()
+        .map(|slot| {
+            format!(
+                "{:?} game_frame={} confirmed={}",
+                slot.session.current_state(),
+                slot.game.gs.frame,
+                slot.session.confirmed_frame().as_i32()
+            )
+        })
+        .collect();
+    println!("step {step}: {summary:?}\n  net={:?}", net.stats());
+    for (i, slot) in peers.iter().enumerate() {
+        println!("  peer{i}: {}", slot.session.diagnostic_connect_status());
+    }
+}
+
+/// Diagnostic variant of [`run`]: prints per-peer progress every 50 steps.
+/// For manual investigation of a repro seed (see `fleet::diagnose_repro`).
+// Deliberate diagnostic stdout: this path only runs under `--run-ignored`
+// manual investigation, where print output IS the deliverable.
+#[allow(clippy::print_stdout, clippy::disallowed_macros)]
+pub fn diagnose(schedule: &Schedule) {
+    let report = run_inner(schedule, &RunOptions::default(), true);
+    println!(
+        "final: confirmed={:?} net={:?} failures={:#?}",
+        report.final_confirmed, report.net_stats, report.verdict.failures
+    );
+}
+
+/// Runs one schedule to completion and reports.
+#[must_use]
+pub fn run(schedule: &Schedule, options: &RunOptions) -> RunReport {
+    run_inner(schedule, options, false)
+}
+
+fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunReport {
+    let n = schedule.config.n_players;
+    let clock = TestClock::new();
+    let net: SimNet<Message> = SimNet::new(schedule.link_seed, clock.as_protocol_clock());
+
+    let addrs: Vec<SocketAddr> = (0..n).map(peer_addr).collect();
+    for (from, to, policy) in &schedule.initial_links {
+        net.set_link(addrs[*from], addrs[*to], policy.clone());
+    }
+
+    // Build one session per peer. Handles: peer i is Local handle i, Remote
+    // handle j at addrs[j] for j != i. Protocol RNG seeded per peer so magic
+    // numbers/sync tokens are reproducible.
+    let mut peers: Vec<PeerSlot> = (0..n)
+        .map(|i| {
+            let socket: SimSocket<Message> = net.attach(addrs[i]);
+            let observer = Arc::new(CollectingObserver::new());
+            let protocol_config = ProtocolConfig {
+                clock: Some(clock.as_protocol_clock()),
+                protocol_rng_seed: Some(fnv1a_hash(&(schedule.seed, i))),
+                ..ProtocolConfig::default()
+            };
+            let mut builder = SessionBuilder::<StubConfig>::new()
+                .with_num_players(n)
+                .expect("valid player count")
+                .with_max_prediction_window(schedule.config.max_prediction)
+                .with_input_delay(schedule.config.input_delay)
+                .expect("valid input delay")
+                .with_desync_detection_mode(DesyncDetection::On {
+                    interval: schedule.config.desync_interval,
+                })
+                .with_disconnect_behavior(schedule.config.disconnect_behavior.into())
+                .with_protocol_config(protocol_config)
+                .with_violation_observer(Arc::clone(&observer) as Arc<_>);
+            for (j, addr) in addrs.iter().enumerate() {
+                let player_type = if j == i {
+                    PlayerType::Local
+                } else {
+                    PlayerType::Remote(*addr)
+                };
+                builder = builder
+                    .add_player(player_type, PlayerHandle::new(j))
+                    .expect("valid player registration");
+            }
+            let session = builder.start_p2p_session(socket).expect("session starts");
+
+            let mut game = SimGameStub::new();
+            if let Some((peer, from)) = options.corrupt_state_from {
+                if peer == i {
+                    game.corrupt_state_from = Some(from);
+                }
+            }
+            if let Some((peer, from)) = options.corrupt_checksum_from {
+                if peer == i {
+                    game.corrupt_checksum_from = Some(from);
+                }
+            }
+            PeerSlot {
+                session,
+                game,
+                observer,
+                sampled_confirmed: -1,
+            }
+        })
+        .collect();
+
+    let mut oracle = Oracle::new(n);
+    let mut trace_hash: u64 = 0xcbf2_9ce4_8422_2325; // FNV offset basis
+    let mut next_event = 0usize;
+
+    for step in 0..schedule.config.steps {
+        // Apply control-plane events due at this step.
+        while let Some((event_step, event)) = schedule.events.get(next_event) {
+            if *event_step > step {
+                break;
+            }
+            match event {
+                ScheduleEvent::SetLink { from, to, policy } => {
+                    net.set_link(addrs[*from], addrs[*to], policy.clone());
+                },
+                ScheduleEvent::Block { from, to, blocked } => {
+                    net.set_blocked(addrs[*from], addrs[*to], *blocked);
+                },
+                ScheduleEvent::Hold { from, to, holding } => {
+                    net.set_holding(addrs[*from], addrs[*to], *holding);
+                },
+                ScheduleEvent::HealAll => net.heal_all(),
+            }
+            next_event += 1;
+        }
+
+        // Drive every peer in fixed order.
+        for (i, slot) in peers.iter_mut().enumerate() {
+            slot.session.poll_remote_clients();
+
+            let events: Vec<FortressEvent<StubConfig>> = slot.session.events().collect();
+            for event in &events {
+                if let FortressEvent::DesyncDetected { frame, .. } = event {
+                    oracle.observe_desync_event(i, *frame);
+                }
+                fold_trace(&mut trace_hash, &format!("{event:?}"));
+            }
+
+            if slot.session.current_state() == SessionState::Running {
+                for handle in slot.session.local_player_handles() {
+                    if let Err(error) = slot.session.add_local_input(handle, input_for(step, i)) {
+                        oracle.observe_advance_error(i, step, &error);
+                    }
+                }
+                match slot.session.advance_frame() {
+                    Ok(requests) => slot.game.handle_requests(requests),
+                    Err(error) => oracle.observe_advance_error(i, step, &error),
+                }
+            }
+
+            // Incrementally sample newly confirmed inputs (they evict).
+            let confirmed = slot.session.confirmed_frame();
+            if confirmed.is_valid() {
+                for frame in (slot.sampled_confirmed + 1)..=confirmed.as_i32() {
+                    match slot.session.confirmed_inputs_for_frame(Frame::new(frame)) {
+                        Ok(inputs) => oracle.observe_confirmed_inputs(i, frame, &inputs),
+                        Err(error) => {
+                            oracle.observe_confirmed_unavailable(i, frame, &format!("{error:?}"));
+                        },
+                    }
+                    slot.sampled_confirmed = frame;
+                }
+            }
+
+            fold_trace(
+                &mut trace_hash,
+                &(step, i, slot.game.gs, confirmed.as_i32()),
+            );
+        }
+
+        if diagnose && step % 50 == 0 {
+            print_step_summary(step, &peers, &net);
+        }
+
+        clock.advance(schedule.config.step_dt());
+    }
+
+    // Final observations.
+    for (i, slot) in peers.iter().enumerate() {
+        let severe = slot
+            .observer
+            .violations_at_severity(ViolationSeverity::Error);
+        oracle.observe_violations(i, &severe);
+    }
+    let recorded: Vec<BTreeMap<i32, StateStub>> = peers
+        .iter()
+        .map(|slot| slot.game.recorded.clone())
+        .collect();
+    let end_confirmed: Vec<Frame> = peers
+        .iter()
+        .map(|slot| slot.session.confirmed_frame())
+        .collect();
+    let end_state: Vec<SessionState> = peers
+        .iter()
+        .map(|slot| slot.session.current_state())
+        .collect();
+    let final_confirmed: Vec<i32> = end_confirmed.iter().map(|frame| frame.as_i32()).collect();
+    for confirmed in &final_confirmed {
+        fold_trace(&mut trace_hash, confirmed);
+    }
+
+    let verdict = oracle.finalize(&recorded, &end_confirmed, &end_state);
+    RunReport {
+        verdict,
+        trace_hash,
+        final_confirmed,
+        net_stats: net.stats(),
+    }
+}

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -419,12 +419,32 @@ mod tests {
         )));
     }
 
-    /// Negative control: a desync event and an Error-severity violation each
-    /// fail the run.
+    /// Negative control: a desync event and an `Error`-severity violation each
+    /// fail the run, while a sub-`Error` (`Warning`) violation does not.
     #[test]
     fn oracle_records_desync_events_and_violations() {
+        use fortress_rollback::telemetry::ViolationKind;
+
         let mut oracle = Oracle::new(2);
         oracle.observe_desync_event(0, Frame::new(42));
+        oracle.observe_violations(
+            1,
+            &[
+                SpecViolation::new(
+                    ViolationSeverity::Error,
+                    ViolationKind::ChecksumMismatch,
+                    "seeded error violation",
+                    "oracle.rs",
+                ),
+                // A sub-`Error` violation must be ignored by the severity gate.
+                SpecViolation::new(
+                    ViolationSeverity::Warning,
+                    ViolationKind::NetworkProtocol,
+                    "seeded warning violation",
+                    "oracle.rs",
+                ),
+            ],
+        );
         let verdict = oracle.finalize(
             &[BTreeMap::new(), BTreeMap::new()],
             &[Frame::new(500), Frame::new(500)],
@@ -434,6 +454,20 @@ mod tests {
             f,
             OracleFailure::InbandDesyncDetected { peer: 0, frame: 42 }
         )));
+        assert!(verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::Violation { peer: 1, .. })));
+        // Exactly one violation failure: the `Warning` must not have counted.
+        assert_eq!(
+            verdict
+                .failures
+                .iter()
+                .filter(|f| matches!(f, OracleFailure::Violation { .. }))
+                .count(),
+            1,
+            "only the Error-severity violation should fail the run"
+        );
     }
 
     /// The failure cap keeps a systemically broken run readable.

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -486,4 +486,37 @@ mod tests {
         );
         assert!(verdict.failures.len() <= 64);
     }
+
+    /// The per-class cap must isolate failure *variants*: a flood of one variant
+    /// cannot evict a lone failure of another (the HD-1 "silent cap inside the
+    /// instrument" regression). This also pins that `push_failure` discriminates
+    /// by the failure's own `mem::discriminant`, not the always-equal
+    /// discriminant of a reference — one noisy variant filling the cap would
+    /// otherwise starve the rest.
+    #[test]
+    fn oracle_per_class_cap_preserves_rare_variants() {
+        let mut oracle = Oracle::new(2);
+        // Flood one variant far past the per-class cap (8).
+        for frame in 0..100 {
+            oracle.observe_desync_event(0, Frame::new(frame));
+        }
+        // A single failure of a different variant, pushed after the flood.
+        oracle.observe_confirmed_unavailable(1, 5, "must survive the flood");
+
+        let desyncs = oracle
+            .failures
+            .iter()
+            .filter(|f| matches!(f, OracleFailure::InbandDesyncDetected { .. }))
+            .count();
+        let unavailable = oracle
+            .failures
+            .iter()
+            .filter(|f| matches!(f, OracleFailure::ConfirmedInputUnavailable { .. }))
+            .count();
+        assert_eq!(desyncs, 8, "noisy variant is capped at per_class_cap");
+        assert_eq!(
+            unavailable, 1,
+            "the rare variant is not evicted by the flood"
+        );
+    }
 }

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -1,0 +1,455 @@
+//! Global invariant oracle for the whole-mesh simulation.
+//!
+//! The oracle observes every peer continuously during a run and issues a
+//! final verdict. Its invariants are *global* — properties of the whole mesh
+//! that no per-session assertion can express:
+//!
+//! - **(a) Confirmed-prefix agreement**: every peer's confirmed input stream
+//!   is byte-identical to the first-observed (canonical) stream, frame by
+//!   frame. Sampled incrementally because confirmed inputs evict from the
+//!   session's history window.
+//! - **(b) State agreement**: after the run, every peer's recorded
+//!   post-advance state for each *globally confirmed* frame is identical.
+//!   Speculative (not-yet-confirmed) frames legitimately differ mid-run and
+//!   are never compared.
+//! - **(b-cross) In-band cross-check**: `DesyncDetected` events must be
+//!   consistent with (b): an event while recorded states agree exposes a
+//!   false-positive detector; states diverging without an event exposes a
+//!   silent desync. Either way the run fails with the full picture recorded.
+//! - **(g) Session-error allowlist**: `advance_frame` while `Running` must
+//!   not error (the prediction throttle is `Ok` with no requests, not an
+//!   error). Any error fails the run with the step and peer recorded.
+//! - **Violations**: telemetry violations at `Error`+ severity fail the run
+//!   (Critical is never acceptable; the Error allowlist arrives with the
+//!   lifecycle vocabulary in a later milestone, seeded by a fleet census).
+//! - **(c-lite) End progress**: after heal + drain, every peer must be
+//!   `Running` and have confirmed at least [`MIN_END_CONFIRMED`] frames — a
+//!   coarse whole-mesh liveness check (the full bounded-liveness invariant
+//!   arrives with the lifecycle vocabulary).
+
+// Test infrastructure: not every test binary uses every helper.
+#![allow(dead_code)]
+
+use crate::common::stubs::{StateStub, StubInput};
+use fortress_rollback::telemetry::{SpecViolation, ViolationSeverity};
+use fortress_rollback::{Frame, SessionState};
+use std::collections::BTreeMap;
+
+/// Minimum confirmed frames every peer must reach by end of run (c-lite).
+///
+/// Deliberately conservative: the drain window alone is ≈250 steps of clean
+/// network; a healthy mesh confirms hundreds of frames there.
+pub const MIN_END_CONFIRMED: i32 = 30;
+
+/// One concrete invariant violation, with enough context to debug.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum OracleFailure {
+    /// (a): a peer's confirmed inputs for `frame` differ from the canonical
+    /// stream first observed from `first_author`.
+    ConfirmedInputDivergence {
+        frame: i32,
+        peer: usize,
+        first_author: usize,
+        expected: Vec<u32>,
+        actual: Vec<u32>,
+    },
+    /// (b): a peer's recorded post-advance state for a globally confirmed
+    /// frame differs from the canonical state.
+    StateDivergence {
+        frame: i32,
+        peer: usize,
+        first_author: usize,
+        expected: StateStub,
+        actual: StateStub,
+    },
+    /// (b-cross): the in-band desync detector fired.
+    InbandDesyncDetected { peer: usize, frame: i32 },
+    /// (a)-sampling: confirmed inputs for a frame the session reported as
+    /// confirmed could not be fetched (eviction outran sampling, or a bug).
+    ConfirmedInputUnavailable {
+        peer: usize,
+        frame: i32,
+        error: String,
+    },
+    /// (g): `advance_frame` returned an error while `Running`.
+    SessionError {
+        peer: usize,
+        step: u32,
+        error: String,
+    },
+    /// A telemetry violation at `Error`+ severity was reported.
+    Violation { peer: usize, violation: String },
+    /// (c-lite): a peer failed the end-of-run progress bar.
+    EndProgress {
+        peer: usize,
+        state: SessionState,
+        confirmed: i32,
+        required: i32,
+    },
+}
+
+/// Final verdict of a run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Verdict {
+    pub failures: Vec<OracleFailure>,
+}
+
+impl Verdict {
+    #[must_use]
+    pub fn passed(&self) -> bool {
+        self.failures.is_empty()
+    }
+}
+
+/// The oracle instance for one run.
+pub struct Oracle {
+    n_players: usize,
+    /// frame → (first author, canonical per-slot inputs).
+    canonical_inputs: BTreeMap<i32, (usize, Vec<u32>)>,
+    failures: Vec<OracleFailure>,
+    /// Cap so a systemically broken run reports a readable prefix instead of
+    /// millions of identical failures.
+    failure_cap: usize,
+    /// Per-variant cap. Without it, a flood of one failure class evicts
+    /// rarer classes entirely: the N=16 oracle-integrity control found the
+    /// per-peer `InbandDesyncDetected` stream filling all 64 global slots
+    /// before the end-of-run state comparison ran, so `StateDivergence`
+    /// vanished from the report (PLAN.md Part V — the "silent cap"
+    /// anti-pattern inside the oracle itself). Every class is now
+    /// guaranteed representation.
+    per_class_cap: usize,
+}
+
+impl Oracle {
+    #[must_use]
+    pub fn new(n_players: usize) -> Self {
+        Self {
+            n_players,
+            canonical_inputs: BTreeMap::new(),
+            failures: Vec::new(),
+            failure_cap: 64,
+            per_class_cap: 8,
+        }
+    }
+
+    fn push_failure(&mut self, failure: OracleFailure) {
+        let same_class = self
+            .failures
+            .iter()
+            .filter(|f| std::mem::discriminant(*f) == std::mem::discriminant(&failure))
+            .count();
+        if same_class >= self.per_class_cap {
+            return;
+        }
+        if self.failures.len() < self.failure_cap {
+            self.failures.push(failure);
+        }
+    }
+
+    /// (a): feed one peer's confirmed inputs for one frame, in ascending
+    /// frame order per peer.
+    pub fn observe_confirmed_inputs(&mut self, peer: usize, frame: i32, inputs: &[StubInput]) {
+        let values: Vec<u32> = inputs.iter().map(|i| i.inp).collect();
+        match self.canonical_inputs.get(&frame) {
+            None => {
+                self.canonical_inputs.insert(frame, (peer, values));
+            },
+            Some((first_author, canonical)) => {
+                if *canonical != values {
+                    let failure = OracleFailure::ConfirmedInputDivergence {
+                        frame,
+                        peer,
+                        first_author: *first_author,
+                        expected: canonical.clone(),
+                        actual: values,
+                    };
+                    self.push_failure(failure);
+                }
+            },
+        }
+    }
+
+    /// (a)-sampling: the session claimed `frame` confirmed but the inputs
+    /// could not be fetched.
+    pub fn observe_confirmed_unavailable(&mut self, peer: usize, frame: i32, error: &str) {
+        self.push_failure(OracleFailure::ConfirmedInputUnavailable {
+            peer,
+            frame,
+            error: error.to_owned(),
+        });
+    }
+
+    /// (b-cross): a `DesyncDetected` event surfaced on `peer`.
+    pub fn observe_desync_event(&mut self, peer: usize, frame: Frame) {
+        self.push_failure(OracleFailure::InbandDesyncDetected {
+            peer,
+            frame: frame.as_i32(),
+        });
+    }
+
+    /// (g): `advance_frame` errored while `Running`.
+    pub fn observe_advance_error(
+        &mut self,
+        peer: usize,
+        step: u32,
+        error: &fortress_rollback::FortressError,
+    ) {
+        self.push_failure(OracleFailure::SessionError {
+            peer,
+            step,
+            error: format!("{error:?}"),
+        });
+    }
+
+    /// Telemetry violations collected for one peer over the whole run.
+    pub fn observe_violations(&mut self, peer: usize, violations: &[SpecViolation]) {
+        for violation in violations {
+            if violation.severity >= ViolationSeverity::Error {
+                self.push_failure(OracleFailure::Violation {
+                    peer,
+                    violation: format!(
+                        "[{:?}/{:?}] {}",
+                        violation.severity, violation.kind, violation.message
+                    ),
+                });
+            }
+        }
+    }
+
+    /// (b) + (c-lite): end-of-run checks. `recorded[i]` is peer `i`'s
+    /// post-advance state map; `end_confirmed[i]` its final confirmed frame;
+    /// `end_state[i]` its final session state.
+    pub fn finalize(
+        mut self,
+        recorded: &[BTreeMap<i32, StateStub>],
+        end_confirmed: &[Frame],
+        end_state: &[SessionState],
+    ) -> Verdict {
+        assert_eq!(recorded.len(), self.n_players);
+        assert_eq!(end_confirmed.len(), self.n_players);
+        assert_eq!(end_state.len(), self.n_players);
+
+        // (c-lite) end progress per peer.
+        for peer in 0..self.n_players {
+            let confirmed = end_confirmed
+                .get(peer)
+                .copied()
+                .unwrap_or(Frame::NULL)
+                .as_i32();
+            let state = end_state
+                .get(peer)
+                .copied()
+                .unwrap_or(SessionState::Synchronizing);
+            if state != SessionState::Running || confirmed < MIN_END_CONFIRMED {
+                self.push_failure(OracleFailure::EndProgress {
+                    peer,
+                    state,
+                    confirmed,
+                    required: MIN_END_CONFIRMED,
+                });
+            }
+        }
+
+        // (b) state agreement over the globally confirmed prefix.
+        let global_confirmed = end_confirmed
+            .iter()
+            .map(|frame| frame.as_i32())
+            .min()
+            .unwrap_or(-1);
+        // Recorded states are keyed by post-advance frame (frame N+1 holds
+        // the result of simulating frame N with confirmed inputs ≤ N), so a
+        // frame's state is final once the *previous* frame is confirmed;
+        // comparing up to `global_confirmed` stays strictly inside the final
+        // region.
+        let mut canonical_states: BTreeMap<i32, (usize, StateStub)> = BTreeMap::new();
+        for (peer, states) in recorded.iter().enumerate() {
+            for (&frame, &state) in states.range(..=global_confirmed) {
+                match canonical_states.get(&frame) {
+                    None => {
+                        canonical_states.insert(frame, (peer, state));
+                    },
+                    Some(&(first_author, canonical)) => {
+                        if canonical != state {
+                            self.push_failure(OracleFailure::StateDivergence {
+                                frame,
+                                peer,
+                                first_author,
+                                expected: canonical,
+                                actual: state,
+                            });
+                        }
+                    },
+                }
+            }
+        }
+
+        Verdict {
+            failures: self.failures,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn inputs(values: &[u32]) -> Vec<StubInput> {
+        values.iter().map(|&inp| StubInput { inp }).collect()
+    }
+
+    /// Negative control: the input-divergence invariant must fire on a
+    /// seeded divergence and stay silent on agreement.
+    #[test]
+    fn oracle_detects_confirmed_input_divergence() {
+        let mut oracle = Oracle::new(2);
+        oracle.observe_confirmed_inputs(0, 5, &inputs(&[1, 2]));
+        oracle.observe_confirmed_inputs(1, 5, &inputs(&[1, 2]));
+        oracle.observe_confirmed_inputs(0, 6, &inputs(&[3, 4]));
+        oracle.observe_confirmed_inputs(1, 6, &inputs(&[3, 9]));
+
+        let verdict = oracle.finalize(
+            &[BTreeMap::new(), BTreeMap::new()],
+            &[Frame::new(60), Frame::new(60)],
+            &[SessionState::Running, SessionState::Running],
+        );
+        assert!(!verdict.passed());
+        assert!(verdict.failures.iter().any(|f| matches!(
+            f,
+            OracleFailure::ConfirmedInputDivergence {
+                frame: 6,
+                peer: 1,
+                ..
+            }
+        )));
+        assert!(
+            !verdict
+                .failures
+                .iter()
+                .any(|f| matches!(f, OracleFailure::ConfirmedInputDivergence { frame: 5, .. })),
+            "agreeing frames must not fail"
+        );
+    }
+
+    /// Negative control: the state-agreement invariant must fire on a seeded
+    /// divergence within the confirmed prefix, and ignore speculative frames.
+    #[test]
+    fn oracle_detects_state_divergence_only_in_confirmed_prefix() {
+        let oracle = Oracle::new(2);
+        let mut a = BTreeMap::new();
+        let mut b = BTreeMap::new();
+        // Agreement at frame 10, divergence at 11 (inside confirmed prefix),
+        // divergence at 50 (speculative — must be ignored).
+        a.insert(
+            10,
+            StateStub {
+                frame: 10,
+                state: 4,
+            },
+        );
+        b.insert(
+            10,
+            StateStub {
+                frame: 10,
+                state: 4,
+            },
+        );
+        a.insert(
+            11,
+            StateStub {
+                frame: 11,
+                state: 6,
+            },
+        );
+        b.insert(
+            11,
+            StateStub {
+                frame: 11,
+                state: 5,
+            },
+        );
+        a.insert(
+            50,
+            StateStub {
+                frame: 50,
+                state: 1,
+            },
+        );
+        b.insert(
+            50,
+            StateStub {
+                frame: 50,
+                state: 2,
+            },
+        );
+
+        let verdict = oracle.finalize(
+            &[a, b],
+            &[Frame::new(20), Frame::new(30)],
+            &[SessionState::Running, SessionState::Running],
+        );
+        let state_failures: Vec<_> = verdict
+            .failures
+            .iter()
+            .filter(|f| matches!(f, OracleFailure::StateDivergence { .. }))
+            .collect();
+        assert_eq!(state_failures.len(), 1, "exactly the frame-11 divergence");
+        assert!(matches!(
+            state_failures[0],
+            OracleFailure::StateDivergence { frame: 11, .. }
+        ));
+    }
+
+    /// Negative control: end-progress fires for a stuck peer.
+    #[test]
+    fn oracle_detects_end_stall() {
+        let oracle = Oracle::new(2);
+        let verdict = oracle.finalize(
+            &[BTreeMap::new(), BTreeMap::new()],
+            &[Frame::new(500), Frame::new(3)],
+            &[SessionState::Running, SessionState::Running],
+        );
+        assert!(verdict.failures.iter().any(|f| matches!(
+            f,
+            OracleFailure::EndProgress {
+                peer: 1,
+                confirmed: 3,
+                ..
+            }
+        )));
+    }
+
+    /// Negative control: a desync event and an Error-severity violation each
+    /// fail the run.
+    #[test]
+    fn oracle_records_desync_events_and_violations() {
+        let mut oracle = Oracle::new(2);
+        oracle.observe_desync_event(0, Frame::new(42));
+        let verdict = oracle.finalize(
+            &[BTreeMap::new(), BTreeMap::new()],
+            &[Frame::new(500), Frame::new(500)],
+            &[SessionState::Running, SessionState::Running],
+        );
+        assert!(verdict.failures.iter().any(|f| matches!(
+            f,
+            OracleFailure::InbandDesyncDetected { peer: 0, frame: 42 }
+        )));
+    }
+
+    /// The failure cap keeps a systemically broken run readable.
+    #[test]
+    fn oracle_caps_recorded_failures() {
+        let mut oracle = Oracle::new(2);
+        oracle.observe_confirmed_inputs(0, 0, &inputs(&[1]));
+        for frame in 0..1000 {
+            oracle.observe_confirmed_inputs(0, frame, &inputs(&[1]));
+            oracle.observe_confirmed_inputs(1, frame, &inputs(&[2]));
+        }
+        let verdict = oracle.finalize(
+            &[BTreeMap::new(), BTreeMap::new()],
+            &[Frame::new(500), Frame::new(500)],
+            &[SessionState::Running, SessionState::Running],
+        );
+        assert!(verdict.failures.len() <= 64);
+    }
+}

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -1,0 +1,433 @@
+//! Schedule generation for the deterministic whole-mesh simulation harness.
+//!
+//! A [`Schedule`] is the **fully materialized** plan for one simulation run:
+//! per-link fault policies, timed fault events, and the heal/drain window.
+//! [`generate`] is a pure function of `(seed, SimConfig)` — every random draw
+//! comes from one seeded RNG consumed at generation time, and the runtime
+//! never touches that RNG — so a schedule reproduces exactly from its seed,
+//! and a serialized schedule (the corpus format) reproduces even after the
+//! generator itself evolves.
+//!
+//! Link-level *noise* (per-send drop/dup/jitter rolls) is separately seeded
+//! via [`Schedule::link_seed`], so editing a schedule's event list during
+//! shrinking does not perturb the background noise stream.
+
+// Test infrastructure: not every test binary uses every helper.
+#![allow(dead_code)]
+
+use crate::common::sim_net::LinkPolicy;
+use fortress_rollback::rng::{Pcg32, SeedableRng};
+use fortress_rollback::DisconnectBehavior;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Serializable mirror of [`DisconnectBehavior`] (the production enum does
+/// not derive serde; schedules must round-trip as corpus artifacts).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DropPolicy {
+    /// Mirror of [`DisconnectBehavior::Halt`] (the library default).
+    #[default]
+    Halt,
+    /// Mirror of [`DisconnectBehavior::ContinueWithout`].
+    ContinueWithout,
+}
+
+impl From<DropPolicy> for DisconnectBehavior {
+    fn from(policy: DropPolicy) -> Self {
+        match policy {
+            DropPolicy::Halt => Self::Halt,
+            DropPolicy::ContinueWithout => Self::ContinueWithout,
+        }
+    }
+}
+
+/// Schema version for serialized schedules (bump on breaking layout change).
+pub const SCHEDULE_SCHEMA_VERSION: u32 = 1;
+
+/// Background link-noise level applied to every directed link at start.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BackgroundNoise {
+    /// Perfect links.
+    Clean,
+    /// LAN-to-good-WAN: ≤2% loss, 5–30ms delay, ≤10ms jitter, ≤1% dup.
+    Mild,
+    /// Bad WAN / mobile: 2–10% loss, 20–80ms delay, ≤30ms jitter, ≤3% dup,
+    /// occasional short loss bursts.
+    Rough,
+}
+
+/// Static configuration of one simulation run — the fleet's axes.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SimConfig {
+    /// Number of P2P peers in the mesh (2..=16).
+    pub n_players: usize,
+    /// Total schedule length in steps (including the drain window).
+    pub steps: u32,
+    /// Virtual milliseconds advanced per step.
+    pub step_dt_ms: u64,
+    /// Session input delay (frames).
+    pub input_delay: usize,
+    /// Session prediction window (frames).
+    pub max_prediction: usize,
+    /// Desync-detection checksum interval (frames); always on in simulation.
+    pub desync_interval: u32,
+    /// Background link noise.
+    pub noise: BackgroundNoise,
+    /// Peer-drop policy for every session in the mesh. `#[serde(default)]`
+    /// (= `Halt`, the library default) keeps pre-existing corpus artifacts
+    /// replayable without a schema bump.
+    #[serde(default)]
+    pub disconnect_behavior: DropPolicy,
+}
+
+impl SimConfig {
+    /// The PR-smoke configuration: short schedule, mild noise.
+    ///
+    /// 600 steps × 16ms ≈ 10 virtual seconds, of which the last 250 steps
+    /// (≈4s) are the post-heal drain window — enough to cover the default 2s
+    /// disconnect timeout plus sync retries after the harshest storyline.
+    #[must_use]
+    pub fn smoke(n_players: usize) -> Self {
+        Self {
+            n_players,
+            steps: 600,
+            step_dt_ms: 16,
+            input_delay: 1,
+            max_prediction: 8,
+            desync_interval: 30,
+            noise: BackgroundNoise::Mild,
+            disconnect_behavior: DropPolicy::default(),
+        }
+    }
+
+    /// Virtual duration of one step.
+    #[must_use]
+    pub fn step_dt(&self) -> Duration {
+        Duration::from_millis(self.step_dt_ms)
+    }
+}
+
+/// A timed control-plane event. Link endpoints are peer *indices* (resolved
+/// to addresses by the harness) so schedules are address-independent.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ScheduleEvent {
+    /// Replace the fault policy of the directed link `from → to`.
+    SetLink {
+        from: usize,
+        to: usize,
+        policy: LinkPolicy,
+    },
+    /// Black-hole (or restore) the directed link `from → to`.
+    Block {
+        from: usize,
+        to: usize,
+        blocked: bool,
+    },
+    /// Start (or stop, flushing FIFO) capture-and-hold on `from → to`.
+    Hold {
+        from: usize,
+        to: usize,
+        holding: bool,
+    },
+    /// Reset every link to clean and release all held traffic.
+    HealAll,
+}
+
+/// A fully materialized simulation plan. Serializable (corpus format).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Schedule {
+    /// Serialized-layout version.
+    pub schema_version: u32,
+    /// The generator seed this schedule was derived from (provenance).
+    pub seed: u64,
+    /// Seed for the `SimNet` per-send fault rolls (independent stream).
+    pub link_seed: u64,
+    /// Run configuration.
+    pub config: SimConfig,
+    /// Initial policy for **every** directed link `(from, to)`, explicit.
+    pub initial_links: Vec<(usize, usize, LinkPolicy)>,
+    /// Timed events, sorted ascending by step.
+    pub events: Vec<(u32, ScheduleEvent)>,
+    /// Step at which [`ScheduleEvent::HealAll`] fires (always present in
+    /// `events`); the remaining steps are the clean drain window.
+    pub heal_at: u32,
+}
+
+/// Storyline kinds — multi-step fault narratives layered over the background
+/// noise, FoundationDB-buggify style. These target the emergent N-peer corner
+/// space (windows of heavy asymmetric loss, black-holes, and reordering) that
+/// uniform i.i.d. noise rarely reaches.
+#[derive(Copy, Clone, Debug)]
+enum StorylineKind {
+    /// A window of heavy loss on one directed link.
+    HeavyLossWindow,
+    /// A window where one direction of a pair is fully black-holed
+    /// (asymmetric partition).
+    AsymmetricBlackhole,
+    /// Capture-and-hold one directed link, then release (mass reorder).
+    HoldRelease,
+}
+
+/// Deterministic uniform helpers over the generator RNG.
+struct Draw<'a> {
+    rng: &'a mut Pcg32,
+}
+
+impl Draw<'_> {
+    /// Uniform `f64` in `[0, 1)`.
+    fn unit(&mut self) -> f64 {
+        f64::from(self.rng.next_u32()) / (f64::from(u32::MAX) + 1.0)
+    }
+
+    /// Uniform integer in `[lo, hi]` (inclusive). `hi >= lo` required.
+    fn range_u64(&mut self, lo: u64, hi: u64) -> u64 {
+        debug_assert!(hi >= lo);
+        let span = hi - lo + 1;
+        lo + (self.rng.next_u64() % span)
+    }
+
+    /// Uniform `f64` in `[lo, hi)`.
+    fn range_f64(&mut self, lo: f64, hi: f64) -> f64 {
+        lo + self.unit() * (hi - lo)
+    }
+}
+
+/// Rolls one background-noise link policy.
+fn roll_background_policy(draw: &mut Draw<'_>, noise: BackgroundNoise) -> LinkPolicy {
+    match noise {
+        BackgroundNoise::Clean => LinkPolicy::clean(),
+        BackgroundNoise::Mild => LinkPolicy {
+            drop_rate: draw.range_f64(0.0, 0.02),
+            dup_rate: draw.range_f64(0.0, 0.01),
+            base_delay: Duration::from_millis(draw.range_u64(5, 30)),
+            jitter: Duration::from_millis(draw.range_u64(0, 10)),
+            burst_rate: 0.0,
+            burst_len: 0,
+        },
+        BackgroundNoise::Rough => LinkPolicy {
+            drop_rate: draw.range_f64(0.02, 0.10),
+            dup_rate: draw.range_f64(0.0, 0.03),
+            base_delay: Duration::from_millis(draw.range_u64(20, 80)),
+            jitter: Duration::from_millis(draw.range_u64(0, 30)),
+            burst_rate: draw.range_f64(0.0, 0.005),
+            burst_len: u32::try_from(draw.range_u64(2, 5)).unwrap_or(3),
+        },
+    }
+}
+
+/// Generates the fully materialized schedule for `(seed, config)`.
+///
+/// Pure and deterministic: same inputs, same schedule, always.
+#[must_use]
+pub fn generate(seed: u64, config: SimConfig) -> Schedule {
+    assert!(
+        (2..=16).contains(&config.n_players),
+        "simulation supports 2..=16 players (got {})",
+        config.n_players
+    );
+    // Domain-separated generator stream; link noise gets its own stream so
+    // shrinking events never perturbs background rolls.
+    let mut rng = Pcg32::seed_from_u64(seed ^ 0x5EED_5EED_0000_0001);
+    let link_seed = seed ^ 0x1111_2222_3333_4444;
+    let mut draw = Draw { rng: &mut rng };
+
+    // Drain window: cover the default 2s disconnect timeout + sync retries
+    // with margin at 16ms steps, but never consume the whole schedule.
+    let drain_steps = (config.steps / 2).min(250);
+    let heal_at = config.steps.saturating_sub(drain_steps).max(1);
+
+    // Explicit initial policy for every directed link.
+    let n = config.n_players;
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                let policy = roll_background_policy(&mut draw, config.noise);
+                initial_links.push((from, to, policy));
+            }
+        }
+    }
+
+    // 0..=3 storyline segments, each entirely inside (10%..90%) of the
+    // pre-heal window and short enough (≤60 steps ≈ 1s virtual) not to trip
+    // the 2s disconnect timeout on its own — full disconnect lifecycles are
+    // introduced deliberately in the lifecycle vocabulary, not by accident.
+    let mut events: Vec<(u32, ScheduleEvent)> = Vec::new();
+    let storyline_budget = heal_at.saturating_sub(20);
+    let n_storylines = if storyline_budget > 100 {
+        draw.range_u64(0, 3)
+    } else {
+        0
+    };
+    for _ in 0..n_storylines {
+        let kind = match draw.range_u64(0, 2) {
+            0 => StorylineKind::HeavyLossWindow,
+            1 => StorylineKind::AsymmetricBlackhole,
+            _ => StorylineKind::HoldRelease,
+        };
+        let from = usize::try_from(draw.range_u64(0, (n - 1) as u64)).unwrap_or(0);
+        let mut to = usize::try_from(draw.range_u64(0, (n - 1) as u64)).unwrap_or(0);
+        if to == from {
+            to = (to + 1) % n;
+        }
+        let lo = storyline_budget / 10;
+        let hi = storyline_budget.saturating_sub(70).max(lo + 1);
+        let start = u32::try_from(draw.range_u64(u64::from(lo), u64::from(hi))).unwrap_or(lo);
+        let duration = u32::try_from(draw.range_u64(10, 60)).unwrap_or(30);
+        let end = (start + duration).min(heal_at.saturating_sub(1));
+
+        match kind {
+            StorylineKind::HeavyLossWindow => {
+                let heavy = LinkPolicy {
+                    drop_rate: draw.range_f64(0.25, 0.45),
+                    ..roll_background_policy(&mut draw, config.noise)
+                };
+                let restore = roll_background_policy(&mut draw, config.noise);
+                events.push((
+                    start,
+                    ScheduleEvent::SetLink {
+                        from,
+                        to,
+                        policy: heavy,
+                    },
+                ));
+                events.push((
+                    end,
+                    ScheduleEvent::SetLink {
+                        from,
+                        to,
+                        policy: restore,
+                    },
+                ));
+            },
+            StorylineKind::AsymmetricBlackhole => {
+                events.push((
+                    start,
+                    ScheduleEvent::Block {
+                        from,
+                        to,
+                        blocked: true,
+                    },
+                ));
+                events.push((
+                    end,
+                    ScheduleEvent::Block {
+                        from,
+                        to,
+                        blocked: false,
+                    },
+                ));
+            },
+            StorylineKind::HoldRelease => {
+                events.push((
+                    start,
+                    ScheduleEvent::Hold {
+                        from,
+                        to,
+                        holding: true,
+                    },
+                ));
+                events.push((
+                    end,
+                    ScheduleEvent::Hold {
+                        from,
+                        to,
+                        holding: false,
+                    },
+                ));
+            },
+        }
+    }
+
+    events.push((heal_at, ScheduleEvent::HealAll));
+    // Stable sort: same-step events keep their push order.
+    events.sort_by_key(|(step, _)| *step);
+
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed,
+        link_seed,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_is_pure_same_seed_same_schedule() {
+        let a = generate(42, SimConfig::smoke(4));
+        let b = generate(42, SimConfig::smoke(4));
+        assert_eq!(a, b, "generation must be a pure function of (seed, config)");
+    }
+
+    #[test]
+    fn generate_differs_across_seeds() {
+        let a = generate(1, SimConfig::smoke(4));
+        let b = generate(2, SimConfig::smoke(4));
+        assert_ne!(a, b, "different seeds should differ (links or events)");
+    }
+
+    #[test]
+    fn generate_covers_every_directed_link() {
+        for n in 2..=16 {
+            let schedule = generate(7, SimConfig::smoke(n));
+            assert_eq!(
+                schedule.initial_links.len(),
+                n * (n - 1),
+                "every directed pair needs an explicit policy (n={n})"
+            );
+        }
+    }
+
+    #[test]
+    fn generate_always_heals_before_end() {
+        for seed in 0..50 {
+            let schedule = generate(seed, SimConfig::smoke(3));
+            assert!(schedule.heal_at < schedule.config.steps);
+            assert!(
+                schedule
+                    .events
+                    .iter()
+                    .any(|(step, ev)| *step == schedule.heal_at
+                        && matches!(ev, ScheduleEvent::HealAll)),
+                "HealAll must be scheduled (seed={seed})"
+            );
+            // All events happen at or before heal.
+            assert!(
+                schedule
+                    .events
+                    .iter()
+                    .all(|(step, _)| *step <= schedule.heal_at),
+                "no fault events may fire inside the drain window (seed={seed})"
+            );
+        }
+    }
+
+    #[test]
+    fn events_are_sorted_by_step() {
+        for seed in 0..50 {
+            let schedule = generate(seed, SimConfig::smoke(5));
+            let steps: Vec<u32> = schedule.events.iter().map(|(s, _)| *s).collect();
+            let mut sorted = steps.clone();
+            sorted.sort_unstable();
+            assert_eq!(steps, sorted, "events must be sorted (seed={seed})");
+        }
+    }
+
+    #[test]
+    fn schedule_round_trips_through_json() {
+        let schedule = generate(42, SimConfig::smoke(4));
+        let json = serde_json::to_string(&schedule).unwrap();
+        let back: Schedule = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            schedule, back,
+            "corpus artifacts must round-trip losslessly"
+        );
+    }
+}

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -225,6 +225,17 @@ pub fn generate(seed: u64, config: SimConfig) -> Schedule {
         "simulation supports 2..=16 players (got {})",
         config.n_players
     );
+    // The schedule always appends a `HealAll` at `heal_at` followed by a drain
+    // window, and the run loop is `0..steps`. With fewer than 2 steps `heal_at`
+    // saturates to 1 (or the loop is empty), stranding the heal at a step that
+    // never runs and violating the heal-before-end invariant. Guard it like the
+    // player bound; real configs use hundreds of steps (smoke default 600).
+    assert!(
+        config.steps >= 2,
+        "simulation needs at least 2 steps so the appended HealAll lands inside \
+         the run (got {})",
+        config.steps
+    );
     // Domain-separated generator stream; link noise gets its own stream so
     // shrinking events never perturbs background rolls.
     let mut rng = Pcg32::seed_from_u64(seed ^ 0x5EED_5EED_0000_0001);
@@ -407,6 +418,39 @@ mod tests {
                 "no fault events may fire inside the drain window (seed={seed})"
             );
         }
+    }
+
+    /// The heal-before-end invariant must hold at the minimum allowed step
+    /// count, not just for the smoke default — the boundary the `steps >= 2`
+    /// guard protects.
+    #[test]
+    fn generate_heals_before_end_at_minimum_steps() {
+        let schedule = generate(
+            7,
+            SimConfig {
+                steps: 2,
+                ..SimConfig::smoke(2)
+            },
+        );
+        assert!(schedule.heal_at < schedule.config.steps);
+        assert!(schedule
+            .events
+            .iter()
+            .any(|(step, ev)| *step == schedule.heal_at && matches!(ev, ScheduleEvent::HealAll)));
+    }
+
+    /// Too few steps would strand `HealAll` outside the `0..steps` run — the
+    /// guard rejects it rather than emitting an inconsistent schedule.
+    #[test]
+    #[should_panic(expected = "at least 2 steps")]
+    fn generate_rejects_degenerate_step_count() {
+        let _ = generate(
+            0,
+            SimConfig {
+                steps: 1,
+                ..SimConfig::smoke(2)
+            },
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Distributed-systems hardening for the rollback netcode, in two coherent parts.

### M0/M1 — deterministic whole-mesh simulation fleet (commit `b3c1b67`)
- **M0 (D6):** ping/RTT round-trip timing virtualized onto the injectable protocol clock (`ping_epoch_base`/`ping_millis`) — quality-report RTT can no longer be corrupted by wall-clock steps (NTP/VM restore) and is exactly reproducible under a virtual clock. `js-sys` dropped as a `wasm32` dependency.
- **M1:** a seeded virtual-time whole-mesh simulation harness — `SimNet` message switch (per-link drop/dup/delay/jitter/partition/hold), a storyline schedule generator, and an invariant oracle (confirmed-prefix agreement, end-state agreement, in-band desync consistency, liveness), each with a negative control; PR smoke fleet of 8 seeds × N∈{2,3,4}.
- **Real bug found & fixed by the fleet on its first 4-player run (D8):** a permanent whole-mesh confirmation deadlock at N≥3. Connect-status gossip rides only `Input` packets; once every peer exhausted its prediction window with acked send queues, stale `Frame::NULL` caches never refreshed and the mesh froze permanently on a healed network with every session `Running`. Fixed by arming the connect-status nudge on the deadlock signature (window exhausted AND gossip-bound below receipts), with reserved hot-join endpoints excluded.

### M2 §5.1 — wire-exact bandwidth accounting (D1, commit `6ace99e`)
- `NetworkStats::kbps_sent` accounted `std::mem::size_of_val(&Message)` — the constant in-memory enum size, identical for every packet regardless of payload — so reported send bandwidth was fiction. Sends are now metered with a new alloc-free arithmetic `Message::encoded_len()` that is byte-exact against the codec.
- Regression: proptest `encoded_len == codec::encode(&msg).len()` for arbitrary messages of every variant (hot-join under `cfg`); plus a test documenting the `size_of_val` divergence.

## Validation
- `cargo fmt` + `cargo clippy --workspace --all-targets` (`tokio,json` and `…,hot-join`) — clean.
- `cargo nextest run` — 2336 passed (default) / 2574 passed (hot-join), 55 skipped.
- `python3 scripts/ci/agent-preflight.py` — all checks pass.

Changelog carries `**Pre-existing:** ### Fixed` entries for D6, D8, and D1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes P2P confirmation liveness logic and alters reported bandwidth/ping semantics; incorrect nudge timing could affect production mesh behavior or hot-join.
> 
> **Overview**
> Fixes **network telemetry** and a **multi-player liveness deadlock**, and adds a **deterministic whole-mesh simulation** test stack.
> 
> **Bandwidth and ping:** Outbound metering now uses alloc-free `Message::encoded_len()` (proptest vs `codec::encode`) instead of `size_of_val(&Message)`. `kbps_sent` is corrected to kilobits/sec (×8, ÷1000). Quality-report RTT uses the injectable protocol clock via `ping_epoch_base`/`ping_millis`, not wall time; **`js-sys` is removed** on `wasm32`. Send counters use **`u64`** to avoid wrap on 32-bit targets.
> 
> **N≥3 confirmation deadlock (D8):** Connect-status gossip only rides on `Input`. When every peer exhausted its prediction window with fully-acked queues, stale gossip could freeze confirmation forever. The connect-status nudge now also arms when the prediction window is exhausted **and** mesh gossip binds confirmation below local receipts (`gossip_holds_confirmation_below_receipts`); reserved hot-join endpoints are never nudged.
> 
> **Simulation fleet (M0/M1):** New `SimNet` (seeded per-link faults, virtual clock), schedule generator, harness oracle, PR smoke tests for 2–4 players, pinned regression for seed 1 / 4 players, integration tests for deterministic ping, and hidden `diagnostic_connect_status` for stall debugging. `serde_json` gains **`float_roundtrip`** for schedule corpus artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 822e944145b55daf2e1ee14bbf60b48eb776723a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->