### PR TITLE
Hardening M2 §5.4: SessionMetrics + D9 event-discard telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     exactly like a build-time reserved slot — this is the "previously gracefully-dropped" path above.
     Legacy `disconnect_player` (`Halt`-style) drops, and drops on a host that does not serve hot-joins, are
     not made re-joinable.
+- Always-on session metrics: `SessionMetrics` (a cheap, `Copy`, `serde::Serialize` snapshot of cumulative
+  counters), exposed via `P2PSession::metrics()` and `SpectatorSession::metrics()`. Counters are plain
+  integers updated inline on the paths they measure — no timers, no allocation, no `Instant` — so reads are
+  deterministic and WASM-safe. The first surface is **event-queue-overflow accounting**:
+  `SessionMetrics::events_discarded_total` counts events dropped because the application drained the bounded
+  event queue slower than events arrived, and `events_discarded_by_kind` (an `EventKindCounts`) breaks that
+  total down per category so a lost safety-critical notification (a `Disconnected` or `DesyncDetected`) is
+  visible rather than silent. Supporting types: `EventKind` (a payload-free mirror of `FortressEvent`'s
+  variants, with `as_str()`, `ALL`, and `COUNT`) plus `FortressEvent::kind()` to obtain one, and — under the
+  `json` feature — `SessionMetrics::to_json()` / `to_json_pretty()` (the per-kind breakdown serializes as a
+  self-describing snake_case-keyed map). `SessionMetrics` is `#[non_exhaustive]`, so later releases can add
+  counters without a breaking change.
 
 ### Changed
 
@@ -276,6 +288,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   framing as the existing protocol messages). Byzantine peers are out of scope. The existing
   defense-in-depth — the prediction-window rollback clamp, the sparse earlier-checkpoint search, and the
   disconnect-rollback checksum invalidation/deferral — is unchanged and now mostly dormant.
+- **Pre-existing:** Event-queue overflow no longer discards events **silently**. When the bounded event
+  queue exceeds its configured size the session still drops the oldest events (unchanged retention — that
+  policy is revisited separately), but each drop is now recorded in `SessionMetrics` (see *Added*) and a
+  rate-limited `Warning`/`NetworkProtocol` violation is reported once per overflow episode (re-armed each
+  time the application drains events), so a churn burst warns once rather than once per message. Previously the
+  oldest event — even a safety-critical `Disconnected` or `DesyncDetected` — was dropped with no violation
+  and no counter, so an application draining events slower than they arrive could miss a disconnect or a
+  desync with no way to detect the loss. Both `P2PSession` and `SpectatorSession` are covered. Drain events
+  every poll, or raise the event-queue size, to keep `events_discarded_total` at zero.
 
 ## [0.8.1] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,8 +295,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   time the application drains events), so a churn burst warns once rather than once per message. Previously the
   oldest event — even a safety-critical `Disconnected` or `DesyncDetected` — was dropped with no violation
   and no counter, so an application draining events slower than they arrive could miss a disconnect or a
-  desync with no way to detect the loss. Both `P2PSession` and `SpectatorSession` are covered. Drain events
-  every poll, or raise the event-queue size, to keep `events_discarded_total` at zero.
+  desync with no way to detect the loss. Both `P2PSession` and `SpectatorSession` are covered. The cap is
+  now enforced at **every** event-emission path — including events raised from `advance_frame` (wait
+  recommendations, desync detection), `remove_player`/`disconnect_player`, and the hot-join lifecycle —
+  not only when an inbound message is handled, so the queue can no longer sit above its configured size
+  (nor lose events untracked) between polls. Drain events every poll, or raise the event-queue size, to
+  keep `events_discarded_total` at zero.
 
 ## [0.8.1] - 2026-05-16
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ pub use error::{
 /// ```
 pub type FortressResult<T, E = FortressError> = std::result::Result<T, E>;
 
+pub use metrics::{EventKind, EventKindCounts, SessionMetrics};
 pub use network::chaos_socket::{ChaosConfig, ChaosConfigBuilder, ChaosSocket, ChaosStats};
 pub use network::messages::Message;
 pub use network::network_stats::NetworkStats;
@@ -218,6 +219,8 @@ pub mod frame_info;
 pub mod hash;
 #[doc(hidden)]
 pub mod input_queue;
+/// Always-on, pull-based session metrics ([`SessionMetrics`]).
+pub mod metrics;
 /// Internal `Vec` replacement that swaps to a stack-backed inline buffer under
 /// Kani to keep CBMC tractable (zero effect on non-Kani builds).
 pub(crate) mod proof_vec;
@@ -1713,6 +1716,37 @@ where
         /// Address of the joined peer.
         addr: T::Address,
     },
+}
+
+impl<T: Config> FortressEvent<T> {
+    /// The [`EventKind`] category of this event, independent of its payload.
+    ///
+    /// Useful for counting, filtering, or labeling events without matching on
+    /// every variant's payload fields.
+    ///
+    /// [`EventKind`]: crate::metrics::EventKind
+    #[must_use]
+    pub const fn kind(&self) -> crate::metrics::EventKind {
+        use crate::metrics::EventKind;
+        match self {
+            Self::Synchronizing { .. } => EventKind::Synchronizing,
+            Self::Synchronized { .. } => EventKind::Synchronized,
+            Self::Disconnected { .. } => EventKind::Disconnected,
+            Self::NetworkInterrupted { .. } => EventKind::NetworkInterrupted,
+            Self::NetworkResumed { .. } => EventKind::NetworkResumed,
+            Self::WaitRecommendation { .. } => EventKind::WaitRecommendation,
+            Self::DesyncDetected { .. } => EventKind::DesyncDetected,
+            Self::SyncTimeout { .. } => EventKind::SyncTimeout,
+            Self::ReplayDesync { .. } => EventKind::ReplayDesync,
+            Self::SpectatorDivergence { .. } => EventKind::SpectatorDivergence,
+            Self::InputDelayRecommendation { .. } => EventKind::InputDelayRecommendation,
+            Self::PeerDropped { .. } => EventKind::PeerDropped,
+            #[cfg(feature = "hot-join")]
+            Self::JoinRequested { .. } => EventKind::JoinRequested,
+            #[cfg(feature = "hot-join")]
+            Self::PeerJoined { .. } => EventKind::PeerJoined,
+        }
+    }
 }
 
 impl<T: Config> std::fmt::Display for FortressEvent<T>

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -217,12 +217,13 @@ impl Serialize for EventKindCounts {
 
 /// A cumulative snapshot of session-level metrics.
 ///
-/// Returned by [`P2PSession::metrics`] and [`SpectatorSession::metrics`]. Every
-/// counter is monotonic for the life of the session and cheap to read (the type
-/// is `Copy`).
+/// In normal use you read a snapshot from [`P2PSession::metrics`] or
+/// [`SpectatorSession::metrics`]; every counter is monotonic for the life of the
+/// session and cheap to read (the type is `Copy`).
 ///
-/// This type is `#[non_exhaustive]`: future library versions may add counters,
-/// so obtain instances only from the session accessors and match with `..`.
+/// This type is `#[non_exhaustive]`: future library versions may add counters
+/// without a breaking change, so it cannot be built with a struct literal
+/// outside this crate — match with `..`.
 ///
 /// # Example
 ///

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -275,8 +275,10 @@ impl SessionMetrics {
 
     /// Serializes this snapshot to a compact JSON string.
     ///
-    /// Returns `None` if serialization fails (which cannot happen for this
-    /// plain-integer type in practice).
+    /// Returns `None` if serialization fails. This type is a small set of
+    /// integer counters, so failure is not expected in normal operation, but it
+    /// is not impossible (for example, an allocation failure inside
+    /// `serde_json`).
     #[cfg(feature = "json")]
     #[must_use]
     pub fn to_json(&self) -> Option<String> {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,500 @@
+//! Always-on, pull-based session metrics.
+//!
+//! [`SessionMetrics`] is a cheap, `Copy` snapshot of cumulative session
+//! counters returned by [`P2PSession::metrics`] and
+//! [`SpectatorSession::metrics`]. Counters are plain integers updated inline on
+//! the paths they measure — no timers, no allocation, no `Instant` — so reading
+//! them is deterministic and WASM-safe.
+//!
+//! The first surface exposed here is **event-queue overflow accounting**: when
+//! the bounded event queue discards an undrained [`FortressEvent`] the session
+//! records it in [`SessionMetrics::events_discarded_total`] and the per-category
+//! [`SessionMetrics::events_discarded_by_kind`] breakdown, so a lost
+//! notification — possibly a safety-critical [`FortressEvent::Disconnected`] or
+//! [`FortressEvent::DesyncDetected`] — is observable instead of silent.
+//!
+//! [`P2PSession::metrics`]: crate::P2PSession::metrics
+//! [`SpectatorSession::metrics`]: crate::SpectatorSession::metrics
+//! [`FortressEvent`]: crate::FortressEvent
+//! [`FortressEvent::Disconnected`]: crate::FortressEvent::Disconnected
+//! [`FortressEvent::DesyncDetected`]: crate::FortressEvent::DesyncDetected
+
+use serde::Serialize;
+
+/// The category of a [`FortressEvent`], independent of its payload.
+///
+/// Mirrors the variants of [`FortressEvent`] one-to-one so events can be
+/// counted, filtered, or labeled without matching on their payload fields.
+/// Obtain one with [`FortressEvent::kind`].
+///
+/// The hot-join categories (`JoinRequested`, `PeerJoined`) exist only when the
+/// `hot-join` feature is enabled, mirroring the corresponding [`FortressEvent`]
+/// variants.
+///
+/// [`FortressEvent`]: crate::FortressEvent
+/// [`FortressEvent::kind`]: crate::FortressEvent::kind
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    /// [`FortressEvent::Synchronizing`](crate::FortressEvent::Synchronizing).
+    Synchronizing,
+    /// [`FortressEvent::Synchronized`](crate::FortressEvent::Synchronized).
+    Synchronized,
+    /// [`FortressEvent::Disconnected`](crate::FortressEvent::Disconnected).
+    Disconnected,
+    /// [`FortressEvent::NetworkInterrupted`](crate::FortressEvent::NetworkInterrupted).
+    NetworkInterrupted,
+    /// [`FortressEvent::NetworkResumed`](crate::FortressEvent::NetworkResumed).
+    NetworkResumed,
+    /// [`FortressEvent::WaitRecommendation`](crate::FortressEvent::WaitRecommendation).
+    WaitRecommendation,
+    /// [`FortressEvent::DesyncDetected`](crate::FortressEvent::DesyncDetected).
+    DesyncDetected,
+    /// [`FortressEvent::SyncTimeout`](crate::FortressEvent::SyncTimeout).
+    SyncTimeout,
+    /// [`FortressEvent::ReplayDesync`](crate::FortressEvent::ReplayDesync).
+    ReplayDesync,
+    /// [`FortressEvent::SpectatorDivergence`](crate::FortressEvent::SpectatorDivergence).
+    SpectatorDivergence,
+    /// [`FortressEvent::InputDelayRecommendation`](crate::FortressEvent::InputDelayRecommendation).
+    InputDelayRecommendation,
+    /// [`FortressEvent::PeerDropped`](crate::FortressEvent::PeerDropped).
+    PeerDropped,
+    /// [`FortressEvent::JoinRequested`](crate::FortressEvent::JoinRequested).
+    #[cfg(feature = "hot-join")]
+    JoinRequested,
+    /// [`FortressEvent::PeerJoined`](crate::FortressEvent::PeerJoined).
+    #[cfg(feature = "hot-join")]
+    PeerJoined,
+}
+
+impl EventKind {
+    /// The number of event categories.
+    ///
+    /// Varies with enabled features: two additional categories exist when the
+    /// `hot-join` feature is on.
+    #[cfg(not(feature = "hot-join"))]
+    pub const COUNT: usize = 12;
+    /// The number of event categories.
+    ///
+    /// Varies with enabled features: two additional categories exist when the
+    /// `hot-join` feature is on.
+    #[cfg(feature = "hot-join")]
+    pub const COUNT: usize = 14;
+
+    /// Every category, in declaration order. Its length is [`Self::COUNT`].
+    #[cfg(not(feature = "hot-join"))]
+    pub const ALL: [Self; Self::COUNT] = [
+        Self::Synchronizing,
+        Self::Synchronized,
+        Self::Disconnected,
+        Self::NetworkInterrupted,
+        Self::NetworkResumed,
+        Self::WaitRecommendation,
+        Self::DesyncDetected,
+        Self::SyncTimeout,
+        Self::ReplayDesync,
+        Self::SpectatorDivergence,
+        Self::InputDelayRecommendation,
+        Self::PeerDropped,
+    ];
+    /// Every category, in declaration order. Its length is [`Self::COUNT`].
+    #[cfg(feature = "hot-join")]
+    pub const ALL: [Self; Self::COUNT] = [
+        Self::Synchronizing,
+        Self::Synchronized,
+        Self::Disconnected,
+        Self::NetworkInterrupted,
+        Self::NetworkResumed,
+        Self::WaitRecommendation,
+        Self::DesyncDetected,
+        Self::SyncTimeout,
+        Self::ReplayDesync,
+        Self::SpectatorDivergence,
+        Self::InputDelayRecommendation,
+        Self::PeerDropped,
+        Self::JoinRequested,
+        Self::PeerJoined,
+    ];
+
+    /// A stable snake_case label for this category, suitable for logging or as
+    /// a metrics key. Matches the JSON key produced by serialization.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Synchronizing => "synchronizing",
+            Self::Synchronized => "synchronized",
+            Self::Disconnected => "disconnected",
+            Self::NetworkInterrupted => "network_interrupted",
+            Self::NetworkResumed => "network_resumed",
+            Self::WaitRecommendation => "wait_recommendation",
+            Self::DesyncDetected => "desync_detected",
+            Self::SyncTimeout => "sync_timeout",
+            Self::ReplayDesync => "replay_desync",
+            Self::SpectatorDivergence => "spectator_divergence",
+            Self::InputDelayRecommendation => "input_delay_recommendation",
+            Self::PeerDropped => "peer_dropped",
+            #[cfg(feature = "hot-join")]
+            Self::JoinRequested => "join_requested",
+            #[cfg(feature = "hot-join")]
+            Self::PeerJoined => "peer_joined",
+        }
+    }
+
+    /// The array index this category occupies in [`EventKindCounts`]. Always
+    /// less than [`Self::COUNT`].
+    const fn index(self) -> usize {
+        match self {
+            Self::Synchronizing => 0,
+            Self::Synchronized => 1,
+            Self::Disconnected => 2,
+            Self::NetworkInterrupted => 3,
+            Self::NetworkResumed => 4,
+            Self::WaitRecommendation => 5,
+            Self::DesyncDetected => 6,
+            Self::SyncTimeout => 7,
+            Self::ReplayDesync => 8,
+            Self::SpectatorDivergence => 9,
+            Self::InputDelayRecommendation => 10,
+            Self::PeerDropped => 11,
+            #[cfg(feature = "hot-join")]
+            Self::JoinRequested => 12,
+            #[cfg(feature = "hot-join")]
+            Self::PeerJoined => 13,
+        }
+    }
+}
+
+impl std::fmt::Display for EventKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Per-[`EventKind`] counters, keyed by category.
+///
+/// Backed by a fixed-size array (one slot per [`EventKind`]); read individual
+/// counts with [`get`](Self::get). Serializes as a JSON object keyed by each
+/// category's [`EventKind::as_str`] label, so the wire form is self-describing
+/// and stable across counter values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EventKindCounts([u64; EventKind::COUNT]);
+
+impl Default for EventKindCounts {
+    fn default() -> Self {
+        Self([0; EventKind::COUNT])
+    }
+}
+
+impl EventKindCounts {
+    /// The count recorded for `kind`.
+    ///
+    /// `kind.index()` is always in bounds, so the `unwrap_or` fallback is
+    /// unreachable; it keeps the accessor panic-free without an index.
+    #[must_use]
+    pub fn get(&self, kind: EventKind) -> u64 {
+        self.0.get(kind.index()).copied().unwrap_or(0)
+    }
+
+    /// Increments the counter for `kind` by one, saturating at [`u64::MAX`].
+    fn record(&mut self, kind: EventKind) {
+        if let Some(slot) = self.0.get_mut(kind.index()) {
+            *slot = slot.saturating_add(1);
+        }
+    }
+}
+
+impl Serialize for EventKindCounts {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(EventKind::COUNT))?;
+        for kind in EventKind::ALL {
+            map.serialize_entry(kind.as_str(), &self.get(kind))?;
+        }
+        map.end()
+    }
+}
+
+/// A cumulative snapshot of session-level metrics.
+///
+/// Returned by [`P2PSession::metrics`] and [`SpectatorSession::metrics`]. Every
+/// counter is monotonic for the life of the session and cheap to read (the type
+/// is `Copy`).
+///
+/// This type is `#[non_exhaustive]`: future library versions may add counters,
+/// so obtain instances only from the session accessors and match with `..`.
+///
+/// # Example
+///
+/// ```
+/// # use fortress_rollback::metrics::SessionMetrics;
+/// let metrics = SessionMetrics::default();
+/// assert_eq!(metrics.events_discarded_total, 0);
+/// ```
+///
+/// [`P2PSession::metrics`]: crate::P2PSession::metrics
+/// [`SpectatorSession::metrics`]: crate::SpectatorSession::metrics
+#[non_exhaustive]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[must_use = "SessionMetrics should be inspected after being queried"]
+pub struct SessionMetrics {
+    /// Total number of queued [`FortressEvent`]s discarded because the bounded
+    /// event queue overflowed before the application drained it.
+    ///
+    /// A non-zero value means events are being produced faster than the
+    /// application drains them and notifications have been lost — possibly
+    /// safety-critical ones such as [`FortressEvent::Disconnected`] or
+    /// [`FortressEvent::DesyncDetected`]. Drain events every poll, or raise the
+    /// event-queue size, to keep this at zero. See
+    /// [`events_discarded_by_kind`](Self::events_discarded_by_kind) for the
+    /// per-category breakdown.
+    ///
+    /// [`FortressEvent`]: crate::FortressEvent
+    /// [`FortressEvent::Disconnected`]: crate::FortressEvent::Disconnected
+    /// [`FortressEvent::DesyncDetected`]: crate::FortressEvent::DesyncDetected
+    pub events_discarded_total: u64,
+
+    /// Per-[`EventKind`] breakdown of
+    /// [`events_discarded_total`](Self::events_discarded_total): how many
+    /// discarded events fell into each category.
+    pub events_discarded_by_kind: EventKindCounts,
+}
+
+impl SessionMetrics {
+    /// Creates a zeroed snapshot.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records one event-queue-overflow discard of an event of category `kind`.
+    pub(crate) fn record_event_discard(&mut self, kind: EventKind) {
+        self.events_discarded_total = self.events_discarded_total.saturating_add(1);
+        self.events_discarded_by_kind.record(kind);
+    }
+
+    /// Serializes this snapshot to a compact JSON string.
+    ///
+    /// Returns `None` if serialization fails (which cannot happen for this
+    /// plain-integer type in practice).
+    #[cfg(feature = "json")]
+    #[must_use]
+    pub fn to_json(&self) -> Option<String> {
+        serde_json::to_string(self).ok()
+    }
+
+    /// Serializes this snapshot to a pretty-printed JSON string.
+    ///
+    /// Like [`to_json`](Self::to_json), but indented for readability.
+    #[cfg(feature = "json")]
+    #[must_use]
+    pub fn to_json_pretty(&self) -> Option<String> {
+        serde_json::to_string_pretty(self).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Config, FortressEvent, Frame, PlayerHandle};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    struct TestConfig;
+    impl Config for TestConfig {
+        type Input = u8;
+        type State = u8;
+        type Address = SocketAddr;
+    }
+
+    fn addr() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1)
+    }
+
+    #[test]
+    fn event_kind_all_len_matches_count() {
+        assert_eq!(EventKind::ALL.len(), EventKind::COUNT);
+    }
+
+    #[test]
+    fn event_kind_index_is_bijective_over_all() {
+        for (i, kind) in EventKind::ALL.into_iter().enumerate() {
+            assert_eq!(kind.index(), i, "index of {kind:?}");
+        }
+    }
+
+    #[test]
+    fn event_kind_as_str_labels_are_unique_and_nonempty() {
+        let mut seen = std::collections::BTreeSet::new();
+        for kind in EventKind::ALL {
+            assert!(!kind.as_str().is_empty());
+            assert!(
+                seen.insert(kind.as_str()),
+                "duplicate label {}",
+                kind.as_str()
+            );
+        }
+        assert_eq!(seen.len(), EventKind::COUNT);
+    }
+
+    #[test]
+    fn event_kind_counts_default_is_zero_and_records_saturate() {
+        let mut counts = EventKindCounts::default();
+        for kind in EventKind::ALL {
+            assert_eq!(counts.get(kind), 0);
+        }
+        counts.record(EventKind::Disconnected);
+        counts.record(EventKind::Disconnected);
+        assert_eq!(counts.get(EventKind::Disconnected), 2);
+        assert_eq!(counts.get(EventKind::Synchronized), 0);
+    }
+
+    #[test]
+    fn session_metrics_record_event_discard_bumps_total_and_kind() {
+        let mut metrics = SessionMetrics::new();
+        assert_eq!(metrics.events_discarded_total, 0);
+        metrics.record_event_discard(EventKind::DesyncDetected);
+        metrics.record_event_discard(EventKind::Disconnected);
+        metrics.record_event_discard(EventKind::Disconnected);
+        assert_eq!(metrics.events_discarded_total, 3);
+        assert_eq!(
+            metrics
+                .events_discarded_by_kind
+                .get(EventKind::DesyncDetected),
+            1
+        );
+        assert_eq!(
+            metrics
+                .events_discarded_by_kind
+                .get(EventKind::Disconnected),
+            2
+        );
+        assert_eq!(
+            metrics
+                .events_discarded_by_kind
+                .get(EventKind::Synchronized),
+            0
+        );
+    }
+
+    #[test]
+    fn fortress_event_kind_maps_every_variant() {
+        let a = addr();
+        let cases: [(FortressEvent<TestConfig>, EventKind); 12] = [
+            (
+                FortressEvent::Synchronizing {
+                    addr: a,
+                    total: 1,
+                    count: 0,
+                    total_requests_sent: 0,
+                    elapsed_ms: 0,
+                },
+                EventKind::Synchronizing,
+            ),
+            (
+                FortressEvent::Synchronized { addr: a },
+                EventKind::Synchronized,
+            ),
+            (
+                FortressEvent::Disconnected { addr: a },
+                EventKind::Disconnected,
+            ),
+            (
+                FortressEvent::NetworkInterrupted {
+                    addr: a,
+                    disconnect_timeout: 0,
+                },
+                EventKind::NetworkInterrupted,
+            ),
+            (
+                FortressEvent::NetworkResumed { addr: a },
+                EventKind::NetworkResumed,
+            ),
+            (
+                FortressEvent::WaitRecommendation { skip_frames: 0 },
+                EventKind::WaitRecommendation,
+            ),
+            (
+                FortressEvent::DesyncDetected {
+                    frame: Frame::new(1),
+                    local_checksum: 0,
+                    remote_checksum: 0,
+                    addr: a,
+                },
+                EventKind::DesyncDetected,
+            ),
+            (
+                FortressEvent::SyncTimeout {
+                    addr: a,
+                    elapsed_ms: 0,
+                },
+                EventKind::SyncTimeout,
+            ),
+            (
+                FortressEvent::ReplayDesync {
+                    frame: Frame::new(1),
+                    expected_checksum: 0,
+                    actual_checksum: 0,
+                },
+                EventKind::ReplayDesync,
+            ),
+            (
+                FortressEvent::SpectatorDivergence {
+                    frame: Frame::new(1),
+                    player: PlayerHandle::new(0),
+                    primary_addr: a,
+                    conflicting_addr: a,
+                },
+                EventKind::SpectatorDivergence,
+            ),
+            (
+                FortressEvent::InputDelayRecommendation {
+                    player_handle: PlayerHandle::new(0),
+                    current_delay: 0,
+                    suggested_delay: 0,
+                },
+                EventKind::InputDelayRecommendation,
+            ),
+            (
+                FortressEvent::PeerDropped {
+                    handle: PlayerHandle::new(0),
+                    addr: a,
+                },
+                EventKind::PeerDropped,
+            ),
+        ];
+        for (event, expected) in cases {
+            assert_eq!(event.kind(), expected, "expected kind {expected:?}");
+        }
+
+        #[cfg(feature = "hot-join")]
+        {
+            assert_eq!(
+                FortressEvent::<TestConfig>::JoinRequested {
+                    handle: PlayerHandle::new(0),
+                    addr: a,
+                }
+                .kind(),
+                EventKind::JoinRequested
+            );
+            assert_eq!(
+                FortressEvent::<TestConfig>::PeerJoined {
+                    handle: PlayerHandle::new(0),
+                    addr: a,
+                }
+                .kind(),
+                EventKind::PeerJoined
+            );
+        }
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn session_metrics_serializes_kind_breakdown_as_labeled_map() {
+        let mut metrics = SessionMetrics::new();
+        metrics.record_event_discard(EventKind::Disconnected);
+        let json = metrics.to_json().expect("json serialization succeeds");
+        assert!(json.contains(r#""events_discarded_total":1"#), "{json}");
+        // The per-kind breakdown is a self-describing, snake_case-keyed map.
+        assert!(json.contains(r#""disconnected":1"#), "{json}");
+        assert!(json.contains(r#""synchronized":0"#), "{json}");
+    }
+}

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -9161,6 +9161,11 @@ impl<T: Config> P2PSession<T> {
                 self.enter_fail_closed_disconnect_state();
             }
         }
+        // Propagated auto-disconnects (disconnect_timeout + ContinueWithout) emit
+        // PeerDropped/Disconnected here, inside `advance_frame` and outside
+        // `handle_event`'s trim; bound the queue so they can't exceed the cap
+        // (or defer the D9 discard telemetry) before the next poll.
+        self.trim_event_queue();
     }
 
     /// Gather average frame advantage from each remote player endpoint and return the maximum.

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -9380,7 +9380,12 @@ impl<T: Config> P2PSession<T> {
     }
 
     /// Handle events received from the UDP endpoints. Most events are being forwarded to the user for notification, but some require action.
-    fn handle_event(
+    /// Handles a single protocol event. Wrapped by
+    /// [`handle_event`](Self::handle_event), which enforces the event-queue cap
+    /// after this method returns through *any* path (including its several early
+    /// returns), so no emitted event escapes the cap or the D9 discard
+    /// telemetry.
+    fn handle_event_inner(
         &mut self,
         event: Event<T>,
         player_handles: Arc<[PlayerHandle]>,
@@ -9667,8 +9672,23 @@ impl<T: Config> P2PSession<T> {
                 }
             },
         }
+    }
 
-        // check event queue size and discard oldest events if too big
+    /// Handles a protocol event and then enforces the event-queue cap.
+    ///
+    /// The cap (and its D9 overflow telemetry) is applied here, after
+    /// [`handle_event_inner`](Self::handle_event_inner) returns through *any*
+    /// path — including its early returns (e.g. an unresolvable disconnect that
+    /// emits `Disconnected` then returns) — so an event emitted just before an
+    /// early return cannot leave the queue above its configured size or defer
+    /// the discard accounting.
+    fn handle_event(
+        &mut self,
+        event: Event<T>,
+        player_handles: Arc<[PlayerHandle]>,
+        addr: T::Address,
+    ) {
+        self.handle_event_inner(event, player_handles, addr);
         self.trim_event_queue();
     }
 
@@ -10329,6 +10349,46 @@ mod tests {
         assert!(
             session.metrics().events_discarded_total > before,
             "the overflow discard from the DesyncDetected push must be counted"
+        );
+    }
+
+    /// `handle_event` has early-return paths that emit an event then return
+    /// before the handler's normal end (e.g. a `Disconnected` for an endpoint
+    /// with no resolvable handles). The cap must still hold: `handle_event`
+    /// wraps `handle_event_inner` and trims after **every** exit, so an
+    /// early-return emission cannot escape the cap or the D9 accounting.
+    #[test]
+    fn handle_event_early_return_emission_is_bounded_by_wrapper_trim() {
+        let mut session = create_two_player_session();
+
+        // Saturate the queue.
+        let filler = test_addr(9998);
+        for _ in 0..session.max_event_queue_size {
+            session
+                .event_queue
+                .push_back(FortressEvent::NetworkResumed { addr: filler });
+        }
+        assert_eq!(session.event_queue.len(), session.max_event_queue_size);
+        let before = session.metrics().events_discarded_total;
+
+        // A `Disconnected` for an unregistered address with only a local handle
+        // resolves to no target, taking the early-return branch that pushes a
+        // `Disconnected` event and returns before the handler's normal end.
+        let unknown = test_addr(9997);
+        session.handle_event(
+            Event::Disconnected,
+            Arc::from([PlayerHandle::new(0)]),
+            unknown,
+        );
+
+        assert_eq!(
+            session.event_queue.len(),
+            session.max_event_queue_size,
+            "the wrapper trim must bound handle_event's early-return emission paths"
+        );
+        assert!(
+            session.metrics().events_discarded_total > before,
+            "the early-return emission's overflow discard must be counted"
         );
     }
 

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -1,5 +1,6 @@
 use crate::error::{allocation_failed, FortressError, InternalErrorKind, InvalidRequestKind};
 use crate::frame_info::PlayerInput;
+use crate::metrics::SessionMetrics;
 use crate::network::messages::ConnectionStatus;
 #[cfg(feature = "hot-join")]
 use crate::network::messages::StateSnapshot;
@@ -223,6 +224,14 @@ where
     /// Controls how the session reacts when a peer disconnects.
     /// See [`DisconnectBehavior`] for options.
     disconnect_behavior: DisconnectBehavior,
+
+    /// Cumulative, always-on session metrics (see [`P2PSession::metrics`]).
+    metrics: SessionMetrics,
+    /// Whether an event-queue-overflow `Warning` has already been reported since
+    /// the last [`events`](P2PSession::events) drain. Rate-limits the overflow
+    /// violation to one per overflow episode; the counters in `metrics` keep the
+    /// full history regardless.
+    event_discard_warned: bool,
 
     /// Hot-join state (host and joiner orchestration).
     ///
@@ -900,6 +909,8 @@ impl<T: Config> P2PSession<T> {
             recording: recording.then(|| ReplayRecorder::new(num_players)),
             last_recorded_frame: Frame::NULL,
             disconnect_behavior,
+            metrics: SessionMetrics::new(),
+            event_discard_warned: false,
             #[cfg(feature = "hot-join")]
             hot_join: HotJoinState {
                 reserved_slots: hot_join.reserved_slots,
@@ -5834,7 +5845,33 @@ impl<T: Config> P2PSession<T> {
     /// oldest events will be discarded.
     #[must_use = "events should be handled to react to session state changes"]
     pub fn events(&mut self) -> EventDrain<'_, T> {
+        // Draining starts a new overflow episode: re-arm the rate-limited
+        // event-queue-overflow warning (see `trim_event_queue`).
+        self.event_discard_warned = false;
         EventDrain::from_drain(self.event_queue.drain(..))
+    }
+
+    /// Returns a snapshot of this session's cumulative [`SessionMetrics`].
+    ///
+    /// Counters are always-on, monotonic for the life of the session, and cheap
+    /// to read (the returned value is `Copy`). The first surface is event-queue
+    /// overflow accounting: a non-zero
+    /// [`events_discarded_total`](SessionMetrics::events_discarded_total) means
+    /// the application is draining [`events`](Self::events) slower than they
+    /// arrive and has lost notifications — see
+    /// [`events_discarded_by_kind`](SessionMetrics::events_discarded_by_kind)
+    /// for the per-category breakdown.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let metrics = session.metrics();
+    /// if metrics.events_discarded_total > 0 {
+    ///     // The app is not draining events fast enough; some were lost.
+    /// }
+    /// ```
+    pub fn metrics(&self) -> SessionMetrics {
+        self.metrics
     }
 
     /// Returns the confirmed inputs for all players at a specific frame.
@@ -9607,8 +9644,46 @@ impl<T: Config> P2PSession<T> {
         }
 
         // check event queue size and discard oldest events if too big
+        self.trim_event_queue();
+    }
+
+    /// Bounds the event queue to `max_event_queue_size`, dropping the oldest
+    /// events first.
+    ///
+    /// Overflow means the application is draining events slower than they
+    /// arrive; the dropped events are lost. This used to happen silently
+    /// (defect D9) — a discarded [`FortressEvent::Disconnected`] or
+    /// [`FortressEvent::DesyncDetected`] left no trace. Every drop is now
+    /// recorded in [`SessionMetrics`] (total + per-[`EventKind`]), and one
+    /// rate-limited `Warning` violation is reported per overflow episode so the
+    /// loss is observable via the metrics snapshot and any registered violation
+    /// observer.
+    ///
+    /// The `Warning` is rate-limited to at most once between drains: the flag is
+    /// cleared in [`events`](Self::events), so a churn burst that overflows on
+    /// many messages within one poll produces a single `Warning`, not one per
+    /// message, while the always-incrementing counters keep the full history.
+    fn trim_event_queue(&mut self) {
+        let mut discarded = 0u64;
         while self.event_queue.len() > self.max_event_queue_size {
-            self.event_queue.pop_front();
+            if let Some(dropped) = self.event_queue.pop_front() {
+                self.metrics.record_event_discard(dropped.kind());
+                discarded += 1;
+            } else {
+                break;
+            }
+        }
+        if discarded > 0 && !self.event_discard_warned {
+            self.event_discard_warned = true;
+            report_violation!(
+                ViolationSeverity::Warning,
+                ViolationKind::NetworkProtocol,
+                "event queue overflow: discarding undrained event(s) (queue cap {}); \
+                 drain events every poll or raise the event-queue size to avoid losing \
+                 notifications (possibly Disconnected/DesyncDetected). See \
+                 SessionMetrics::events_discarded_total for the running count",
+                self.max_event_queue_size
+            );
         }
     }
 
@@ -10022,23 +10097,30 @@ mod tests {
         assert_eq!(DEFAULT_MAX_EVENT_QUEUE_SIZE, 100);
     }
 
-    /// Red-documentation test for defect D9 (PLAN.md §2): event-queue
-    /// overflow silently discards the oldest event — even a safety-critical
-    /// `Disconnected` — with **zero** telemetry: no violation, no counter,
-    /// nothing an application could use to learn an event was lost.
+    /// Regression for defect D9 (PLAN.md §2): event-queue overflow used to
+    /// discard the oldest event — even a safety-critical `Disconnected` — with
+    /// **zero** telemetry (no violation, no counter, nothing an application
+    /// could use to learn an event was lost). The M2 metrics layer makes the
+    /// loss observable: every discarded event increments [`SessionMetrics`]
+    /// (total + per-[`EventKind`](crate::metrics::EventKind)) and the session
+    /// reports a single rate-limited `Warning` violation per overflow pass.
     ///
-    /// This pins today's defective behavior so the defect is executable, not
-    /// just documented. When the M2 discard telemetry lands (rate-limited
-    /// Warning violation + `events_discarded_total` counter), the final
-    /// assertion flips to expect the violation instead.
+    /// This is the green successor to the red-documentation test that pinned
+    /// the silent behavior (PLAN.md §21.3): the final assertions flipped from
+    /// "no telemetry" to "telemetry recorded" once the fix landed.
     #[test]
-    fn event_queue_overflow_discards_disconnected_event_with_zero_telemetry() {
+    fn event_queue_overflow_records_discard_telemetry() {
+        use crate::metrics::EventKind;
+
         let mut session = create_two_player_session();
         let addr = test_addr(8080);
         let observer = Arc::new(crate::telemetry::CollectingObserver::new());
         let _guard = crate::telemetry::push_violation_observer(
             Arc::clone(&observer) as Arc<dyn crate::telemetry::ViolationObserver>
         );
+
+        // Nothing discarded before the overflow.
+        assert_eq!(session.metrics().events_discarded_total, 0);
 
         // Canary: an undrained Disconnected event at the front of the queue.
         session
@@ -10074,11 +10156,94 @@ mod tests {
             !disconnected_still_queued,
             "the Disconnected canary must have been evicted by the overflow trim"
         );
-        // RED (defect D9): the loss is completely silent today.
+
+        // GREEN (D9 fixed): the loss is recorded, not silent.
+        let metrics = session.metrics();
         assert!(
-            observer.violations().is_empty(),
-            "expected today's defective silent discard (no telemetry); observed violations: {:?}",
-            observer.violations()
+            metrics.events_discarded_total >= 1,
+            "overflow must count discarded events; got {}",
+            metrics.events_discarded_total
+        );
+        assert_eq!(
+            metrics
+                .events_discarded_by_kind
+                .get(EventKind::Disconnected),
+            1,
+            "the safety-critical Disconnected canary must be attributed to its kind"
+        );
+        // And a rate-limited Warning/NetworkProtocol violation was reported.
+        let violations = observer.violations();
+        assert!(
+            violations
+                .iter()
+                .any(|v| v.severity == ViolationSeverity::Warning
+                    && v.kind == ViolationKind::NetworkProtocol
+                    && v.message.contains("event queue overflow")),
+            "expected a rate-limited overflow Warning; observed: {violations:?}"
+        );
+    }
+
+    /// The overflow `Warning` is rate-limited to one per overflow episode: a
+    /// churn burst that discards on many messages within one drain gap produces
+    /// a single `Warning` (not one per message), and draining events
+    /// (`events()`) re-arms it so a subsequent overflow warns again. The
+    /// per-kind counters keep incrementing regardless.
+    #[test]
+    fn event_queue_overflow_warning_is_rate_limited_per_drain_gap() {
+        let mut session = create_two_player_session();
+        let addr = test_addr(8081);
+        let observer = Arc::new(crate::telemetry::CollectingObserver::new());
+        let _guard = crate::telemetry::push_violation_observer(
+            Arc::clone(&observer) as Arc<dyn crate::telemetry::ViolationObserver>
+        );
+
+        // Overflow the queue on many separate messages (each `handle_event`
+        // trims), all within a single drain gap.
+        let burst = |session: &mut P2PSession<TestConfig>| {
+            for _ in 0..(session.max_event_queue_size + 5) {
+                session.handle_event(
+                    Event::Synchronizing {
+                        total: 10,
+                        count: 1,
+                        total_requests_sent: 1,
+                        elapsed_ms: 5,
+                    },
+                    Arc::from([PlayerHandle::new(1)]),
+                    addr,
+                );
+            }
+        };
+        let overflow_warnings = |observer: &crate::telemetry::CollectingObserver| {
+            observer
+                .violations()
+                .iter()
+                .filter(|v| {
+                    v.severity == ViolationSeverity::Warning
+                        && v.kind == ViolationKind::NetworkProtocol
+                        && v.message.contains("event queue overflow")
+                })
+                .count()
+        };
+
+        burst(&mut session);
+        assert!(
+            session.metrics().events_discarded_total >= 5,
+            "the burst must discard on many messages; got {}",
+            session.metrics().events_discarded_total
+        );
+        assert_eq!(
+            overflow_warnings(&observer),
+            1,
+            "many discards within one drain gap must yield a single Warning"
+        );
+
+        // Draining re-arms the rate limiter.
+        let _ = session.events();
+        burst(&mut session);
+        assert_eq!(
+            overflow_warnings(&observer),
+            2,
+            "a fresh drain must re-arm the overflow Warning"
         );
     }
 

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -1756,6 +1756,9 @@ impl<T: Config> P2PSession<T> {
         // phases above are unaffected.
         self.poll_npeer_host_serve();
         self.poll_npeer_post_serve();
+        // JoinRequested/PeerJoined above are emitted during poll, outside
+        // `handle_event`'s trim; bound the queue (D9 telemetry must cover them).
+        self.trim_event_queue();
     }
 
     /// Returns the **survivor set** for a prospective N-peer serve: the
@@ -1976,6 +1979,8 @@ impl<T: Config> P2PSession<T> {
 
         self.event_queue
             .push_back(FortressEvent::JoinRequested { handle, addr });
+        // Runs during poll outside `handle_event`'s trim; bound the queue.
+        self.trim_event_queue();
     }
 
     /// Returns `true` while a freeze-frame convergence re-adjust whose forced
@@ -2388,6 +2393,8 @@ impl<T: Config> P2PSession<T> {
             handle,
             addr: joiner_addr,
         });
+        // Runs during poll outside `handle_event`'s trim; bound the queue.
+        self.trim_event_queue();
     }
 
     /// Concludes an N-peer serve unsuccessfully: announces `JoinAborted` to the
@@ -4923,6 +4930,8 @@ impl<T: Config> P2PSession<T> {
         // coordinator `Disconnected` as an idempotent teardown cue.
         self.event_queue
             .push_back(FortressEvent::Disconnected { addr: host_addr });
+        // Runs during poll outside `handle_event`'s trim; bound the queue.
+        self.trim_event_queue();
     }
 
     /// Post-apply late-sync backfill (S34 fix round 1, discovered finding
@@ -5409,13 +5418,17 @@ impl<T: Config> P2PSession<T> {
             }
             .into());
         }
-        self.disconnect_player_with_policy(
+        let result = self.disconnect_player_with_policy(
             player_handle,
             None,
             DisconnectBehavior::ContinueWithout,
             DisconnectEventPolicy::Emit,
             GracefulDropFailurePolicy::Abort,
-        )
+        );
+        // `remove_player` emits PeerDropped/Disconnected outside `handle_event`'s
+        // trim; bound the queue before returning control to the caller (D9).
+        self.trim_event_queue();
+        result
     }
 
     /// Disconnects a remote player and all other remote players with the same address from the session.
@@ -5502,13 +5515,16 @@ impl<T: Config> P2PSession<T> {
                         kind: InternalErrorKind::DisconnectStatusNotFound { player_handle },
                     })?;
                 if !status.disconnected {
-                    return self.disconnect_player_with_policy(
+                    let result = self.disconnect_player_with_policy(
                         player_handle,
                         None,
                         DisconnectBehavior::Halt,
                         DisconnectEventPolicy::Suppress,
                         GracefulDropFailurePolicy::DisconnectAndHalt,
                     );
+                    // Emitted outside `handle_event`'s trim; bound the queue (D9).
+                    self.trim_event_queue();
+                    return result;
                 }
                 Err(InvalidRequestKind::AlreadyDisconnected {
                     handle: player_handle,
@@ -5518,6 +5534,7 @@ impl<T: Config> P2PSession<T> {
             // disconnecting spectators is simpler
             Some(PlayerType::Spectator(_)) => {
                 self.disconnect_player_at_frame(player_handle, Frame::NULL);
+                self.trim_event_queue();
                 Ok(())
             },
         }
@@ -9186,6 +9203,9 @@ impl<T: Config> P2PSession<T> {
             self.event_queue
                 .push_back(FortressEvent::WaitRecommendation { skip_frames });
         }
+        // This runs from `advance_frame`, outside `handle_event`'s trim, so bound
+        // the queue here too (D9: overflow must stay accounted + telemetered).
+        self.trim_event_queue();
     }
 
     fn check_last_saved_state(
@@ -9768,6 +9788,10 @@ impl<T: Config> P2PSession<T> {
             },
             DesyncDetection::Off => (),
         }
+        // The `DesyncDetected` pushes above run from `advance_frame`, outside
+        // `handle_event`'s trim; bound the queue so the overflow accounting and
+        // telemetry (D9) cover them too.
+        self.trim_event_queue();
     }
 
     fn check_checksum_send_interval(&mut self) {
@@ -10244,6 +10268,62 @@ mod tests {
             overflow_warnings(&observer),
             2,
             "a fresh drain must re-arm the overflow Warning"
+        );
+    }
+
+    /// Events emitted **outside** `handle_event` (here `DesyncDetected` from
+    /// `compare_local_checksums_against_peers`, which runs inside `advance_frame`)
+    /// must also honor the event-queue cap and its discard telemetry. Before the
+    /// fix, `trim_event_queue` ran only at the end of `handle_event`, so these
+    /// paths could push above the cap — and bypass the D9 accounting — until the
+    /// next inbound message happened to be handled.
+    #[test]
+    fn desync_detected_push_outside_handle_event_is_bounded_and_counted() {
+        let mut session = create_three_player_desync_session();
+        let addr_b = test_addr(8080);
+
+        // Make frame 0 comparable and force Running (DummySocket never syncs).
+        session.sync_layer.advance_frame();
+        session.sync_layer.advance_frame();
+        session
+            .sync_layer
+            .set_last_confirmed_frame(Frame::new(2), session.save_mode);
+        session.state = SessionState::Running;
+
+        // Plant a mismatching confirmed-frame checksum so the next comparison
+        // emits a `DesyncDetected` event.
+        let frame = Frame::new(0);
+        session.local_checksum_history.insert(frame, 0xABCD_1234);
+        {
+            let b = session
+                .player_reg
+                .remotes
+                .get_mut(&addr_b)
+                .expect("B endpoint exists");
+            b.pending_checksums.insert(frame, 0x0000_0001); // differs from local
+        }
+
+        // Saturate the event queue with benign events first.
+        let filler = test_addr(9999);
+        for _ in 0..session.max_event_queue_size {
+            session
+                .event_queue
+                .push_back(FortressEvent::NetworkResumed { addr: filler });
+        }
+        assert_eq!(session.event_queue.len(), session.max_event_queue_size);
+        let before = session.metrics().events_discarded_total;
+
+        // Runs outside `handle_event`; must still enforce the cap + count the drop.
+        session.compare_local_checksums_against_peers();
+
+        assert_eq!(
+            session.event_queue.len(),
+            session.max_event_queue_size,
+            "the cap must hold for enqueues outside handle_event"
+        );
+        assert!(
+            session.metrics().events_discarded_total > before,
+            "the overflow discard from the DesyncDetected push must be counted"
         );
     }
 

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -10103,7 +10103,7 @@ mod tests {
     /// could use to learn an event was lost). The M2 metrics layer makes the
     /// loss observable: every discarded event increments [`SessionMetrics`]
     /// (total + per-[`EventKind`](crate::metrics::EventKind)) and the session
-    /// reports a single rate-limited `Warning` violation per overflow pass.
+    /// reports one rate-limited `Warning` violation per overflow episode.
     ///
     /// This is the green successor to the red-documentation test that pinned
     /// the silent behavior (PLAN.md §21.3): the final assertions flipped from

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -9654,8 +9654,8 @@ impl<T: Config> P2PSession<T> {
     /// arrive; the dropped events are lost. This used to happen silently
     /// (defect D9) — a discarded [`FortressEvent::Disconnected`] or
     /// [`FortressEvent::DesyncDetected`] left no trace. Every drop is now
-    /// recorded in [`SessionMetrics`] (total + per-[`EventKind`]), and one
-    /// rate-limited `Warning` violation is reported per overflow episode so the
+    /// recorded in [`SessionMetrics`] (total + per-[`EventKind`](crate::metrics::EventKind)),
+    /// and one rate-limited `Warning` violation is reported per overflow episode so the
     /// loss is observable via the metrics snapshot and any registered violation
     /// observer.
     ///

--- a/src/sessions/p2p_spectator_session.rs
+++ b/src/sessions/p2p_spectator_session.rs
@@ -14,7 +14,8 @@ use crate::{
     telemetry::{ViolationKind, ViolationObserver, ViolationSeverity},
     Config, EventDrain, FortressError, FortressEvent, FortressRequest, FortressResult, Frame,
     GameStateCell, InputStatus, InputVec, InternalErrorKind, InvalidFrameReason,
-    InvalidRequestKind, NetworkStats, NonBlockingSocket, PlayerHandle, RequestVec, SessionState,
+    InvalidRequestKind, NetworkStats, NonBlockingSocket, PlayerHandle, RequestVec, SessionMetrics,
+    SessionState,
 };
 
 /// The number of frames the spectator advances in a single step during normal operation.
@@ -174,6 +175,13 @@ where
     violation_observer: Option<Arc<dyn ViolationObserver>>,
     /// Maximum number of events to queue before oldest are dropped.
     max_event_queue_size: usize,
+    /// Cumulative, always-on session metrics (see [`SpectatorSession::metrics`]).
+    metrics: SessionMetrics,
+    /// Whether an event-queue-overflow `Warning` has already been reported since
+    /// the last [`events`](SpectatorSession::events) drain. Rate-limits the
+    /// overflow violation to one per overflow episode; `metrics` keeps the full
+    /// history regardless.
+    event_discard_warned: bool,
     spectator_divergence: Option<SpectatorDivergenceState<T::Address>>,
     /// Host indices that will emit `Disconnected` during the current poll.
     /// Cross-host comparisons must ignore these hosts so same-poll failover
@@ -321,6 +329,8 @@ impl<T: Config> SpectatorSession<T> {
             state_buffer,
             violation_observer,
             max_event_queue_size: event_queue_size,
+            metrics: SessionMetrics::new(),
+            event_discard_warned: false,
             spectator_divergence: None,
             disconnecting_hosts: Vec::new(),
         })
@@ -574,7 +584,25 @@ impl<T: Config> SpectatorSession<T> {
     /// oldest events will be discarded.
     #[must_use = "events should be handled to react to session state changes"]
     pub fn events(&mut self) -> EventDrain<'_, T> {
+        // Draining starts a new overflow episode: re-arm the rate-limited
+        // event-queue-overflow warning (see `trim_event_queue`).
+        self.event_discard_warned = false;
         EventDrain::from_drain(self.event_queue.drain(..))
+    }
+
+    /// Returns a snapshot of this spectator's cumulative [`SessionMetrics`].
+    ///
+    /// Counters are always-on, monotonic for the life of the session, and cheap
+    /// to read (the returned value is `Copy`). A non-zero
+    /// [`events_discarded_total`](SessionMetrics::events_discarded_total) means
+    /// the application is draining [`events`](Self::events) slower than they
+    /// arrive and has lost notifications.
+    ///
+    /// [`SessionMetrics`] is shared with [`P2PSession`](crate::P2PSession), so
+    /// per-kind categories a spectator never emits (for example
+    /// `wait_recommendation`) stay at zero here.
+    pub fn metrics(&self) -> SessionMetrics {
+        self.metrics
     }
 
     /// Returns a reference to the violation observer, if one was configured.
@@ -1292,9 +1320,38 @@ impl<T: Config> SpectatorSession<T> {
         self.trim_event_queue();
     }
 
+    /// Bounds the event queue to `max_event_queue_size`, dropping the oldest
+    /// events first.
+    ///
+    /// Overflow means the application is draining events slower than they
+    /// arrive; the dropped events are lost. This used to happen silently
+    /// (defect D9). Every drop is now recorded in [`SessionMetrics`] (total +
+    /// per-[`EventKind`](crate::metrics::EventKind)), and one rate-limited
+    /// `Warning` violation is reported per overflow episode (the flag is cleared
+    /// on each [`events`](Self::events) drain) so the loss is observable via
+    /// [`metrics`](Self::metrics) and any registered violation observer without
+    /// flooding on a churn burst.
     fn trim_event_queue(&mut self) {
+        let mut discarded = 0u64;
         while self.event_queue.len() > self.max_event_queue_size {
-            self.event_queue.pop_front();
+            if let Some(dropped) = self.event_queue.pop_front() {
+                self.metrics.record_event_discard(dropped.kind());
+                discarded += 1;
+            } else {
+                break;
+            }
+        }
+        if discarded > 0 && !self.event_discard_warned {
+            self.event_discard_warned = true;
+            report_violation_to!(
+                &self.violation_observer,
+                ViolationSeverity::Warning,
+                ViolationKind::NetworkProtocol,
+                "spectator event queue overflow: discarding undrained event(s) (queue cap {}); \
+                 drain events every poll or raise the event-queue size to avoid losing \
+                 notifications. See SessionMetrics::events_discarded_total for the running count",
+                self.max_event_queue_size
+            );
         }
     }
 
@@ -2433,6 +2490,136 @@ mod tests {
     fn spectator_session_creates_successfully() {
         let session = create_test_spectator_session();
         assert!(session.is_some());
+    }
+
+    /// Regression for defect D9 (PLAN.md §2) on the **spectator** session: its
+    /// event-queue trim used to discard undrained events silently, just like
+    /// the P2P session. The overflow now increments [`SessionMetrics`] (total +
+    /// per-[`EventKind`](crate::metrics::EventKind)) and reports a single
+    /// rate-limited `Warning` to the configured violation observer.
+    #[test]
+    fn spectator_event_queue_overflow_records_discard_telemetry() {
+        use crate::metrics::EventKind;
+        use crate::telemetry::CollectingObserver;
+
+        let observer = Arc::new(CollectingObserver::new());
+        let mut session = SessionBuilder::<TestConfig>::new()
+            .with_num_players(2)
+            .unwrap()
+            .with_event_queue_size(10)
+            .unwrap()
+            .with_violation_observer(Arc::clone(&observer) as Arc<dyn ViolationObserver>)
+            .start_spectator_session(test_addr(7100), DummySocket)
+            .expect("spectator session builds");
+
+        assert_eq!(session.metrics().events_discarded_total, 0);
+
+        let addr = test_addr(9000);
+        // Canary at the front: a safety-critical Disconnected.
+        session
+            .event_queue
+            .push_back(FortressEvent::Disconnected { addr });
+        // Push past the cap with benign events so the canary overflows out.
+        for _ in 0..session.max_event_queue_size {
+            session
+                .event_queue
+                .push_back(FortressEvent::NetworkResumed { addr });
+        }
+        session.trim_event_queue();
+
+        assert_eq!(
+            session.event_queue.len(),
+            session.max_event_queue_size,
+            "queue must be trimmed to its cap"
+        );
+        let metrics = session.metrics();
+        assert!(
+            metrics.events_discarded_total >= 1,
+            "overflow must count discarded events; got {}",
+            metrics.events_discarded_total
+        );
+        assert_eq!(
+            metrics
+                .events_discarded_by_kind
+                .get(EventKind::Disconnected),
+            1,
+            "the safety-critical Disconnected canary must be attributed to its kind"
+        );
+        let violations = observer.violations();
+        assert!(
+            violations
+                .iter()
+                .any(|v| v.severity == ViolationSeverity::Warning
+                    && v.kind == ViolationKind::NetworkProtocol
+                    && v.message.contains("spectator event queue overflow")),
+            "expected a rate-limited spectator overflow Warning; observed: {violations:?}"
+        );
+    }
+
+    /// The spectator's overflow `Warning` is rate-limited per overflow episode
+    /// (mirror of the P2P contract): several trim passes within one drain gap
+    /// yield a single `Warning`, and `events()` re-arms it. The per-kind
+    /// counters keep incrementing regardless.
+    #[test]
+    fn spectator_event_queue_overflow_warning_is_rate_limited_per_drain_gap() {
+        use crate::telemetry::CollectingObserver;
+
+        let observer = Arc::new(CollectingObserver::new());
+        let mut session = SessionBuilder::<TestConfig>::new()
+            .with_num_players(2)
+            .unwrap()
+            .with_event_queue_size(10)
+            .unwrap()
+            .with_violation_observer(Arc::clone(&observer) as Arc<dyn ViolationObserver>)
+            .start_spectator_session(test_addr(7101), DummySocket)
+            .expect("spectator session builds");
+
+        let addr = test_addr(9001);
+        let overflow_warnings = |observer: &CollectingObserver| {
+            observer
+                .violations()
+                .iter()
+                .filter(|v| {
+                    v.severity == ViolationSeverity::Warning
+                        && v.kind == ViolationKind::NetworkProtocol
+                        && v.message.contains("spectator event queue overflow")
+                })
+                .count()
+        };
+
+        // First episode: several overflowing trim passes, no drain between them.
+        for _ in 0..5 {
+            for _ in 0..(session.max_event_queue_size + 1) {
+                session
+                    .event_queue
+                    .push_back(FortressEvent::NetworkResumed { addr });
+            }
+            session.trim_event_queue();
+        }
+        assert!(
+            session.metrics().events_discarded_total >= 5,
+            "the passes must discard repeatedly; got {}",
+            session.metrics().events_discarded_total
+        );
+        assert_eq!(
+            overflow_warnings(&observer),
+            1,
+            "many discards within one drain gap must yield a single Warning"
+        );
+
+        // Draining re-arms the rate limiter.
+        let _ = session.events();
+        for _ in 0..(session.max_event_queue_size + 1) {
+            session
+                .event_queue
+                .push_back(FortressEvent::NetworkResumed { addr });
+        }
+        session.trim_event_queue();
+        assert_eq!(
+            overflow_warnings(&observer),
+            2,
+            "a fresh drain must re-arm the overflow Warning"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an always-on, pull-based **session metrics layer** (`src/metrics.rs`) and uses its first counter surface to fix defect **D9**: event-queue overflow no longer discards undrained events silently.

This is the next increment of the M2 milestone (metrics + baseline sweep) after M2 §5.1 (D1, #189). It ships the metrics-module foundation plus the event-queue-overflow accounting that closes D9's telemetry gap. `PeerMetrics`, the rollback/stall/confirmation-lag counters, and the baseline sweep are follow-up PRs — every field lands with a consuming site so nothing is dead code under `deny(warnings)`, and `SessionMetrics` is `#[non_exhaustive]` so those are additive.

## The defect (D9)

Both session types bounded the event queue with `while event_queue.len() > max { pop_front() }` — dropping the **oldest** event with **zero** telemetry (no violation, no counter). A slow-draining app during a churn burst could silently lose a safety-critical `Disconnected` or `DesyncDetected`. A red-doc test pinned the silence; this PR flips it green.

## What's new

- **`SessionMetrics`** — `#[non_exhaustive]`, `Copy`, `serde::Serialize`, `to_json()`/`to_json_pretty()` under `json`. First fields: `events_discarded_total` + `events_discarded_by_kind` (per-`EventKind`). Plain integers updated inline — no timers, no alloc, no `Instant` — so reads are deterministic and WASM-safe.
- **`EventKind`** — a payload-free mirror of every `FortressEvent` variant (`as_str()`/`ALL`/`COUNT`), plus **`FortressEvent::kind()`**. The events analogue of the planned `MessageKind`.
- **`P2PSession::metrics()` / `SpectatorSession::metrics()`** accessors. `trim_event_queue` now records every discarded event's kind and emits **one** rate-limited `Warning`/`NetworkProtocol` violation per overflow **episode** — re-armed on each `events()` drain, so a churn burst warns once, not once per message. **Retention is unchanged** (still drops oldest); the policy change is deferred to M4.

## Red → green

- Rewrote the red-doc test → `event_queue_overflow_records_discard_telemetry`.
- Verified RED by temporarily neutralizing the fix (silent trim): `overflow must count discarded events; got 0`.
- GREEN: the `Disconnected` canary is attributed to its kind, `events_discarded_total >= 1`, and a rate-limited `Warning` fires.
- New regressions: P2P + spectator rate-limit-per-drain-gap tests, spectator discard test, and `metrics::tests` (index↔ALL↔as_str bijection, exhaustive `kind()` mapping over all variants, labeled-map JSON).

## Validation

- `cargo fmt` + `cargo clippy --workspace --all-targets` clean under `tokio,json` and `tokio,json,hot-join`.
- `cargo nextest run`: **2349** passed (`tokio,json`), **2587** passed (`+hot-join`).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean (both feature sets).
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass.

An adversarial review pass verified the core (index/ALL/as_str bijection, `kind()` totality, custom-Serialize stability) and confirmed the counter has no bypass: the only `pop_front` on the event queue is in `trim_event_queue`, and the only `drain(..)` is in `events()` (which re-arms the rate limiter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all event-queue emission paths in P2P and spectator sessions; miscounted or missed trims could still hide lost Disconnected/DesyncDetected events, though regressions target that behavior.
> 
> **Overview**
> Introduces **`SessionMetrics`** (`src/metrics.rs`) with **`P2PSession::metrics()`** and **`SpectatorSession::metrics()`**, plus **`EventKind`**, **`EventKindCounts`**, and **`FortressEvent::kind()`** so overflow drops can be counted by category. Optional **`to_json()`** / **`to_json_pretty()`** when the `json` feature is enabled.
> 
> **D9 fix:** bounded event-queue overflow still drops oldest events, but each discard increments **`events_discarded_total`** and **`events_discarded_by_kind`**, and emits one rate-limited **`Warning`/`NetworkProtocol`** violation per overflow episode (re-armed when **`events()`** drains). **`handle_event`** is split so **`trim_event_queue`** runs after every emission path—including **`advance_frame`**, disconnect/hot-join, and early returns—not only inbound protocol handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216e135095895b2b1af686d029057b136906415a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->