### PR TITLE
Hardening M2 §5.2: SessionMetrics rollback + pacing counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variants, with `as_str()`, `ALL`, and `COUNT`) plus `FortressEvent::kind()` to obtain one, and — under the
   `json` feature — `SessionMetrics::to_json()` / `to_json_pretty()` (the per-kind breakdown serializes as a
   self-describing snake_case-keyed map). `SessionMetrics` is `#[non_exhaustive]`, so later releases can add
-  counters without a breaking change.
+  counters without a breaking change. `SessionMetrics` now also carries **rollback and pacing counters** for
+  `P2PSession`: `frames_advanced` (total simulation steps), `visual_frames` (forward/rendered advances),
+  `resimulated_frames` (frames replayed during rollback — `frames_advanced == visual_frames +
+  resimulated_frames` by construction), `rollback_count`, `rollback_depth_histogram` (a new
+  `RollbackDepthHistogram` bucketing rollbacks by re-simulated depth `1..=16` then `17_plus`, serialized as a
+  self-describing depth-keyed map), `max_rollback_depth`, `prediction_miss_count`, `stall_count` (advances
+  throttled by a full prediction window — previously unobservable), `wait_recommendations`,
+  `confirmation_lag_current` / `_max` / `_sum` (per-advance samples of how far ahead of the confirmed frame
+  the simulation runs), `checksums_compared` / `checksums_matched` / `checksums_mismatched` (desync-detection
+  comparisons), and the `event_queue_high_water` / `checksum_history_high_water` container high-water marks.
+  All counters are always-on, allocation-free, and updated inline on the paths they measure.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub use error::{
 /// ```
 pub type FortressResult<T, E = FortressError> = std::result::Result<T, E>;
 
-pub use metrics::{EventKind, EventKindCounts, SessionMetrics};
+pub use metrics::{EventKind, EventKindCounts, RollbackDepthHistogram, SessionMetrics};
 pub use network::chaos_socket::{ChaosConfig, ChaosConfigBuilder, ChaosSocket, ChaosStats};
 pub use network::messages::Message;
 pub use network::network_stats::NetworkStats;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -215,6 +215,80 @@ impl Serialize for EventKindCounts {
     }
 }
 
+/// A histogram of rollback depths (the number of frames re-simulated per
+/// rollback), bucketed by depth.
+///
+/// Backed by a fixed-size array of [`BUCKETS`](Self::BUCKETS) slots: slot `i`
+/// (`0..=15`) counts rollbacks of depth `i + 1`, and the final slot counts every
+/// rollback deeper than 16. Read individual buckets with [`bucket`](Self::bucket)
+/// or the grand total with [`total`](Self::total). Serializes as a JSON object
+/// keyed by each bucket's depth label (`"1"..="16"`, then `"17_plus"`), so the
+/// wire form is self-describing and stable across counter values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RollbackDepthHistogram([u64; Self::BUCKETS]);
+
+impl RollbackDepthHistogram {
+    /// The number of depth buckets: one per depth `1..=16` plus a final
+    /// catch-all for every rollback deeper than 16.
+    pub const BUCKETS: usize = 17;
+
+    /// The self-describing label for each bucket, in slot order. The final label
+    /// (`"17_plus"`) covers every rollback deeper than 16.
+    const LABELS: [&'static str; Self::BUCKETS] = [
+        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
+        "17_plus",
+    ];
+
+    /// The slot a rollback of `depth` frames falls into. Depths at or below 1 map
+    /// to the first bucket; depths above 16 saturate into the final bucket.
+    fn bucket_index(depth: usize) -> usize {
+        // Clamp into `1..=BUCKETS`, then shift to a zero-based slot: depth 1 → 0,
+        // depth 16 → 15, depth ≥ 17 → 16 (the "17_plus" catch-all).
+        depth.clamp(1, Self::BUCKETS).saturating_sub(1)
+    }
+
+    /// Records one rollback of `depth` frames, saturating the bucket at
+    /// [`u64::MAX`]. A `depth` of 0 (not a real rollback) is ignored.
+    fn record(&mut self, depth: usize) {
+        if depth == 0 {
+            return;
+        }
+        if let Some(slot) = self.0.get_mut(Self::bucket_index(depth)) {
+            *slot = slot.saturating_add(1);
+        }
+    }
+
+    /// The count recorded in bucket `index` (see the type docs for the bucket
+    /// layout). Returns 0 for an out-of-range index.
+    #[must_use]
+    pub fn bucket(&self, index: usize) -> u64 {
+        self.0.get(index).copied().unwrap_or(0)
+    }
+
+    /// The total number of rollbacks recorded across every bucket.
+    #[must_use]
+    pub fn total(&self) -> u64 {
+        self.0.iter().copied().fold(0u64, u64::saturating_add)
+    }
+}
+
+impl Default for RollbackDepthHistogram {
+    fn default() -> Self {
+        Self([0; Self::BUCKETS])
+    }
+}
+
+impl Serialize for RollbackDepthHistogram {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(Self::BUCKETS))?;
+        for (index, label) in Self::LABELS.into_iter().enumerate() {
+            map.serialize_entry(label, &self.bucket(index))?;
+        }
+        map.end()
+    }
+}
+
 /// A cumulative snapshot of session-level metrics.
 ///
 /// In normal use you read a snapshot from [`P2PSession::metrics`] or
@@ -231,6 +305,7 @@ impl Serialize for EventKindCounts {
 /// # use fortress_rollback::metrics::SessionMetrics;
 /// let metrics = SessionMetrics::default();
 /// assert_eq!(metrics.events_discarded_total, 0);
+/// assert_eq!(metrics.frames_advanced, 0);
 /// ```
 ///
 /// [`P2PSession::metrics`]: crate::P2PSession::metrics
@@ -239,6 +314,96 @@ impl Serialize for EventKindCounts {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
 #[must_use = "SessionMetrics should be inspected after being queried"]
 pub struct SessionMetrics {
+    /// Total frames the game state was stepped forward, counting **both** the
+    /// forward advances that produce a rendered frame
+    /// ([`visual_frames`](Self::visual_frames)) and the frames replayed during
+    /// rollbacks ([`resimulated_frames`](Self::resimulated_frames)). By
+    /// construction `frames_advanced == visual_frames + resimulated_frames`, so
+    /// the ratio `resimulated_frames / frames_advanced` is the fraction of
+    /// simulation work spent on rollback repair.
+    pub frames_advanced: u64,
+
+    /// The number of forward frame advances — one per
+    /// [`P2PSession::advance_frame`](crate::P2PSession::advance_frame) call that
+    /// steps the simulation to a new (never-before-simulated) frame. This is the
+    /// count of frames the application renders.
+    pub visual_frames: u64,
+
+    /// The number of frames re-simulated during rollbacks. Each rollback of
+    /// depth `d` re-simulates `d` frames, so this is the running sum of rollback
+    /// depths (see [`rollback_depth_histogram`](Self::rollback_depth_histogram)).
+    pub resimulated_frames: u64,
+
+    /// The number of rollbacks performed (a load-and-resimulate episode),
+    /// regardless of depth.
+    pub rollback_count: u64,
+
+    /// A histogram of rollback depths: how many rollbacks re-simulated 1 frame,
+    /// 2 frames, …, 16 frames, and more than 16 frames. Its
+    /// [`total`](RollbackDepthHistogram::total) equals
+    /// [`rollback_count`](Self::rollback_count).
+    pub rollback_depth_histogram: RollbackDepthHistogram,
+
+    /// The deepest single rollback observed (its number of re-simulated frames).
+    /// Stays 0 until the first rollback.
+    pub max_rollback_depth: u32,
+
+    /// The number of individual per-player prediction misses that triggered
+    /// rollback repair. One misprediction-driven rollback can count several
+    /// misses (one per player whose predicted input turned out wrong).
+    pub prediction_miss_count: u64,
+
+    /// The number of times an
+    /// [`advance_frame`](crate::P2PSession::advance_frame) call could not step
+    /// the simulation because the prediction window was already full (the session
+    /// is waiting for a slow or unreachable peer to confirm inputs). A rising
+    /// count means the local simulation is being throttled by the network.
+    pub stall_count: u64,
+
+    /// The number of [`FortressEvent::WaitRecommendation`] events emitted (the
+    /// session asked the application to slow down to let a peer catch up).
+    ///
+    /// [`FortressEvent::WaitRecommendation`]: crate::FortressEvent::WaitRecommendation
+    pub wait_recommendations: u64,
+
+    /// The most recently sampled confirmation lag: how many frames ahead of the
+    /// last confirmed frame the simulation was at the last forward advance. A
+    /// gauge, not a monotonic counter.
+    pub confirmation_lag_current: u64,
+
+    /// The maximum [`confirmation_lag_current`](Self::confirmation_lag_current)
+    /// observed over the life of the session.
+    pub confirmation_lag_max: u64,
+
+    /// The running sum of the per-advance confirmation lag samples. Divide by
+    /// [`visual_frames`](Self::visual_frames) for the mean confirmation lag.
+    pub confirmation_lag_sum: u64,
+
+    /// The number of confirmed-frame checksums compared against a peer's
+    /// checksum for desync detection. Zero unless
+    /// [`DesyncDetection`](crate::DesyncDetection) is enabled. Equals
+    /// [`checksums_matched`](Self::checksums_matched) `+`
+    /// [`checksums_mismatched`](Self::checksums_mismatched).
+    pub checksums_compared: u64,
+
+    /// How many compared checksums matched their peer's value.
+    pub checksums_matched: u64,
+
+    /// How many compared checksums disagreed with their peer's value (each also
+    /// emits a [`FortressEvent::DesyncDetected`]).
+    ///
+    /// [`FortressEvent::DesyncDetected`]: crate::FortressEvent::DesyncDetected
+    pub checksums_mismatched: u64,
+
+    /// The high-water mark of the event-queue length: the largest the bounded
+    /// event queue grew before the application drained it. Compare against the
+    /// configured event-queue size to see how close overflow (and the resulting
+    /// [`events_discarded_total`](Self::events_discarded_total)) came.
+    pub event_queue_high_water: u64,
+
+    /// The high-water mark of the local desync-checksum history length.
+    pub checksum_history_high_water: u64,
+
     /// Total number of queued [`FortressEvent`]s discarded because the bounded
     /// event queue overflowed before the application drained it.
     ///
@@ -271,6 +436,67 @@ impl SessionMetrics {
     pub(crate) fn record_event_discard(&mut self, kind: EventKind) {
         self.events_discarded_total = self.events_discarded_total.saturating_add(1);
         self.events_discarded_by_kind.record(kind);
+    }
+
+    /// Records one forward frame advance (a rendered/visual frame) and samples
+    /// the confirmation lag at that advance.
+    pub(crate) fn record_forward_advance(&mut self, confirmation_lag: u64) {
+        self.frames_advanced = self.frames_advanced.saturating_add(1);
+        self.visual_frames = self.visual_frames.saturating_add(1);
+        self.confirmation_lag_current = confirmation_lag;
+        self.confirmation_lag_max = self.confirmation_lag_max.max(confirmation_lag);
+        self.confirmation_lag_sum = self.confirmation_lag_sum.saturating_add(confirmation_lag);
+    }
+
+    /// Records one rollback that re-simulated `depth` frames.
+    pub(crate) fn record_rollback(&mut self, depth: usize) {
+        let depth_u64 = u64::try_from(depth).unwrap_or(u64::MAX);
+        self.rollback_count = self.rollback_count.saturating_add(1);
+        self.resimulated_frames = self.resimulated_frames.saturating_add(depth_u64);
+        self.frames_advanced = self.frames_advanced.saturating_add(depth_u64);
+        let depth_u32 = u32::try_from(depth).unwrap_or(u32::MAX);
+        self.max_rollback_depth = self.max_rollback_depth.max(depth_u32);
+        self.rollback_depth_histogram.record(depth);
+    }
+
+    /// Records `count` per-player prediction misses that triggered a rollback.
+    pub(crate) fn record_prediction_misses(&mut self, count: u64) {
+        self.prediction_miss_count = self.prediction_miss_count.saturating_add(count);
+    }
+
+    /// Records one prediction-window stall (an advance that could not step the
+    /// simulation because the prediction window was full).
+    pub(crate) fn record_stall(&mut self) {
+        self.stall_count = self.stall_count.saturating_add(1);
+    }
+
+    /// Records one emitted [`FortressEvent::WaitRecommendation`].
+    ///
+    /// [`FortressEvent::WaitRecommendation`]: crate::FortressEvent::WaitRecommendation
+    pub(crate) fn record_wait_recommendation(&mut self) {
+        self.wait_recommendations = self.wait_recommendations.saturating_add(1);
+    }
+
+    /// Records one confirmed-frame checksum comparison against a peer.
+    pub(crate) fn record_checksum_comparison(&mut self, matched: bool) {
+        self.checksums_compared = self.checksums_compared.saturating_add(1);
+        if matched {
+            self.checksums_matched = self.checksums_matched.saturating_add(1);
+        } else {
+            self.checksums_mismatched = self.checksums_mismatched.saturating_add(1);
+        }
+    }
+
+    /// Updates the event-queue high-water mark with an observed queue length.
+    pub(crate) fn observe_event_queue_len(&mut self, len: usize) {
+        let len = u64::try_from(len).unwrap_or(u64::MAX);
+        self.event_queue_high_water = self.event_queue_high_water.max(len);
+    }
+
+    /// Updates the checksum-history high-water mark with an observed length.
+    pub(crate) fn observe_checksum_history_len(&mut self, len: usize) {
+        let len = u64::try_from(len).unwrap_or(u64::MAX);
+        self.checksum_history_high_water = self.checksum_history_high_water.max(len);
     }
 
     /// Serializes this snapshot to a compact JSON string.
@@ -487,6 +713,113 @@ mod tests {
                 EventKind::PeerJoined
             );
         }
+    }
+
+    #[test]
+    fn rollback_histogram_buckets_depths_and_saturates_overflow() {
+        let mut hist = RollbackDepthHistogram::default();
+        assert_eq!(hist.total(), 0);
+        // depth 0 is not a real rollback and is ignored
+        hist.record(0);
+        assert_eq!(hist.total(), 0);
+        // depth d (1..=16) lands in slot d-1
+        for depth in 1..=16usize {
+            hist.record(depth);
+            assert_eq!(hist.bucket(depth - 1), 1, "depth {depth}");
+        }
+        // every depth > 16 saturates into the final "17_plus" bucket (index 16)
+        hist.record(17);
+        hist.record(100);
+        hist.record(usize::MAX);
+        assert_eq!(hist.bucket(16), 3);
+        assert_eq!(hist.total(), 16 + 3);
+        // out-of-range index reads as zero, never panics
+        assert_eq!(hist.bucket(RollbackDepthHistogram::BUCKETS), 0);
+        assert_eq!(hist.bucket(999), 0);
+    }
+
+    #[test]
+    fn record_rollback_keeps_frames_advanced_identity_and_max_depth() {
+        let mut m = SessionMetrics::new();
+        // Two forward advances and two rollbacks (depths 3 and 5).
+        m.record_forward_advance(1);
+        m.record_forward_advance(2);
+        m.record_rollback(3);
+        m.record_rollback(5);
+        assert_eq!(m.visual_frames, 2);
+        assert_eq!(m.resimulated_frames, 8);
+        // The core invariant: total simulation work = visual + resimulated.
+        assert_eq!(m.frames_advanced, m.visual_frames + m.resimulated_frames);
+        assert_eq!(m.frames_advanced, 10);
+        assert_eq!(m.rollback_count, 2);
+        assert_eq!(m.rollback_depth_histogram.total(), m.rollback_count);
+        assert_eq!(m.max_rollback_depth, 5);
+        assert_eq!(m.rollback_depth_histogram.bucket(2), 1); // depth 3
+        assert_eq!(m.rollback_depth_histogram.bucket(4), 1); // depth 5
+    }
+
+    #[test]
+    fn record_forward_advance_tracks_confirmation_lag_gauge_max_and_sum() {
+        let mut m = SessionMetrics::new();
+        m.record_forward_advance(5);
+        m.record_forward_advance(2);
+        m.record_forward_advance(9);
+        assert_eq!(m.confirmation_lag_current, 9); // gauge: last sample
+        assert_eq!(m.confirmation_lag_max, 9);
+        assert_eq!(m.confirmation_lag_sum, 16);
+        assert_eq!(m.visual_frames, 3);
+    }
+
+    #[test]
+    fn record_checksum_comparison_splits_matches_and_mismatches() {
+        let mut m = SessionMetrics::new();
+        m.record_checksum_comparison(true);
+        m.record_checksum_comparison(false);
+        m.record_checksum_comparison(true);
+        assert_eq!(m.checksums_compared, 3);
+        assert_eq!(m.checksums_matched, 2);
+        assert_eq!(m.checksums_mismatched, 1);
+        assert_eq!(
+            m.checksums_compared,
+            m.checksums_matched + m.checksums_mismatched
+        );
+    }
+
+    #[test]
+    fn high_water_marks_track_the_maximum_observed_length() {
+        let mut m = SessionMetrics::new();
+        m.observe_event_queue_len(3);
+        m.observe_event_queue_len(7);
+        m.observe_event_queue_len(4); // shrinking does not lower the mark
+        assert_eq!(m.event_queue_high_water, 7);
+        m.observe_checksum_history_len(10);
+        m.observe_checksum_history_len(2);
+        assert_eq!(m.checksum_history_high_water, 10);
+    }
+
+    #[test]
+    fn stall_prediction_miss_and_wait_recommendation_counters_saturate_up() {
+        let mut m = SessionMetrics::new();
+        m.record_stall();
+        m.record_stall();
+        m.record_prediction_misses(4);
+        m.record_prediction_misses(1);
+        m.record_wait_recommendation();
+        assert_eq!(m.stall_count, 2);
+        assert_eq!(m.prediction_miss_count, 5);
+        assert_eq!(m.wait_recommendations, 1);
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn rollback_histogram_serializes_as_labeled_depth_map() {
+        let mut m = SessionMetrics::new();
+        m.record_rollback(1);
+        m.record_rollback(17);
+        let json = m.to_json().expect("json serialization succeeds");
+        assert!(json.contains(r#""1":1"#), "{json}");
+        assert!(json.contains(r#""17_plus":1"#), "{json}");
+        assert!(json.contains(r#""frames_advanced":18"#), "{json}");
     }
 
     #[cfg(feature = "json")]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -465,6 +465,13 @@ impl SessionMetrics {
 
     /// Records one rollback that re-simulated `depth` frames.
     pub(crate) fn record_rollback(&mut self, depth: usize) {
+        debug_assert!(
+            depth > 0,
+            "record_rollback called with depth 0 — not a real rollback"
+        );
+        if depth == 0 {
+            return;
+        }
         let depth_u64 = u64::try_from(depth).unwrap_or(u64::MAX);
         self.rollback_count = self.rollback_count.saturating_add(1);
         self.resimulated_frames = self.resimulated_frames.saturating_add(depth_u64);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -299,6 +299,17 @@ impl Serialize for RollbackDepthHistogram {
 /// without a breaking change, so it cannot be built with a struct literal
 /// outside this crate — match with `..`.
 ///
+/// # Which counters each session type populates
+///
+/// The rollback and pacing counters (everything except the
+/// `events_discarded_*` family) are populated by [`P2PSession`]. A
+/// [`SpectatorSession`] shares this type but currently records only the
+/// event-discard counters (plus its own `frames_behind_host`, exposed
+/// separately); its rollback/pacing counters stay at their default `0`.
+///
+/// [`P2PSession`]: crate::P2PSession
+/// [`SpectatorSession`]: crate::SpectatorSession
+///
 /// # Example
 ///
 /// ```
@@ -321,6 +332,10 @@ pub struct SessionMetrics {
     /// construction `frames_advanced == visual_frames + resimulated_frames`, so
     /// the ratio `resimulated_frames / frames_advanced` is the fraction of
     /// simulation work spent on rollback repair.
+    ///
+    /// The one-time `AdvanceFrame` a hot-join joiner runs to bridge a loaded
+    /// snapshot up to its activation frame is a state-restoration step, not
+    /// steady-state simulation, and is deliberately not counted here.
     pub frames_advanced: u64,
 
     /// The number of forward frame advances — one per

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -1116,11 +1116,13 @@ impl<T: Config> P2PSession<T> {
                 .check_simulation_consistency(self.disconnect_frame);
             // if we have an incorrect frame, then we need to rollback
             if first_incorrect != Frame::NULL {
+                let misses = self
+                    .sync_layer
+                    .players_with_incorrect_predictions(self.disconnect_frame);
+                self.metrics
+                    .record_prediction_misses(u64::try_from(misses.len()).unwrap_or(u64::MAX));
                 if let Some(telemetry) = &self.telemetry {
-                    for (player, frame) in self
-                        .sync_layer
-                        .players_with_incorrect_predictions(self.disconnect_frame)
-                    {
+                    for (player, frame) in misses {
                         telemetry.on_prediction_miss(player, frame);
                     }
                 }
@@ -1243,14 +1245,29 @@ impl<T: Config> P2PSession<T> {
             self.local_inputs.clear();
             requests.push(FortressRequest::AdvanceFrame { inputs });
 
+            // Record the forward (visual) advance and sample confirmation lag:
+            // how many frames ahead of the last confirmed frame we now are.
+            let current = self.sync_layer.current_frame();
+            let last_confirmed = self.sync_layer.last_confirmed_frame();
+            let lag = if last_confirmed.is_null() {
+                current.as_i32()
+            } else {
+                current - last_confirmed
+            };
+            self.metrics
+                .record_forward_advance(u64::try_from(lag.max(0)).unwrap_or(0));
+
             if let Some(telemetry) = &self.telemetry {
-                telemetry.on_frame_advance(self.sync_layer.current_frame());
+                telemetry.on_frame_advance(current);
             }
         } else {
             debug!(
                 "Prediction Threshold reached. Skipping on frame {}",
                 self.sync_layer.current_frame()
             );
+            // A stall: the prediction window is full, so the network is
+            // throttling the local simulation (waiting on a peer to confirm).
+            self.metrics.record_stall();
         }
 
         Ok(requests)
@@ -2630,11 +2647,13 @@ impl<T: Config> P2PSession<T> {
             .sync_layer
             .check_simulation_consistency(self.disconnect_frame);
         if !first_incorrect.is_null() {
+            let misses = self
+                .sync_layer
+                .players_with_incorrect_predictions(self.disconnect_frame);
+            self.metrics
+                .record_prediction_misses(u64::try_from(misses.len()).unwrap_or(u64::MAX));
             if let Some(telemetry) = &self.telemetry {
-                for (player, frame) in self
-                    .sync_layer
-                    .players_with_incorrect_predictions(self.disconnect_frame)
-                {
+                for (player, frame) in misses {
                     telemetry.on_prediction_miss(player, frame);
                 }
             }
@@ -7822,6 +7841,7 @@ impl<T: Config> P2PSession<T> {
         let count = current_frame - load_target;
 
         if let Ok(depth) = usize::try_from(count) {
+            self.metrics.record_rollback(depth);
             if let Some(telemetry) = &self.telemetry {
                 telemetry.on_rollback(depth, load_target);
             }
@@ -9207,6 +9227,7 @@ impl<T: Config> P2PSession<T> {
             let skip_frames = self.frames_ahead.try_into().unwrap_or(0);
             self.event_queue
                 .push_back(FortressEvent::WaitRecommendation { skip_frames });
+            self.metrics.record_wait_recommendation();
         }
         // This runs from `advance_frame`, outside `handle_event`'s trim, so bound
         // the queue here too (D9: overflow must stay accounted + telemetered).
@@ -9709,6 +9730,9 @@ impl<T: Config> P2PSession<T> {
     /// many messages within one poll produces a single `Warning`, not one per
     /// message, while the always-incrementing counters keep the full history.
     fn trim_event_queue(&mut self) {
+        // Sample the queue length before trimming to capture the true peak
+        // (including any just-pushed overflow) as the high-water mark.
+        self.metrics.observe_event_queue_len(self.event_queue.len());
         let mut discarded = 0u64;
         while self.event_queue.len() > self.max_event_queue_size {
             if let Some(dropped) = self.event_queue.pop_front() {
@@ -9746,6 +9770,8 @@ impl<T: Config> P2PSession<T> {
                         if let Some(&local_checksum) =
                             self.local_checksum_history.get(&remote_frame)
                         {
+                            self.metrics
+                                .record_checksum_comparison(local_checksum == remote_checksum);
                             if local_checksum != remote_checksum {
                                 self.event_queue.push_back(FortressEvent::DesyncDetected {
                                     frame: remote_frame,
@@ -9874,6 +9900,10 @@ impl<T: Config> P2PSession<T> {
                         self.last_sent_checksum_frame = frame_to_send;
                         // collect locally for later comparison
                         self.local_checksum_history.insert(frame_to_send, checksum);
+                        // Record the peak history length (the momentary overshoot
+                        // before the size-cap prune below is the true high-water).
+                        self.metrics
+                            .observe_checksum_history_len(self.local_checksum_history.len());
                     }
 
                     let max_history = self.protocol_config.max_checksum_history;

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -1267,9 +1267,14 @@ impl<T: Config> P2PSession<T> {
                 "Prediction Threshold reached. Skipping on frame {}",
                 self.sync_layer.current_frame()
             );
-            // A stall: the prediction window is full, so the network is
+            // A prediction-window stall: the window is full, so the network is
             // throttling the local simulation (waiting on a peer to confirm).
-            self.metrics.record_stall();
+            // Lockstep mode waits for confirmed inputs by design — that is the
+            // mode's normal cadence, not a stall — so it is excluded to keep the
+            // counter's documented "prediction window was full" meaning exact.
+            if !lockstep {
+                self.metrics.record_stall();
+            }
         }
 
         Ok(requests)

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -7841,7 +7841,6 @@ impl<T: Config> P2PSession<T> {
         let count = current_frame - load_target;
 
         if let Ok(depth) = usize::try_from(count) {
-            self.metrics.record_rollback(depth);
             if let Some(telemetry) = &self.telemetry {
                 telemetry.on_rollback(depth, load_target);
             }
@@ -7905,6 +7904,13 @@ impl<T: Config> P2PSession<T> {
             // advance the frame
             self.sync_layer.advance_frame();
             requests.push(FortressRequest::AdvanceFrame { inputs });
+        }
+        // Record the rollback only after every re-simulated frame was actually
+        // advanced. A mid-loop internal error returns above without recording,
+        // so `resimulated_frames`/`frames_advanced` can never over-count the
+        // frames the application actually stepped.
+        if let Ok(depth) = usize::try_from(count) {
+            self.metrics.record_rollback(depth);
         }
         // after all this, we should have arrived at the same frame where we started
         let final_frame = self.sync_layer.current_frame();

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -1116,13 +1116,15 @@ impl<T: Config> P2PSession<T> {
                 .check_simulation_consistency(self.disconnect_frame);
             // if we have an incorrect frame, then we need to rollback
             if first_incorrect != Frame::NULL {
-                let misses = self
-                    .sync_layer
-                    .players_with_incorrect_predictions(self.disconnect_frame);
-                self.metrics
-                    .record_prediction_misses(u64::try_from(misses.len()).unwrap_or(u64::MAX));
+                self.metrics.record_prediction_misses(
+                    self.sync_layer
+                        .count_players_with_incorrect_predictions(self.disconnect_frame),
+                );
                 if let Some(telemetry) = &self.telemetry {
-                    for (player, frame) in misses {
+                    for (player, frame) in self
+                        .sync_layer
+                        .players_with_incorrect_predictions(self.disconnect_frame)
+                    {
                         telemetry.on_prediction_miss(player, frame);
                     }
                 }
@@ -2647,13 +2649,15 @@ impl<T: Config> P2PSession<T> {
             .sync_layer
             .check_simulation_consistency(self.disconnect_frame);
         if !first_incorrect.is_null() {
-            let misses = self
-                .sync_layer
-                .players_with_incorrect_predictions(self.disconnect_frame);
-            self.metrics
-                .record_prediction_misses(u64::try_from(misses.len()).unwrap_or(u64::MAX));
+            self.metrics.record_prediction_misses(
+                self.sync_layer
+                    .count_players_with_incorrect_predictions(self.disconnect_frame),
+            );
             if let Some(telemetry) = &self.telemetry {
-                for (player, frame) in misses {
+                for (player, frame) in self
+                    .sync_layer
+                    .players_with_incorrect_predictions(self.disconnect_frame)
+                {
                     telemetry.on_prediction_miss(player, frame);
                 }
             }

--- a/src/sync_layer/mod.rs
+++ b/src/sync_layer/mod.rs
@@ -1508,6 +1508,20 @@ impl<T: Config> SyncLayer<T> {
         first_incorrect
     }
 
+    /// Returns the number of players that have incorrect predictions at or before
+    /// `disconnect_frame`, without allocating. Used by always-on metrics counters.
+    pub(crate) fn count_players_with_incorrect_predictions(&self, disconnect_frame: Frame) -> u64 {
+        let mut count: u64 = 0;
+        for queue in self.input_queues.iter() {
+            let incorrect = queue.first_incorrect_frame();
+            if !incorrect.is_null() && (disconnect_frame.is_null() || incorrect <= disconnect_frame)
+            {
+                count = count.saturating_add(1);
+            }
+        }
+        count
+    }
+
     /// Returns the player handles that have incorrect predictions at or before `disconnect_frame`.
     /// Used by telemetry to identify which players' inputs were mispredicted.
     pub(crate) fn players_with_incorrect_predictions(

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -41,6 +41,85 @@ fn pr_smoke_four_player_mesh_holds_invariants() {
     run_smoke_fleet(4);
 }
 
+/// M2 §5.2: the always-on [`SessionMetrics`] counters must actually be wired to
+/// the paths they measure. The PR-smoke fleet runs mild-loss meshes for 600
+/// frames, which reliably drives rollbacks, prediction misses, and periodic
+/// desync-checksum comparisons. This asserts, per peer, the structural
+/// identities that must hold by construction, and mesh-wide that the network
+/// paths feeding these counters are exercised (so none is silently dead).
+#[test]
+fn session_metrics_are_wired_across_smoke_fleet() {
+    let mut total_visual = 0u64;
+    let mut total_rollbacks = 0u64;
+    let mut total_prediction_misses = 0u64;
+    let mut total_checksum_comparisons = 0u64;
+    let mut total_checksum_mismatches = 0u64;
+
+    for n_players in [2usize, 3, 4] {
+        for seed in PR_SMOKE_SEEDS {
+            let schedule = generate(seed, SimConfig::smoke(n_players));
+            let report = run(&schedule, &RunOptions::default());
+            report.expect_pass(&schedule);
+
+            for (i, m) in report.metrics.iter().enumerate() {
+                let ctx = || format!("peer {i} seed {seed} n{n_players}: {m:?}");
+                // Total simulation work splits exactly into forward (visual)
+                // advances plus rollback re-simulation.
+                assert_eq!(
+                    m.frames_advanced,
+                    m.visual_frames + m.resimulated_frames,
+                    "frames_advanced != visual + resimulated — {}",
+                    ctx()
+                );
+                // The depth histogram accounts for every rollback exactly once.
+                assert_eq!(
+                    m.rollback_depth_histogram.total(),
+                    m.rollback_count,
+                    "histogram total != rollback_count — {}",
+                    ctx()
+                );
+                // Checksum comparisons split cleanly into matches + mismatches.
+                assert_eq!(
+                    m.checksums_compared,
+                    m.checksums_matched + m.checksums_mismatched,
+                    "checksum split mismatch — {}",
+                    ctx()
+                );
+                // Every peer that reached a passing end-state advanced forward.
+                assert!(m.visual_frames > 0, "no forward advances — {}", ctx());
+                // A clean (green) run must never observe a checksum mismatch.
+                assert_eq!(
+                    m.checksums_mismatched,
+                    0,
+                    "unexpected checksum mismatch on a clean run — {}",
+                    ctx()
+                );
+
+                total_visual += m.visual_frames;
+                total_rollbacks += m.rollback_count;
+                total_prediction_misses += m.prediction_miss_count;
+                total_checksum_comparisons += m.checksums_compared;
+                total_checksum_mismatches += m.checksums_mismatched;
+            }
+        }
+    }
+
+    assert!(total_visual > 0, "fleet recorded no forward advances");
+    assert!(total_rollbacks > 0, "fleet recorded no rollbacks");
+    assert!(
+        total_prediction_misses > 0,
+        "fleet recorded no prediction misses"
+    );
+    assert!(
+        total_checksum_comparisons > 0,
+        "fleet recorded no checksum comparisons"
+    );
+    assert_eq!(
+        total_checksum_mismatches, 0,
+        "clean fleet must have zero checksum mismatches"
+    );
+}
+
 /// Meta-determinism: the same schedule must produce a bit-identical trace.
 /// This guards the harness itself — any hidden wall-clock read, unseeded RNG,
 /// or iteration-order nondeterminism in session, net, or harness breaks it.

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -54,6 +54,11 @@ fn session_metrics_are_wired_across_smoke_fleet() {
     let mut total_prediction_misses = 0u64;
     let mut total_checksum_comparisons = 0u64;
     let mut total_checksum_mismatches = 0u64;
+    let mut total_stalls = 0u64;
+    let mut total_wait_recs = 0u64;
+    let mut max_confirmation_lag = 0u64;
+    let mut max_event_queue_hw = 0u64;
+    let mut max_checksum_hw = 0u64;
 
     for n_players in [2usize, 3, 4] {
         for seed in PR_SMOKE_SEEDS {
@@ -100,6 +105,11 @@ fn session_metrics_are_wired_across_smoke_fleet() {
                 total_prediction_misses += m.prediction_miss_count;
                 total_checksum_comparisons += m.checksums_compared;
                 total_checksum_mismatches += m.checksums_mismatched;
+                total_stalls += m.stall_count;
+                total_wait_recs += m.wait_recommendations;
+                max_confirmation_lag = max_confirmation_lag.max(m.confirmation_lag_max);
+                max_event_queue_hw = max_event_queue_hw.max(m.event_queue_high_water);
+                max_checksum_hw = max_checksum_hw.max(m.checksum_history_high_water);
             }
         }
     }
@@ -117,6 +127,31 @@ fn session_metrics_are_wired_across_smoke_fleet() {
     assert_eq!(
         total_checksum_mismatches, 0,
         "clean fleet must have zero checksum mismatches"
+    );
+    // Wiring coverage for the pacing / high-water counters: mild loss over 600
+    // frames reliably drives prediction-window stalls and wait recommendations,
+    // runs the simulation ahead of confirmation, and fills the event queue and
+    // checksum history — so every one of these sites is proven reachable, not
+    // merely exercised by the direct-call unit tests.
+    assert!(
+        total_stalls > 0,
+        "fleet recorded no prediction-window stalls"
+    );
+    assert!(
+        total_wait_recs > 0,
+        "fleet recorded no wait recommendations"
+    );
+    assert!(
+        max_confirmation_lag > 0,
+        "fleet never sampled a non-zero confirmation lag"
+    );
+    assert!(
+        max_event_queue_hw > 0,
+        "fleet never recorded an event-queue high-water mark"
+    );
+    assert!(
+        max_checksum_hw > 0,
+        "fleet never recorded a checksum-history high-water mark"
     );
 }
 

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -54,6 +54,8 @@ pub struct RunReport {
     pub final_confirmed: Vec<i32>,
     /// Network delivery/drop counters.
     pub net_stats: crate::common::sim_net::SimNetStats,
+    /// Each peer's final [`SessionMetrics`] snapshot (indexed by peer).
+    pub metrics: Vec<fortress_rollback::SessionMetrics>,
 }
 
 impl RunReport {
@@ -385,11 +387,15 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
         fold_trace(&mut trace_hash, confirmed);
     }
 
+    let metrics: Vec<fortress_rollback::SessionMetrics> =
+        peers.iter().map(|slot| slot.session.metrics()).collect();
+
     let verdict = oracle.finalize(&recorded, &end_confirmed, &end_state);
     RunReport {
         verdict,
         trace_hash,
         final_confirmed,
         net_stats: net.stats(),
+        metrics,
     }
 }


### PR DESCRIPTION
## Summary

Advances **M2 §5.2** (metrics types). Session 64 landed the `SessionMetrics` foundation (event-discard telemetry) and the `metrics()` accessors; this PR wires the **session-level rollback and pacing counters** to the `P2PSession` paths they measure. Every new field lands with a live consuming site (no dead fields under `deny(warnings)`).

## New public surface (`src/metrics.rs`)

- **`RollbackDepthHistogram`** — `[u64; 17]`, buckets rollbacks by re-simulated depth `1..=16` then `17_plus`, serialized as a self-describing depth-keyed map (mirrors the existing `EventKindCounts` precedent). Re-exported from the crate root.
- **New `SessionMetrics` fields** (`#[non_exhaustive]`, so additive): `frames_advanced`, `visual_frames`, `resimulated_frames`, `rollback_count`, `rollback_depth_histogram`, `max_rollback_depth`, `prediction_miss_count`, `stall_count` (previously unobservable), `wait_recommendations`, `confirmation_lag_current/_max/_sum`, `checksums_compared/_matched/_mismatched`, `event_queue_high_water`, `checksum_history_high_water`.

Two identities hold **by construction** of the recording methods:
- `frames_advanced == visual_frames + resimulated_frames`
- `rollback_depth_histogram.total() == rollback_count`

## Wiring (`src/sessions/p2p_session.rs`, 8 sites)

Forward advance (+ confirmation-lag sample), prediction-threshold stall, rollback, misprediction detection (main **and** npeer-paused paths), wait recommendation, checksum comparison, and the event-queue / checksum-history high-water marks. All recorded **outside** the `if let Some(telemetry)` guards so counters are always-on. `players_with_incorrect_predictions()` is called once and reused for both the metric count and the telemetry loop.

## Tests

- **7 metrics unit tests**: histogram bucketing / overflow saturation, the `frames_advanced` identity, confirmation-lag gauge/max/sum, checksum split, high-water max-tracking, counter saturation, labeled-map JSON.
- **Fleet test** `session_metrics_are_wired_across_smoke_fleet`: `RunReport` now exposes each peer's final `SessionMetrics`; the test runs the PR-smoke fleet (N∈{2,3,4} × 8 seeds, mild loss / 600 frames) and asserts the structural identities per peer plus non-zero rollback / prediction-miss / checksum activity mesh-wide, with **zero** checksum mismatches on clean runs.

## Overhead gate (§5.2)

The existing criterion benches exercise `SyncTestSession`, which has **no** metrics instrumentation (verified by grep) — so they are unaffected by construction. The added `P2PSession` cost is a handful of saturating integer writes per advance/rollback.

## Validation

- clippy clean (`tokio,json` and `tokio,json,hot-join`)
- `cargo nextest run --features tokio,json` → 2359 passed
- `cargo nextest run --features tokio,json,hot-join` → 2597 passed
- Rustdoc private-items link check clean; `agent-preflight.py --auto-fix` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive metrics on existing hot paths (saturating integer updates only); no API breaks beyond new public types/fields on #[non_exhaustive] SessionMetrics.
> 
> **Overview**
> **M2 §5.2** extends always-on **`SessionMetrics`** beyond event-discard telemetry with **rollback and pacing counters** for **`P2PSession`**, plus a new public **`RollbackDepthHistogram`** (depth buckets `1..=16` and `17_plus`, JSON-friendly like **`EventKindCounts`**).
> 
> New fields cover simulation work (`frames_advanced`, `visual_frames`, `resimulated_frames`), rollbacks (`rollback_count`, histogram, `max_rollback_depth`, `prediction_miss_count`), network throttling (`stall_count`, `wait_recommendations`, confirmation-lag gauge/max/sum), desync checksum comparisons, and event-queue / checksum-history **high-water marks**. **`SpectatorSession`** keeps the same type but only event-discard counters are populated there.
> 
> **`P2PSession`** records these at eight sites—forward advance, prediction-window stall (non-lockstep), rollback completion, misprediction on normal and npeer-paused paths, wait recommendations, checksum compare, and high-water sampling—**outside** optional telemetry so counters stay always-on. **`SyncLayer::count_players_with_incorrect_predictions`** avoids extra allocation for miss counts.
> 
> Tests add metrics unit coverage (invariants, JSON) and **`session_metrics_are_wired_across_smoke_fleet`**, with **`RunReport.metrics`** exposing per-peer snapshots from the PR-smoke simulation fleet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 231726ad3f231682dc70ef46a11d1aa53eb18255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->