### PR TITLE
Hardening M2 §5.2: PeerMetrics per-peer wire-exact traffic + accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `confirmation_lag_current` / `_max` / `_sum` (per-advance samples of how far ahead of the confirmed frame
   the simulation runs), `checksums_compared` / `checksums_matched` / `checksums_mismatched` (desync-detection
   comparisons), and the `event_queue_high_water` / `checksum_history_high_water` container high-water marks.
-  All counters are always-on, allocation-free, and updated inline on the paths they measure.
+  All counters are always-on, allocation-free, and updated inline on the paths they measure. A companion
+  **per-peer** snapshot, `PeerMetrics` (read via `P2PSession::peer_metrics(handle)`), carries wire-exact
+  traffic counters for one remote peer or spectator: cumulative `bytes_sent` / `bytes_received` and
+  `packets_sent` / `packets_received`, a per-`MessageKind` breakdown of each direction
+  (`messages_sent_by_kind` / `messages_received_by_kind`, both `MessageKindCounts` serializing as a
+  self-describing label map, with `total()` equal to the matching packet counter), input
+  `input_bytes_pre_compression` / `input_bytes_post_compression` totals, and the instantaneous
+  `pending_output_len`, `pending_checksums_len`, `ping_ms`, and `remote_frame_advantage` gauges. `MessageKind`
+  is a payload-free mirror of the protocol's wire messages (`as_str()`, `ALL`, `COUNT`); `PeerMetrics` is
+  `#[non_exhaustive]` and offers `to_json()` / `to_json_pretty()` under the `json` feature. Byte counts are
+  payload-only (they exclude the per-packet UDP/IP header the `NetworkStats::kbps_sent` estimate folds in).
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,10 @@ pub use error::{
 /// ```
 pub type FortressResult<T, E = FortressError> = std::result::Result<T, E>;
 
-pub use metrics::{EventKind, EventKindCounts, RollbackDepthHistogram, SessionMetrics};
+pub use metrics::{
+    EventKind, EventKindCounts, MessageKind, MessageKindCounts, PeerMetrics,
+    RollbackDepthHistogram, SessionMetrics,
+};
 pub use network::chaos_socket::{ChaosConfig, ChaosConfigBuilder, ChaosSocket, ChaosStats};
 pub use network::messages::Message;
 pub use network::network_stats::NetworkStats;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,6 +6,11 @@
 //! the paths they measure — no timers, no allocation, no `Instant` — so reading
 //! them is deterministic and WASM-safe.
 //!
+//! [`PeerMetrics`] is the per-peer analogue, returned by
+//! [`P2PSession::peer_metrics`]: wire-exact byte and packet counters, a
+//! per-[`MessageKind`] breakdown of traffic in each direction, input-compression
+//! totals, and a few instantaneous connection gauges for one remote endpoint.
+//!
 //! The first surface exposed here is **event-queue overflow accounting**: when
 //! the bounded event queue discards an undrained [`FortressEvent`] the session
 //! records it in [`SessionMetrics::events_discarded_total`] and the per-category
@@ -14,6 +19,7 @@
 //! [`FortressEvent::DesyncDetected`] — is observable instead of silent.
 //!
 //! [`P2PSession::metrics`]: crate::P2PSession::metrics
+//! [`P2PSession::peer_metrics`]: crate::P2PSession::peer_metrics
 //! [`SpectatorSession::metrics`]: crate::SpectatorSession::metrics
 //! [`FortressEvent`]: crate::FortressEvent
 //! [`FortressEvent::Disconnected`]: crate::FortressEvent::Disconnected
@@ -543,6 +549,356 @@ impl SessionMetrics {
     }
 }
 
+/// The category of a protocol message, independent of its payload.
+///
+/// Mirrors the crate's internal wire-message variants one-to-one so per-peer
+/// traffic can be counted and labeled by kind — see
+/// [`PeerMetrics::messages_sent_by_kind`] and
+/// [`PeerMetrics::messages_received_by_kind`] — without exposing the internal
+/// message types.
+///
+/// The hot-join categories (`JoinRequest`, `StateSnapshot`, `StateSnapshotAck`,
+/// `ReactivateSlot`, `ReactivateSlotAck`, `JoinCommitted`, `JoinAborted`) exist
+/// only when the `hot-join` feature is enabled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageKind {
+    /// A synchronization request (part of the connection handshake).
+    SyncRequest,
+    /// A synchronization reply (part of the connection handshake).
+    SyncReply,
+    /// A player-input packet — the steady-state gameplay message.
+    Input,
+    /// An acknowledgement of received input.
+    InputAck,
+    /// A quality report (round-trip-time / frame-advantage probe).
+    QualityReport,
+    /// A quality reply — the pong answering a [`QualityReport`](Self::QualityReport).
+    QualityReply,
+    /// A confirmed-frame checksum report (desync detection).
+    ChecksumReport,
+    /// A keep-alive, sent when no other traffic is otherwise due.
+    KeepAlive,
+    /// A floor-round request (the double-failure-relay reorder fix).
+    FloorRequest,
+    /// A floor-round reply (the double-failure-relay reorder fix).
+    FloorReply,
+    /// A hot-join slot-occupancy request.
+    #[cfg(feature = "hot-join")]
+    JoinRequest,
+    /// A hot-join game-state snapshot.
+    #[cfg(feature = "hot-join")]
+    StateSnapshot,
+    /// A hot-join snapshot acknowledgement.
+    #[cfg(feature = "hot-join")]
+    StateSnapshotAck,
+    /// A hot-join slot-reactivation request.
+    #[cfg(feature = "hot-join")]
+    ReactivateSlot,
+    /// A hot-join slot-reactivation acknowledgement.
+    #[cfg(feature = "hot-join")]
+    ReactivateSlotAck,
+    /// A hot-join commit notification.
+    #[cfg(feature = "hot-join")]
+    JoinCommitted,
+    /// A hot-join abort notification.
+    #[cfg(feature = "hot-join")]
+    JoinAborted,
+}
+
+impl MessageKind {
+    /// The number of message categories.
+    ///
+    /// Varies with enabled features: seven additional categories exist when the
+    /// `hot-join` feature is on.
+    #[cfg(not(feature = "hot-join"))]
+    pub const COUNT: usize = 10;
+    /// The number of message categories.
+    ///
+    /// Varies with enabled features: seven additional categories exist when the
+    /// `hot-join` feature is on.
+    #[cfg(feature = "hot-join")]
+    pub const COUNT: usize = 17;
+
+    /// Every category, in declaration (wire-discriminant) order. Its length is
+    /// [`Self::COUNT`].
+    #[cfg(not(feature = "hot-join"))]
+    pub const ALL: [Self; Self::COUNT] = [
+        Self::SyncRequest,
+        Self::SyncReply,
+        Self::Input,
+        Self::InputAck,
+        Self::QualityReport,
+        Self::QualityReply,
+        Self::ChecksumReport,
+        Self::KeepAlive,
+        Self::FloorRequest,
+        Self::FloorReply,
+    ];
+    /// Every category, in declaration (wire-discriminant) order. Its length is
+    /// [`Self::COUNT`].
+    #[cfg(feature = "hot-join")]
+    pub const ALL: [Self; Self::COUNT] = [
+        Self::SyncRequest,
+        Self::SyncReply,
+        Self::Input,
+        Self::InputAck,
+        Self::QualityReport,
+        Self::QualityReply,
+        Self::ChecksumReport,
+        Self::KeepAlive,
+        Self::FloorRequest,
+        Self::FloorReply,
+        Self::JoinRequest,
+        Self::StateSnapshot,
+        Self::StateSnapshotAck,
+        Self::ReactivateSlot,
+        Self::ReactivateSlotAck,
+        Self::JoinCommitted,
+        Self::JoinAborted,
+    ];
+
+    /// A stable snake_case label for this category, suitable for logging or as a
+    /// metrics key. Matches the JSON key produced by serialization.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SyncRequest => "sync_request",
+            Self::SyncReply => "sync_reply",
+            Self::Input => "input",
+            Self::InputAck => "input_ack",
+            Self::QualityReport => "quality_report",
+            Self::QualityReply => "quality_reply",
+            Self::ChecksumReport => "checksum_report",
+            Self::KeepAlive => "keep_alive",
+            Self::FloorRequest => "floor_request",
+            Self::FloorReply => "floor_reply",
+            #[cfg(feature = "hot-join")]
+            Self::JoinRequest => "join_request",
+            #[cfg(feature = "hot-join")]
+            Self::StateSnapshot => "state_snapshot",
+            #[cfg(feature = "hot-join")]
+            Self::StateSnapshotAck => "state_snapshot_ack",
+            #[cfg(feature = "hot-join")]
+            Self::ReactivateSlot => "reactivate_slot",
+            #[cfg(feature = "hot-join")]
+            Self::ReactivateSlotAck => "reactivate_slot_ack",
+            #[cfg(feature = "hot-join")]
+            Self::JoinCommitted => "join_committed",
+            #[cfg(feature = "hot-join")]
+            Self::JoinAborted => "join_aborted",
+        }
+    }
+
+    /// The array index this category occupies in [`MessageKindCounts`]. Always
+    /// less than [`Self::COUNT`].
+    const fn index(self) -> usize {
+        match self {
+            Self::SyncRequest => 0,
+            Self::SyncReply => 1,
+            Self::Input => 2,
+            Self::InputAck => 3,
+            Self::QualityReport => 4,
+            Self::QualityReply => 5,
+            Self::ChecksumReport => 6,
+            Self::KeepAlive => 7,
+            Self::FloorRequest => 8,
+            Self::FloorReply => 9,
+            #[cfg(feature = "hot-join")]
+            Self::JoinRequest => 10,
+            #[cfg(feature = "hot-join")]
+            Self::StateSnapshot => 11,
+            #[cfg(feature = "hot-join")]
+            Self::StateSnapshotAck => 12,
+            #[cfg(feature = "hot-join")]
+            Self::ReactivateSlot => 13,
+            #[cfg(feature = "hot-join")]
+            Self::ReactivateSlotAck => 14,
+            #[cfg(feature = "hot-join")]
+            Self::JoinCommitted => 15,
+            #[cfg(feature = "hot-join")]
+            Self::JoinAborted => 16,
+        }
+    }
+}
+
+impl std::fmt::Display for MessageKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Per-[`MessageKind`] counters, keyed by category.
+///
+/// Backed by a fixed-size array (one slot per [`MessageKind`]); read individual
+/// counts with [`get`](Self::get) or the grand total with [`total`](Self::total).
+/// Serializes as a JSON object keyed by each category's [`MessageKind::as_str`]
+/// label, so the wire form is self-describing and stable across counter values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MessageKindCounts([u64; MessageKind::COUNT]);
+
+impl Default for MessageKindCounts {
+    fn default() -> Self {
+        Self([0; MessageKind::COUNT])
+    }
+}
+
+impl MessageKindCounts {
+    /// The count recorded for `kind`.
+    ///
+    /// `kind.index()` is always in bounds, so the `unwrap_or` fallback is
+    /// unreachable; it keeps the accessor panic-free without an index.
+    #[must_use]
+    pub fn get(&self, kind: MessageKind) -> u64 {
+        self.0.get(kind.index()).copied().unwrap_or(0)
+    }
+
+    /// The total number of messages recorded across every category.
+    ///
+    /// By construction this equals the corresponding packet counter
+    /// ([`PeerMetrics::packets_sent`] / [`PeerMetrics::packets_received`]): every
+    /// counted packet increments exactly one category bucket.
+    #[must_use]
+    pub fn total(&self) -> u64 {
+        self.0.iter().copied().fold(0u64, u64::saturating_add)
+    }
+
+    /// Increments the counter for `kind` by one, saturating at [`u64::MAX`].
+    pub(crate) fn record(&mut self, kind: MessageKind) {
+        if let Some(slot) = self.0.get_mut(kind.index()) {
+            *slot = slot.saturating_add(1);
+        }
+    }
+}
+
+impl Serialize for MessageKindCounts {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(MessageKind::COUNT))?;
+        for kind in MessageKind::ALL {
+            map.serialize_entry(kind.as_str(), &self.get(kind))?;
+        }
+        map.end()
+    }
+}
+
+/// A per-peer snapshot of protocol-level traffic and connection metrics for one
+/// remote endpoint.
+///
+/// Read one with [`P2PSession::peer_metrics`]. Like [`SessionMetrics`], this is a
+/// cheap `Copy` snapshot updated inline on the paths it measures — no timers, no
+/// allocation, no `Instant` — so reading it is deterministic and WASM-safe.
+///
+/// # Counters vs gauges
+///
+/// The byte, packet, message-kind, and input-compression fields are **cumulative
+/// counters**, monotonic for the life of the endpoint. The trailing four fields —
+/// [`pending_output_len`](Self::pending_output_len),
+/// [`pending_checksums_len`](Self::pending_checksums_len),
+/// [`ping_ms`](Self::ping_ms), and
+/// [`remote_frame_advantage`](Self::remote_frame_advantage) — are **instantaneous
+/// gauges** sampled at the moment of the snapshot.
+///
+/// Byte counts are wire-exact (the same arithmetic as the bandwidth accounting
+/// behind [`NetworkStats`](crate::NetworkStats)) and count payload bytes only —
+/// they exclude the per-packet UDP/IP header that
+/// [`NetworkStats::kbps_sent`](crate::NetworkStats::kbps_sent) folds into its
+/// estimate.
+///
+/// This type is `#[non_exhaustive]`: future library versions may add fields
+/// without a breaking change, so match with `..`.
+///
+/// [`P2PSession::peer_metrics`]: crate::P2PSession::peer_metrics
+/// [`SessionMetrics`]: crate::metrics::SessionMetrics
+///
+/// # Example
+///
+/// ```
+/// # use fortress_rollback::metrics::PeerMetrics;
+/// let metrics = PeerMetrics::default();
+/// assert_eq!(metrics.bytes_sent, 0);
+/// assert_eq!(metrics.packets_received, 0);
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[must_use = "PeerMetrics should be inspected after being queried"]
+pub struct PeerMetrics {
+    /// Total wire-exact payload bytes sent to this peer over the life of the
+    /// endpoint (payload only; see the type docs).
+    pub bytes_sent: u64,
+
+    /// Total wire-exact payload bytes received from this peer, counted for every
+    /// message delivered to the endpoint before any protocol-state filtering.
+    pub bytes_received: u64,
+
+    /// Total packets (messages) sent to this peer — equal to the
+    /// [`messages_sent_by_kind`](Self::messages_sent_by_kind) total.
+    pub packets_sent: u64,
+
+    /// Total packets (messages) received from this peer — equal to the
+    /// [`messages_received_by_kind`](Self::messages_received_by_kind) total.
+    pub packets_received: u64,
+
+    /// Per-[`MessageKind`] breakdown of [`packets_sent`](Self::packets_sent).
+    pub messages_sent_by_kind: MessageKindCounts,
+
+    /// Per-[`MessageKind`] breakdown of
+    /// [`packets_received`](Self::packets_received).
+    pub messages_received_by_kind: MessageKindCounts,
+
+    /// Cumulative raw input bytes batched into `Input` packets **before**
+    /// delta/RLE compression. Divide
+    /// [`input_bytes_post_compression`](Self::input_bytes_post_compression) by
+    /// this for the realized compression ratio.
+    pub input_bytes_pre_compression: u64,
+
+    /// Cumulative encoded input bytes placed on the wire in `Input` packets
+    /// **after** delta/RLE compression.
+    pub input_bytes_post_compression: u64,
+
+    /// **Gauge.** The number of input frames queued for (re)transmission that the
+    /// peer has not yet acknowledged — the connection-backpressure signal also
+    /// reported as
+    /// [`NetworkStats::send_queue_len`](crate::NetworkStats::send_queue_len).
+    pub pending_output_len: u64,
+
+    /// **Gauge.** The number of this peer's confirmed-frame checksums buffered
+    /// awaiting comparison against the local history.
+    pub pending_checksums_len: u64,
+
+    /// **Gauge.** The round-trip time to this peer in milliseconds, as most
+    /// recently measured by a quality-report exchange (the same value as
+    /// [`NetworkStats::ping`](crate::NetworkStats::ping)).
+    pub ping_ms: u128,
+
+    /// **Gauge.** The peer's most recently reported frame advantage over the
+    /// local client (the same value as
+    /// [`NetworkStats::remote_frames_behind`](crate::NetworkStats::remote_frames_behind)).
+    pub remote_frame_advantage: i32,
+}
+
+impl PeerMetrics {
+    /// Serializes this snapshot to a compact JSON string.
+    ///
+    /// Returns `None` if serialization fails — not expected for this small set of
+    /// integer counters, but not impossible (for example, an allocation failure
+    /// inside `serde_json`).
+    #[cfg(feature = "json")]
+    #[must_use]
+    pub fn to_json(&self) -> Option<String> {
+        serde_json::to_string(self).ok()
+    }
+
+    /// Serializes this snapshot to a pretty-printed JSON string.
+    ///
+    /// Like [`to_json`](Self::to_json), but indented for readability.
+    #[cfg(feature = "json")]
+    #[must_use]
+    pub fn to_json_pretty(&self) -> Option<String> {
+        serde_json::to_string_pretty(self).ok()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -854,5 +1210,80 @@ mod tests {
         // The per-kind breakdown is a self-describing, snake_case-keyed map.
         assert!(json.contains(r#""disconnected":1"#), "{json}");
         assert!(json.contains(r#""synchronized":0"#), "{json}");
+    }
+
+    #[test]
+    fn message_kind_all_len_matches_count() {
+        assert_eq!(MessageKind::ALL.len(), MessageKind::COUNT);
+    }
+
+    #[test]
+    fn message_kind_index_is_bijective_over_all() {
+        for (i, kind) in MessageKind::ALL.into_iter().enumerate() {
+            assert_eq!(kind.index(), i, "index of {kind:?}");
+        }
+    }
+
+    #[test]
+    fn message_kind_as_str_labels_are_unique_and_nonempty() {
+        let mut seen = std::collections::BTreeSet::new();
+        for kind in MessageKind::ALL {
+            assert!(!kind.as_str().is_empty());
+            assert!(
+                seen.insert(kind.as_str()),
+                "duplicate label {}",
+                kind.as_str()
+            );
+        }
+        assert_eq!(seen.len(), MessageKind::COUNT);
+    }
+
+    #[test]
+    fn message_kind_counts_record_get_and_total_saturate() {
+        let mut counts = MessageKindCounts::default();
+        assert_eq!(counts.total(), 0);
+        for kind in MessageKind::ALL {
+            assert_eq!(counts.get(kind), 0);
+        }
+        counts.record(MessageKind::Input);
+        counts.record(MessageKind::Input);
+        counts.record(MessageKind::KeepAlive);
+        assert_eq!(counts.get(MessageKind::Input), 2);
+        assert_eq!(counts.get(MessageKind::KeepAlive), 1);
+        assert_eq!(counts.get(MessageKind::SyncRequest), 0);
+        // The total is the sum across every category.
+        assert_eq!(counts.total(), 3);
+    }
+
+    #[test]
+    fn peer_metrics_default_is_zero() {
+        let m = PeerMetrics::default();
+        assert_eq!(m.bytes_sent, 0);
+        assert_eq!(m.bytes_received, 0);
+        assert_eq!(m.packets_sent, 0);
+        assert_eq!(m.packets_received, 0);
+        assert_eq!(m.messages_sent_by_kind.total(), 0);
+        assert_eq!(m.messages_received_by_kind.total(), 0);
+        assert_eq!(m.input_bytes_pre_compression, 0);
+        assert_eq!(m.input_bytes_post_compression, 0);
+        assert_eq!(m.pending_output_len, 0);
+        assert_eq!(m.pending_checksums_len, 0);
+        assert_eq!(m.ping_ms, 0);
+        assert_eq!(m.remote_frame_advantage, 0);
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn peer_metrics_serializes_kind_breakdown_as_labeled_map() {
+        let mut m = PeerMetrics {
+            packets_sent: 1,
+            ..Default::default()
+        };
+        m.messages_sent_by_kind.record(MessageKind::Input);
+        let json = m.to_json().expect("json serialization succeeds");
+        assert!(json.contains(r#""packets_sent":1"#), "{json}");
+        // The per-kind breakdown is a self-describing, snake_case-keyed map.
+        assert!(json.contains(r#""input":1"#), "{json}");
+        assert!(json.contains(r#""keep_alive":0"#), "{json}");
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -803,7 +803,18 @@ impl Serialize for MessageKindCounts {
 /// behind [`NetworkStats`](crate::NetworkStats)) and count payload bytes only —
 /// they exclude the per-packet UDP/IP header that
 /// [`NetworkStats::kbps_sent`](crate::NetworkStats::kbps_sent) folds into its
-/// estimate.
+/// estimate. Sent bytes/packets are tallied when a message is enqueued for the
+/// socket (mirroring the pre-existing `bytes_sent` accounting), received ones
+/// when a message is delivered to the endpoint.
+///
+/// # Per-endpoint attribution
+///
+/// Every counter is scoped to **one endpoint** (one remote peer or spectator).
+/// In the unusual configuration where the same address is registered as both a
+/// remote player and a spectator, each is a distinct endpoint with its own
+/// snapshot, so a single datagram delivered to that address is counted once per
+/// endpoint. Read per-peer values individually; do not sum `bytes_received`
+/// across handles expecting a single "total bytes off the wire".
 ///
 /// This type is `#[non_exhaustive]`: future library versions may add fields
 /// without a breaking change, so match with `..`.
@@ -847,9 +858,10 @@ pub struct PeerMetrics {
     pub messages_received_by_kind: MessageKindCounts,
 
     /// Cumulative raw input bytes batched into `Input` packets **before**
-    /// delta/RLE compression. Divide
+    /// delta/RLE compression. When non-zero, dividing
     /// [`input_bytes_post_compression`](Self::input_bytes_post_compression) by
-    /// this for the realized compression ratio.
+    /// this gives the realized compression ratio (it stays 0 until the first
+    /// input is sent).
     pub input_bytes_pre_compression: u64,
 
     /// Cumulative encoded input bytes placed on the wire in `Input` packets
@@ -871,9 +883,12 @@ pub struct PeerMetrics {
     /// [`NetworkStats::ping`](crate::NetworkStats::ping)).
     pub ping_ms: u128,
 
-    /// **Gauge.** The peer's most recently reported frame advantage over the
-    /// local client (the same value as
-    /// [`NetworkStats::remote_frames_behind`](crate::NetworkStats::remote_frames_behind)).
+    /// **Gauge.** The peer's most recently reported frame-advantage value — the
+    /// same quantity [`NetworkStats::remote_frames_behind`] surfaces (the remote
+    /// player's own estimate of the local↔remote frame gap; see that field for
+    /// the sign convention).
+    ///
+    /// [`NetworkStats::remote_frames_behind`]: crate::NetworkStats::remote_frames_behind
     pub remote_frame_advantage: i32,
 }
 

--- a/src/network/messages.rs
+++ b/src/network/messages.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::metrics::MessageKind;
 use crate::Frame;
 
 /// Connection status for a peer in the network protocol.
@@ -470,6 +471,40 @@ impl MessageBody {
 
         DISCRIMINANT + payload
     }
+
+    /// The payload-independent [`MessageKind`] category of this body.
+    ///
+    /// The `match` is wildcard-free: adding a `MessageBody` variant fails to
+    /// compile until it is categorized here (and, in lockstep, in
+    /// [`MessageKind`]).
+    pub(crate) fn kind(&self) -> MessageKind {
+        match self {
+            Self::SyncRequest(_) => MessageKind::SyncRequest,
+            Self::SyncReply(_) => MessageKind::SyncReply,
+            Self::Input(_) => MessageKind::Input,
+            Self::InputAck(_) => MessageKind::InputAck,
+            Self::QualityReport(_) => MessageKind::QualityReport,
+            Self::QualityReply(_) => MessageKind::QualityReply,
+            Self::ChecksumReport(_) => MessageKind::ChecksumReport,
+            Self::KeepAlive => MessageKind::KeepAlive,
+            Self::FloorRequest(_) => MessageKind::FloorRequest,
+            Self::FloorReply(_) => MessageKind::FloorReply,
+            #[cfg(feature = "hot-join")]
+            Self::JoinRequest(_) => MessageKind::JoinRequest,
+            #[cfg(feature = "hot-join")]
+            Self::StateSnapshot(_) => MessageKind::StateSnapshot,
+            #[cfg(feature = "hot-join")]
+            Self::StateSnapshotAck(_) => MessageKind::StateSnapshotAck,
+            #[cfg(feature = "hot-join")]
+            Self::ReactivateSlot(_) => MessageKind::ReactivateSlot,
+            #[cfg(feature = "hot-join")]
+            Self::ReactivateSlotAck(_) => MessageKind::ReactivateSlotAck,
+            #[cfg(feature = "hot-join")]
+            Self::JoinCommitted(_) => MessageKind::JoinCommitted,
+            #[cfg(feature = "hot-join")]
+            Self::JoinAborted(_) => MessageKind::JoinAborted,
+        }
+    }
 }
 
 impl Message {
@@ -484,6 +519,11 @@ impl Message {
     pub(crate) fn encoded_len(&self) -> usize {
         const HEADER: usize = 2; // MessageHeader { magic: u16 }
         HEADER + self.body.encoded_len()
+    }
+
+    /// The [`MessageKind`] category of this message's body.
+    pub(crate) fn kind(&self) -> MessageKind {
+        self.body.kind()
     }
 }
 
@@ -763,5 +803,110 @@ mod tests {
         };
         let debug = format!("{:?}", input);
         assert!(debug.contains("0x")); // Empty bytes should still show "0x" prefix
+    }
+
+    #[test]
+    fn message_body_kind_maps_every_variant() {
+        let cases: &[(MessageBody, MessageKind)] = &[
+            (
+                MessageBody::SyncRequest(SyncRequest::default()),
+                MessageKind::SyncRequest,
+            ),
+            (
+                MessageBody::SyncReply(SyncReply::default()),
+                MessageKind::SyncReply,
+            ),
+            (MessageBody::Input(Input::default()), MessageKind::Input),
+            (
+                MessageBody::InputAck(InputAck::default()),
+                MessageKind::InputAck,
+            ),
+            (
+                MessageBody::QualityReport(QualityReport::default()),
+                MessageKind::QualityReport,
+            ),
+            (
+                MessageBody::QualityReply(QualityReply::default()),
+                MessageKind::QualityReply,
+            ),
+            (
+                MessageBody::ChecksumReport(ChecksumReport::default()),
+                MessageKind::ChecksumReport,
+            ),
+            (MessageBody::KeepAlive, MessageKind::KeepAlive),
+            (
+                MessageBody::FloorRequest(FloorRequest::default()),
+                MessageKind::FloorRequest,
+            ),
+            (
+                MessageBody::FloorReply(FloorReply::default()),
+                MessageKind::FloorReply,
+            ),
+        ];
+        for (body, expected) in cases {
+            assert_eq!(body.kind(), *expected, "body.kind() for {body:?}");
+            // Message::kind() delegates to its body.
+            let msg = Message {
+                header: MessageHeader::default(),
+                body: body.clone(),
+            };
+            assert_eq!(msg.kind(), *expected, "Message::kind() for {body:?}");
+        }
+
+        #[cfg(feature = "hot-join")]
+        {
+            let hot_cases: &[(MessageBody, MessageKind)] = &[
+                (
+                    MessageBody::JoinRequest(JoinRequest { player_handle: 0 }),
+                    MessageKind::JoinRequest,
+                ),
+                (
+                    MessageBody::StateSnapshot(StateSnapshot {
+                        frame: Frame::NULL,
+                        num_players: 2,
+                        state_bytes: vec![],
+                        bridge_inputs: vec![],
+                        bridge_statuses: vec![],
+                        checksum: None,
+                    }),
+                    MessageKind::StateSnapshot,
+                ),
+                (
+                    MessageBody::StateSnapshotAck(StateSnapshotAck { frame: Frame::NULL }),
+                    MessageKind::StateSnapshotAck,
+                ),
+                (
+                    MessageBody::ReactivateSlot(ReactivateSlot {
+                        handle: 0,
+                        frame: Frame::NULL,
+                    }),
+                    MessageKind::ReactivateSlot,
+                ),
+                (
+                    MessageBody::ReactivateSlotAck(ReactivateSlotAck {
+                        handle: 0,
+                        frame: Frame::NULL,
+                    }),
+                    MessageKind::ReactivateSlotAck,
+                ),
+                (
+                    MessageBody::JoinCommitted(JoinCommitted {
+                        handle: 0,
+                        frame: Frame::NULL,
+                    }),
+                    MessageKind::JoinCommitted,
+                ),
+                (
+                    MessageBody::JoinAborted(JoinAborted {
+                        handle: 0,
+                        frame: Frame::NULL,
+                    }),
+                    MessageKind::JoinAborted,
+                ),
+            ];
+            for (body, expected) in hot_cases {
+                assert_eq!(body.kind(), *expected, "body.kind() for {body:?}");
+            }
+        }
     }
 }

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -13,6 +13,7 @@ pub use state::ProtocolState;
 
 use crate::error::{allocation_failed, SerializationErrorKind};
 use crate::frame_info::PlayerInput;
+use crate::metrics::{MessageKindCounts, PeerMetrics};
 use crate::network::codec;
 use crate::network::compression::{decode_with_max_len, try_encode};
 use crate::network::messages::{
@@ -225,6 +226,20 @@ where
     // ~4 GiB of cumulative traffic and corrupt `network_stats()`.
     packets_sent: u64,
     bytes_sent: u64,
+    // Per-peer receive accounting mirroring `packets_sent`/`bytes_sent`, surfaced
+    // (with the send counters) via `peer_metrics()`. Wire-exact through
+    // `Message::encoded_len`; same `u64` 32-bit-safety rationale as the send side.
+    packets_received: u64,
+    bytes_received: u64,
+    // Per-`MessageKind` send/receive tallies. Each stays in lockstep with the
+    // matching packet counter (one bucket increment per counted packet), so
+    // `messages_*_by_kind.total() == packets_*` by construction.
+    messages_sent_by_kind: MessageKindCounts,
+    messages_received_by_kind: MessageKindCounts,
+    // Cumulative raw (pre-compression) and encoded (post-compression) input bytes
+    // batched into `Input` packets, for realized-compression accounting.
+    input_bytes_pre_compression: u64,
+    input_bytes_post_compression: u64,
     round_trip_time: u128,
     /// Origin instant for quality-report `ping` timestamps, captured from the
     /// protocol clock at endpoint construction. The peer echoes `ping` back
@@ -722,6 +737,12 @@ impl<T: Config> UdpProtocol<T> {
             stats_start_time: now,
             packets_sent: 0,
             bytes_sent: 0,
+            packets_received: 0,
+            bytes_received: 0,
+            messages_sent_by_kind: MessageKindCounts::default(),
+            messages_received_by_kind: MessageKindCounts::default(),
+            input_bytes_pre_compression: 0,
+            input_bytes_post_compression: 0,
             round_trip_time: 0,
             ping_epoch_base: now,
             last_send_time: now,
@@ -854,6 +875,29 @@ impl<T: Config> UdpProtocol<T> {
             remote_checksum: None,
             checksums_match: None,
         })
+    }
+
+    /// A [`PeerMetrics`] snapshot for this endpoint.
+    ///
+    /// Unlike [`network_stats`](Self::network_stats), this never fails and is
+    /// valid from construction: the byte / packet / message-kind / compression
+    /// fields are always-on cumulative counters, and the remaining fields read
+    /// current endpoint state as instantaneous gauges.
+    pub(crate) fn peer_metrics(&self) -> PeerMetrics {
+        PeerMetrics {
+            bytes_sent: self.bytes_sent,
+            bytes_received: self.bytes_received,
+            packets_sent: self.packets_sent,
+            packets_received: self.packets_received,
+            messages_sent_by_kind: self.messages_sent_by_kind,
+            messages_received_by_kind: self.messages_received_by_kind,
+            input_bytes_pre_compression: self.input_bytes_pre_compression,
+            input_bytes_post_compression: self.input_bytes_post_compression,
+            pending_output_len: u64::try_from(self.pending_output.len()).unwrap_or(u64::MAX),
+            pending_checksums_len: u64::try_from(self.pending_checksums.len()).unwrap_or(u64::MAX),
+            ping_ms: self.round_trip_time,
+            remote_frame_advantage: self.remote_frame_advantage,
+        }
     }
 
     pub(crate) fn handles(&self) -> Arc<[PlayerHandle]> {
@@ -1565,16 +1609,24 @@ impl<T: Config> UdpProtocol<T> {
                     return;
                 },
             };
+            // Input-compression accounting (always-on): the pre-compression size
+            // is the sum of the raw per-frame input bytes batched into this send;
+            // the post size is the delta/RLE-encoded `body.bytes`. Their ratio is
+            // the realized compression, surfaced via `peer_metrics()`.
+            let pre_compression_bytes: usize = self
+                .pending_output
+                .iter()
+                .take(batch_len)
+                .map(|gi| gi.bytes.len())
+                .sum();
+            self.input_bytes_pre_compression = self
+                .input_bytes_pre_compression
+                .saturating_add(pre_compression_bytes as u64);
+            self.input_bytes_post_compression = self
+                .input_bytes_post_compression
+                .saturating_add(body.bytes.len() as u64);
             trace!(
-                "Encoded {} bytes from {} of {} pending output(s) into {} bytes",
-                {
-                    let mut sum = 0;
-                    for gi in self.pending_output.iter().take(batch_len) {
-                        sum += gi.bytes.len();
-                    }
-                    sum
-                },
-                batch_len,
+                "Encoded {pre_compression_bytes} bytes from {batch_len} of {} pending output(s) into {} bytes",
                 self.pending_output.len(),
                 body.bytes.len()
             );
@@ -1799,6 +1851,9 @@ impl<T: Config> UdpProtocol<T> {
         // Saturating so the lifetime counter degrades to a ceiling rather than
         // wrapping (or panicking under overflow-checks) on any target.
         self.bytes_sent = self.bytes_sent.saturating_add(msg.encoded_len() as u64);
+        // Per-kind send tally: one bucket per packet keeps
+        // `messages_sent_by_kind.total() == packets_sent`.
+        self.messages_sent_by_kind.record(msg.kind());
 
         // add the packet to the back of the send queue
         self.send_queue.push_back(msg);
@@ -1810,6 +1865,16 @@ impl<T: Config> UdpProtocol<T> {
 
     pub(crate) fn handle_message(&mut self, msg: &Message) {
         trace!("Handling message from {:?}: {:?}", self.peer_addr, msg);
+
+        // Per-peer receive accounting (always-on, wire-exact). Counted for every
+        // message delivered to this endpoint *before* any protocol-state filter
+        // below, so `bytes_received` reflects all traffic that arrived from this
+        // peer and `packets_received == messages_received_by_kind.total()` holds
+        // by construction (the send-side mirror of `queue_message`). Saturating so
+        // the lifetime counters degrade to a ceiling rather than wrapping.
+        self.packets_received = self.packets_received.saturating_add(1);
+        self.bytes_received = self.bytes_received.saturating_add(msg.encoded_len() as u64);
+        self.messages_received_by_kind.record(msg.kind());
 
         // don't handle messages if shutdown
         if self.state == ProtocolState::Shutdown {
@@ -4763,6 +4828,161 @@ mod tests {
         // This will likely fail because no time has passed
         // The actual behavior depends on timing
         assert!(result.is_ok() || matches!(result, Err(FortressError::NotSynchronized)));
+    }
+
+    // ==========================================
+    // Peer Metrics Tests (M2 §5.2)
+    // ==========================================
+
+    #[test]
+    fn peer_metrics_send_accounting_matches_wire_bytes_and_kinds() {
+        use crate::metrics::MessageKind;
+
+        let mut protocol: UdpProtocol<TestConfig> =
+            create_protocol(vec![PlayerHandle::new(0)], 2, 1, 8);
+
+        let bodies = [
+            MessageBody::KeepAlive,
+            MessageBody::QualityReply(QualityReply { pong: 7 }),
+            MessageBody::InputAck(InputAck {
+                ack_frame: Frame::new(3),
+            }),
+            MessageBody::KeepAlive,
+        ];
+        let mut expected_bytes = 0u64;
+        for body in &bodies {
+            // `queue_message` stamps the header magic itself; recompute the same
+            // wire size independently (magic does not affect `encoded_len`).
+            let msg = Message {
+                header: MessageHeader {
+                    magic: protocol.magic,
+                },
+                body: body.clone(),
+            };
+            expected_bytes += msg.encoded_len() as u64;
+            protocol.queue_message(body.clone());
+        }
+
+        let m = protocol.peer_metrics();
+        assert_eq!(m.packets_sent, bodies.len() as u64);
+        assert_eq!(m.bytes_sent, expected_bytes);
+        // One kind bucket per packet: the total equals the packet counter.
+        assert_eq!(m.messages_sent_by_kind.total(), m.packets_sent);
+        assert_eq!(m.messages_sent_by_kind.get(MessageKind::KeepAlive), 2);
+        assert_eq!(m.messages_sent_by_kind.get(MessageKind::QualityReply), 1);
+        assert_eq!(m.messages_sent_by_kind.get(MessageKind::InputAck), 1);
+        assert_eq!(m.messages_sent_by_kind.get(MessageKind::Input), 0);
+        // Nothing received yet.
+        assert_eq!(m.packets_received, 0);
+        assert_eq!(m.bytes_received, 0);
+    }
+
+    #[test]
+    fn peer_metrics_receive_accounting_counts_every_message_before_filters() {
+        use crate::metrics::MessageKind;
+
+        let mut protocol: UdpProtocol<TestConfig> =
+            create_protocol(vec![PlayerHandle::new(0)], 2, 1, 8);
+        // A magic mismatch (and, below, the Shutdown state) drops the message for
+        // handling — but receive accounting is counted first, so the byte/packet
+        // counters still advance. Pin the remote magic so the filter is active.
+        protocol.remote_magic = 999;
+
+        let bodies = [
+            MessageBody::KeepAlive,
+            MessageBody::QualityReport(QualityReport {
+                frame_advantage: 0,
+                ping: 5,
+            }),
+            MessageBody::KeepAlive,
+        ];
+        let mut expected_bytes = 0u64;
+        for body in &bodies {
+            let msg = Message {
+                header: MessageHeader { magic: 123 }, // wrong magic: filtered after counting
+                body: body.clone(),
+            };
+            expected_bytes += msg.encoded_len() as u64;
+            protocol.handle_message(&msg);
+        }
+
+        let m = protocol.peer_metrics();
+        assert_eq!(m.packets_received, bodies.len() as u64);
+        assert_eq!(m.bytes_received, expected_bytes);
+        assert_eq!(m.messages_received_by_kind.total(), m.packets_received);
+        assert_eq!(m.messages_received_by_kind.get(MessageKind::KeepAlive), 2);
+        assert_eq!(
+            m.messages_received_by_kind.get(MessageKind::QualityReport),
+            1
+        );
+
+        // Even a Shutdown endpoint (which returns before handling) counts the
+        // arriving traffic — the accounting is unconditional and precedes every
+        // protocol-state filter.
+        protocol.state = ProtocolState::Shutdown;
+        protocol.handle_message(&Message {
+            header: MessageHeader { magic: 999 },
+            body: MessageBody::KeepAlive,
+        });
+        assert_eq!(
+            protocol.peer_metrics().packets_received,
+            bodies.len() as u64 + 1
+        );
+    }
+
+    #[test]
+    fn peer_metrics_records_input_compression_bytes() {
+        // The endpoint serializes one local player of `u32` input, so the
+        // zeroed reference width is 4 bytes; pushed frames must match it.
+        let mut protocol: UdpProtocol<TestConfig> =
+            create_protocol(vec![PlayerHandle::new(0)], 2, 1, 8);
+        protocol.pending_output.push_back(InputBytes {
+            frame: Frame::new(0),
+            bytes: vec![1, 2, 3, 4],
+        });
+        protocol.pending_output.push_back(InputBytes {
+            frame: Frame::new(1),
+            bytes: vec![5, 6, 7, 8],
+        });
+
+        // Flush the batch: it is delta/RLE-encoded into one `Input` packet.
+        let connect_status = vec![ConnectionStatus::default(); 2];
+        protocol.send_pending_output(&connect_status);
+
+        let m = protocol.peer_metrics();
+        // Two 4-byte frames of raw input were batched before compression.
+        assert_eq!(
+            m.input_bytes_pre_compression, 8,
+            "pre-compression input bytes: {m:?}"
+        );
+        assert!(
+            m.input_bytes_post_compression > 0,
+            "no post-compression input bytes recorded: {m:?}"
+        );
+        // Exactly one Input packet went out, tallied by kind.
+        assert!(m.packets_sent > 0);
+        assert!(
+            m.messages_sent_by_kind
+                .get(crate::metrics::MessageKind::Input)
+                > 0
+        );
+        assert_eq!(m.messages_sent_by_kind.total(), m.packets_sent);
+    }
+
+    #[test]
+    fn peer_metrics_snapshot_reports_connection_gauges() {
+        let mut protocol: UdpProtocol<TestConfig> =
+            create_protocol(vec![PlayerHandle::new(0)], 2, 1, 8);
+        protocol.round_trip_time = 42;
+        protocol.remote_frame_advantage = -3;
+        protocol.pending_checksums.insert(Frame::new(1), 0xABCD);
+        protocol.pending_checksums.insert(Frame::new(2), 0x1234);
+
+        let m = protocol.peer_metrics();
+        assert_eq!(m.ping_ms, 42);
+        assert_eq!(m.remote_frame_advantage, -3);
+        assert_eq!(m.pending_checksums_len, 2);
+        assert_eq!(m.pending_output_len, protocol.pending_output.len() as u64);
     }
 
     // ==========================================

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -1,6 +1,6 @@
 use crate::error::{allocation_failed, FortressError, InternalErrorKind, InvalidRequestKind};
 use crate::frame_info::PlayerInput;
-use crate::metrics::SessionMetrics;
+use crate::metrics::{PeerMetrics, SessionMetrics};
 use crate::network::messages::ConnectionStatus;
 #[cfg(feature = "hot-join")]
 use crate::network::messages::StateSnapshot;
@@ -5617,6 +5617,41 @@ impl<T: Config> P2PSession<T> {
         self.populate_checksum_stats(&mut stats, player_handle);
 
         Ok(stats)
+    }
+
+    /// Returns a [`PeerMetrics`] snapshot of protocol-level traffic and
+    /// connection metrics for one remote peer or spectator.
+    ///
+    /// This complements [`network_stats`](Self::network_stats) with wire-exact,
+    /// always-on per-peer counters: cumulative bytes and packets sent/received, a
+    /// per-[`MessageKind`](crate::metrics::MessageKind) breakdown of traffic in
+    /// each direction, input pre/post-compression totals, plus a few
+    /// instantaneous connection gauges. Unlike `network_stats`, it does not
+    /// require the peer to be synchronized — the counters are valid from
+    /// endpoint construction.
+    ///
+    /// # Errors
+    /// - Returns a [`FortressError`] if the handle does not refer to a remote
+    ///   player or spectator.
+    pub fn peer_metrics(&self, player_handle: PlayerHandle) -> Result<PeerMetrics, FortressError> {
+        match self.player_reg.handles.get(&player_handle) {
+            Some(PlayerType::Remote(addr)) => match self.player_reg.remotes.get(addr) {
+                Some(endpoint) => Ok(endpoint.peer_metrics()),
+                None => Err(FortressError::InternalErrorStructured {
+                    kind: InternalErrorKind::EndpointNotFoundForRemote { player_handle },
+                }),
+            },
+            Some(PlayerType::Spectator(addr)) => match self.player_reg.spectators.get(addr) {
+                Some(endpoint) => Ok(endpoint.peer_metrics()),
+                None => Err(FortressError::InternalErrorStructured {
+                    kind: InternalErrorKind::EndpointNotFoundForSpectator { player_handle },
+                }),
+            },
+            _ => Err(InvalidRequestKind::NotRemotePlayerOrSpectator {
+                handle: player_handle,
+            }
+            .into()),
+        }
     }
 
     /// Populates the checksum-related fields in NetworkStats.

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -13,5 +13,6 @@ mod network {
     pub mod deterministic_ping;
     pub mod in_process_chaos;
     pub mod multi_process;
+    pub mod peer_metrics;
     pub mod resilience;
 }

--- a/tests/network/peer_metrics.rs
+++ b/tests/network/peer_metrics.rs
@@ -1,0 +1,134 @@
+//! Deterministic per-peer metrics ([`PeerMetrics`]) accounting tests.
+//!
+//! `P2PSession::peer_metrics` must report wire-exact, always-on per-peer
+//! counters routed through the real receive path (poll → endpoint
+//! `handle_message`), and — like ping measurement — must be bit-identical across
+//! repeated runs of the same virtual-time schedule (no wall-clock leakage), a
+//! prerequisite for deterministic whole-mesh simulation.
+//!
+//! Input-specific accounting (compression bytes, per-`MessageKind` tallies of a
+//! single message) is asserted exactly at the unit level in
+//! `network::protocol`; here the focus is the public accessor plus the
+//! poll → endpoint routing that feeds the received-side counters.
+
+// Allow test-specific patterns that are appropriate for test code
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+use crate::common::stubs::StubConfig;
+use crate::common::{
+    create_channel_pair, synchronize_sessions_deterministic, SyncConfig, TestClock,
+    POLL_INTERVAL_DETERMINISTIC,
+};
+use fortress_rollback::{
+    FortressError, PeerMetrics, PlayerHandle, PlayerType, ProtocolConfig, SessionBuilder,
+};
+
+/// Number of poll+advance iterations to run after synchronization — enough for
+/// several quality-report rounds to flow in both directions.
+const MEASUREMENT_ITERATIONS: usize = 40;
+
+/// Runs a fixed two-session schedule under virtual time and returns the final
+/// [`PeerMetrics`] each session reports for its single remote peer.
+fn measure_peer_metrics_over_fixed_schedule() -> Result<(PeerMetrics, PeerMetrics), FortressError> {
+    let clock = TestClock::new();
+    let (s1, s2, a1, a2) = create_channel_pair();
+
+    let protocol_config = |seed: u64| ProtocolConfig {
+        clock: Some(clock.as_protocol_clock()),
+        protocol_rng_seed: Some(seed),
+        ..ProtocolConfig::default()
+    };
+
+    let mut sess1 = SessionBuilder::<StubConfig>::new()
+        .with_protocol_config(protocol_config(101))
+        .add_player(PlayerType::Local, PlayerHandle::new(0))?
+        .add_player(PlayerType::Remote(a2), PlayerHandle::new(1))?
+        .start_p2p_session(s1)?;
+
+    let mut sess2 = SessionBuilder::<StubConfig>::new()
+        .with_protocol_config(protocol_config(202))
+        .add_player(PlayerType::Local, PlayerHandle::new(1))?
+        .add_player(PlayerType::Remote(a1), PlayerHandle::new(0))?
+        .start_p2p_session(s2)?;
+
+    synchronize_sessions_deterministic(&mut sess1, &mut sess2, &clock, &SyncConfig::default())
+        .expect("sessions should synchronize under virtual time");
+
+    for _ in 0..MEASUREMENT_ITERATIONS {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+        clock.advance(POLL_INTERVAL_DETERMINISTIC);
+    }
+
+    let m1 = sess1.peer_metrics(PlayerHandle::new(1))?;
+    let m2 = sess2.peer_metrics(PlayerHandle::new(0))?;
+    Ok((m1, m2))
+}
+
+/// End-to-end wiring: the receive path (poll → endpoint `handle_message`)
+/// populates the per-peer counters read back through the public accessor, and
+/// the send/receive per-kind tallies stay in lockstep with the packet counters.
+#[test]
+fn peer_metrics_account_for_bidirectional_traffic() -> Result<(), FortressError> {
+    let (m1, m2) = measure_peer_metrics_over_fixed_schedule()?;
+
+    for (label, m) in [("session 1", m1), ("session 2", m2)] {
+        assert!(m.packets_sent > 0, "{label}: no packets sent");
+        assert!(m.packets_received > 0, "{label}: no packets received");
+        assert!(m.bytes_sent > 0, "{label}: no bytes sent");
+        assert!(m.bytes_received > 0, "{label}: no bytes received");
+        // One kind bucket per packet, in each direction — the invariant the
+        // recording sites uphold by construction.
+        assert_eq!(
+            m.messages_sent_by_kind.total(),
+            m.packets_sent,
+            "{label}: sent kind total != packets_sent — {m:?}"
+        );
+        assert_eq!(
+            m.messages_received_by_kind.total(),
+            m.packets_received,
+            "{label}: received kind total != packets_received — {m:?}"
+        );
+    }
+    Ok(())
+}
+
+/// The same virtual-time schedule must produce bit-identical [`PeerMetrics`] on
+/// every run: per-peer accounting may not read any wall-clock source.
+#[test]
+fn peer_metrics_are_identical_across_runs() -> Result<(), FortressError> {
+    let first = measure_peer_metrics_over_fixed_schedule()?;
+    let second = measure_peer_metrics_over_fixed_schedule()?;
+    assert_eq!(
+        first, second,
+        "identical virtual schedules must report identical peer metrics"
+    );
+    Ok(())
+}
+
+/// The accessor validates the handle: a local player's own handle or an unknown
+/// handle is an error, never a silently-wrong or zeroed snapshot. A remote
+/// handle resolves even before any traffic (the counters are valid from
+/// endpoint construction).
+#[test]
+fn peer_metrics_rejects_non_remote_handles() -> Result<(), FortressError> {
+    let clock = TestClock::new();
+    let (s1, _s2, _a1, a2) = create_channel_pair();
+    let sess1 = SessionBuilder::<StubConfig>::new()
+        .with_protocol_config(ProtocolConfig {
+            clock: Some(clock.as_protocol_clock()),
+            protocol_rng_seed: Some(101),
+            ..ProtocolConfig::default()
+        })
+        .add_player(PlayerType::Local, PlayerHandle::new(0))?
+        .add_player(PlayerType::Remote(a2), PlayerHandle::new(1))?
+        .start_p2p_session(s1)?;
+
+    // The local player's own handle is not a remote/spectator.
+    assert!(sess1.peer_metrics(PlayerHandle::new(0)).is_err());
+    // An unknown handle is rejected.
+    assert!(sess1.peer_metrics(PlayerHandle::new(99)).is_err());
+    // The remote handle resolves.
+    assert!(sess1.peer_metrics(PlayerHandle::new(1)).is_ok());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

M2 §5.2 continued: adds the **per-peer** metrics surface (`PeerMetrics`), the deferred §5.1 receive-side wire accounting, and the `P2PSession::peer_metrics(handle)` accessor. Every counter lands with a live consuming site — no dead fields under `deny(warnings)`.

Builds on #189 (D1 wire-exact bandwidth), #190 (D9 event-discard telemetry), #191 (SessionMetrics rollback/pacing counters).

## What's new (public API)

- **`PeerMetrics`** (`#[non_exhaustive]`, `Copy`, `Serialize`, `to_json`/`to_json_pretty` under `json`) — a per-peer snapshot read via `P2PSession::peer_metrics(handle)`:
  - **Cumulative counters:** `bytes_sent`/`bytes_received`, `packets_sent`/`packets_received` (wire-exact via `Message::encoded_len`), `messages_sent_by_kind`/`messages_received_by_kind`, `input_bytes_pre_compression`/`input_bytes_post_compression`.
  - **Instantaneous gauges:** `pending_output_len`, `pending_checksums_len`, `ping_ms`, `remote_frame_advantage`.
- **`MessageKind`** — payload-free mirror of the wire message variants (`as_str()`/`ALL`/`COUNT`), the message analogue of `EventKind`.
- **`MessageKindCounts`** — per-kind array counter with `get()`/`total()` and a self-describing labeled-map `Serialize`.

## Wiring (single-site, always-on)

| Counter(s) | Site |
|---|---|
| `messages_sent_by_kind` | `queue_message` (with the existing `bytes_sent`/`packets_sent`) |
| `bytes_received`, `packets_received`, `messages_received_by_kind` | top of `handle_message`, **before** any protocol-state filter |
| `input_bytes_pre/post_compression` | `send_pending_output` compression site |

Counting receive before the shutdown/magic/state filters keeps `packets_received == messages_received_by_kind.total()` by construction and makes `bytes_received` a true wire-traffic meter (mirror of the send side). Verified there is exactly one production send site (`send_queue.push_back` in `queue_message`) and one production receive site (`handle_message`, via the poll paths).

## Design note

Dropped the plan's `PeerMetrics::send_queue_len`: it would collide in name with `NetworkStats::send_queue_len` (which actually reports `pending_output.len()`) while exposing only a transient internal flush buffer. `pending_output_len` — the real backpressure gauge — is kept.

## Tests

- `metrics`: `MessageKind`/`MessageKindCounts` structural + JSON tests, `PeerMetrics` default/serialization.
- `messages`: `message_body_kind_maps_every_variant` (all variants + `Message::kind()` delegation).
- `protocol`: exact send byte/kind identity, receive-counts-before-filters (incl. a Shutdown endpoint), input-compression bytes, connection gauges.
- `tests/network/peer_metrics.rs`: end-to-end 2-session routing populates the counters via the public accessor, per-kind totals equal packet counters, metrics are **bit-identical across runs** (no wall-clock leakage), and the accessor rejects local/unknown handles.

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json[,hot-join]` clean
- `cargo nextest run --features tokio,json` → 2373 passed; `+hot-join` → 2611 passed
- Rustdoc `--document-private-items` clean; `cargo test --doc` 159 passed
- `agent-preflight.py --auto-fix` all green (changelog-unreleased, version-sync, link-check, doc-claims, typos, …)

## Follow-ups (M2 §5.2 remainder)

- `SpectatorSession::peer_metrics()` subset and `HotJoinMetrics` (each with its own consuming site).
- §5.3 baseline sweep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only additions on existing send/receive paths; no wire-format or session-behavior changes. Handle validation errors are explicit for non-remote handles.
> 
> **Overview**
> This PR extends session metrics with a **per-peer** surface: **`PeerMetrics`** (via **`P2PSession::peer_metrics(handle)`**) plus **`MessageKind`** / **`MessageKindCounts`** for labeled traffic breakdowns. Snapshots include cumulative payload bytes and packets (send/receive), per-kind counts, input pre/post-compression totals, and gauges (`pending_output_len`, `pending_checksums_len`, `ping_ms`, `remote_frame_advantage`). Unlike **`network_stats`**, peer metrics do not require synchronization.
> 
> Protocol endpoints now increment receive counters at the **start** of **`handle_message`** (before magic/shutdown filters), send-side kind tallies in **`queue_message`**, and compression byte totals when flushing **`Input`** batches. **`MessageBody::kind()`** / **`Message::kind()`** tie wire messages to **`MessageKind`**.
> 
> New unit and integration tests cover kind mapping, accounting invariants, and deterministic two-session **`peer_metrics`** behavior; the changelog documents the public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 441ce79e6ac7208b3c5cdb7236ae0045efa23fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->