### PR TITLE
Hardening M2 §5.3 prep: per-peer wire-metrics aggregation in the DST harness

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -155,6 +155,96 @@ fn session_metrics_are_wired_across_smoke_fleet() {
     );
 }
 
+/// M2 §5.3 prep: the mesh runner now folds each peer's per-remote
+/// [`PeerMetrics`](fortress_rollback::PeerMetrics) into a per-player
+/// `PeerWireTotals` — the bandwidth ledger the baseline sweep consumes. This
+/// asserts, per peer, the by-kind/packet identities that hold by construction
+/// (the aggregation preserves them), and mesh-wide that real wire traffic
+/// flowed — exercising `P2PSession::peer_metrics` end-to-end under randomized
+/// simulation, not just the direct-call unit tests.
+#[test]
+fn peer_wire_metrics_are_wired_across_smoke_fleet() {
+    use fortress_rollback::MessageKind;
+
+    let mut total_bytes_sent = 0u64;
+    let mut total_input_msgs = 0u64;
+    let mut total_input_pre = 0u64;
+    let mut total_input_post = 0u64;
+
+    for n_players in [2usize, 3, 4] {
+        for seed in PR_SMOKE_SEEDS {
+            let schedule = generate(seed, SimConfig::smoke(n_players));
+            let report = run(&schedule, &RunOptions::default());
+            report.expect_pass(&schedule);
+
+            assert_eq!(
+                report.peer_wire.len(),
+                n_players,
+                "one wire ledger per peer — seed {seed} n{n_players}"
+            );
+            for (i, w) in report.peer_wire.iter().enumerate() {
+                let ctx = || format!("peer {i} seed {seed} n{n_players}: {w:?}");
+                // The per-kind buckets partition the packet counters exactly —
+                // aggregation across links preserves the per-link identity.
+                assert_eq!(
+                    w.sent_by_kind_total(),
+                    w.packets_sent,
+                    "sent by-kind total != packets_sent — {}",
+                    ctx()
+                );
+                assert_eq!(
+                    w.received_by_kind_total(),
+                    w.packets_received,
+                    "received by-kind total != packets_received — {}",
+                    ctx()
+                );
+                // Every peer in a live mesh both puts bytes on and takes bytes
+                // off the wire.
+                assert!(
+                    w.packets_sent > 0 && w.bytes_sent > 0,
+                    "no outbound wire traffic — {}",
+                    ctx()
+                );
+                assert!(
+                    w.packets_received > 0 && w.bytes_received > 0,
+                    "no inbound wire traffic — {}",
+                    ctx()
+                );
+                // The gameplay stream rides Input packets in both directions —
+                // must be non-trivial each way.
+                assert!(
+                    w.sent_by_kind(MessageKind::Input) > 0,
+                    "no Input packets sent — {}",
+                    ctx()
+                );
+                assert!(
+                    w.received_by_kind(MessageKind::Input) > 0,
+                    "no Input packets received — {}",
+                    ctx()
+                );
+
+                total_bytes_sent += w.bytes_sent;
+                total_input_msgs += w.sent_by_kind(MessageKind::Input);
+                total_input_pre += w.input_bytes_pre_compression;
+                total_input_post += w.input_bytes_post_compression;
+            }
+        }
+    }
+
+    assert!(total_bytes_sent > 0, "fleet put no bytes on the wire");
+    assert!(total_input_msgs > 0, "fleet sent no Input packets");
+    // The input-compression hook is wired on the send path: both pre- and
+    // post-compression byte totals are recorded for the gameplay stream.
+    assert!(
+        total_input_pre > 0,
+        "no pre-compression input bytes recorded"
+    );
+    assert!(
+        total_input_post > 0,
+        "no post-compression input bytes recorded"
+    );
+}
+
 /// Meta-determinism: the same schedule must produce a bit-identical trace.
 /// This guards the harness itself — any hidden wall-clock read, unseeded RNG,
 /// or iteration-order nondeterminism in session, net, or harness breaks it.

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -501,6 +501,10 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 if j == i {
                     continue;
                 }
+                // Peer `i` registered `PlayerHandle::new(j)` as a remote for
+                // every `j != i` (see the builder loop above), so this MUST
+                // resolve. An error is a real invariant break — fail loudly
+                // rather than silently under-counting a bandwidth regression.
                 let pm = slot
                     .session
                     .peer_metrics(PlayerHandle::new(j))

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -24,7 +24,8 @@ use fortress_rollback::hash::fnv1a_hash;
 use fortress_rollback::telemetry::{CollectingObserver, ViolationSeverity};
 use fortress_rollback::{
     DesyncDetection, FortressEvent, FortressRequest, Frame, GameStateCell, InputVec, Message,
-    P2PSession, PlayerHandle, PlayerType, ProtocolConfig, RequestVec, SessionBuilder, SessionState,
+    MessageKind, P2PSession, PeerMetrics, PlayerHandle, PlayerType, ProtocolConfig, RequestVec,
+    SessionBuilder, SessionState,
 };
 use oracle::{Oracle, Verdict};
 use schedule::{Schedule, ScheduleEvent};
@@ -56,6 +57,102 @@ pub struct RunReport {
     pub net_stats: crate::common::sim_net::SimNetStats,
     /// Each peer's final [`SessionMetrics`] snapshot (indexed by peer).
     pub metrics: Vec<fortress_rollback::SessionMetrics>,
+    /// Each peer's wire-traffic totals, aggregated over all of that peer's
+    /// remote links from the always-on `PeerMetrics` counters (indexed by peer).
+    /// This is the per-player bandwidth ledger the M2 baseline sweep consumes.
+    pub peer_wire: Vec<PeerWireTotals>,
+}
+
+/// One peer's cumulative wire traffic, summed across every remote link it holds.
+///
+/// The mesh runner reads each peer session's per-remote [`PeerMetrics`] at
+/// end-of-run and folds them into these totals, so a single value describes how
+/// much a player put on / took off the wire regardless of mesh size. Byte counts
+/// are wire-exact and payload-only (they match `PeerMetrics`, excluding UDP/IP
+/// headers). The `messages_{sent,received}_by_kind` arrays are positional in
+/// [`MessageKind::ALL`] order; read them by category with
+/// [`sent_by_kind`](Self::sent_by_kind) / [`received_by_kind`](Self::received_by_kind).
+#[derive(Clone, Debug, Default)]
+pub struct PeerWireTotals {
+    pub bytes_sent: u64,
+    pub bytes_received: u64,
+    pub packets_sent: u64,
+    pub packets_received: u64,
+    pub messages_sent_by_kind: [u64; MessageKind::COUNT],
+    pub messages_received_by_kind: [u64; MessageKind::COUNT],
+    pub input_bytes_pre_compression: u64,
+    pub input_bytes_post_compression: u64,
+}
+
+impl PeerWireTotals {
+    /// Folds one remote link's [`PeerMetrics`] snapshot into these totals.
+    ///
+    /// Cumulative counters add; the trailing gauges (`pending_*`, `ping_ms`,
+    /// `remote_frame_advantage`) are deliberately dropped — an instantaneous
+    /// gauge is not additive across links.
+    fn add(&mut self, m: &PeerMetrics) {
+        self.bytes_sent = self.bytes_sent.saturating_add(m.bytes_sent);
+        self.bytes_received = self.bytes_received.saturating_add(m.bytes_received);
+        self.packets_sent = self.packets_sent.saturating_add(m.packets_sent);
+        self.packets_received = self.packets_received.saturating_add(m.packets_received);
+        // Both arrays are laid out in `MessageKind::ALL` order (the same order
+        // used to read them back), independent of the crate-private
+        // `MessageKind::index`.
+        for (slot, kind) in self.messages_sent_by_kind.iter_mut().zip(MessageKind::ALL) {
+            *slot = slot.saturating_add(m.messages_sent_by_kind.get(kind));
+        }
+        for (slot, kind) in self
+            .messages_received_by_kind
+            .iter_mut()
+            .zip(MessageKind::ALL)
+        {
+            *slot = slot.saturating_add(m.messages_received_by_kind.get(kind));
+        }
+        self.input_bytes_pre_compression = self
+            .input_bytes_pre_compression
+            .saturating_add(m.input_bytes_pre_compression);
+        self.input_bytes_post_compression = self
+            .input_bytes_post_compression
+            .saturating_add(m.input_bytes_post_compression);
+    }
+
+    /// Messages of `kind` sent, summed across links.
+    #[must_use]
+    pub fn sent_by_kind(&self, kind: MessageKind) -> u64 {
+        MessageKind::ALL
+            .iter()
+            .position(|k| *k == kind)
+            .and_then(|i| self.messages_sent_by_kind.get(i).copied())
+            .unwrap_or(0)
+    }
+
+    /// Messages of `kind` received, summed across links.
+    #[must_use]
+    pub fn received_by_kind(&self, kind: MessageKind) -> u64 {
+        MessageKind::ALL
+            .iter()
+            .position(|k| *k == kind)
+            .and_then(|i| self.messages_received_by_kind.get(i).copied())
+            .unwrap_or(0)
+    }
+
+    /// Total messages sent across all kinds (equals [`Self::packets_sent`]).
+    #[must_use]
+    pub fn sent_by_kind_total(&self) -> u64 {
+        self.messages_sent_by_kind
+            .iter()
+            .copied()
+            .fold(0u64, u64::saturating_add)
+    }
+
+    /// Total messages received across all kinds (equals [`Self::packets_received`]).
+    #[must_use]
+    pub fn received_by_kind_total(&self) -> u64 {
+        self.messages_received_by_kind
+            .iter()
+            .copied()
+            .fold(0u64, u64::saturating_add)
+    }
 }
 
 impl RunReport {
@@ -390,6 +487,28 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     let metrics: Vec<fortress_rollback::SessionMetrics> =
         peers.iter().map(|slot| slot.session.metrics()).collect();
 
+    // Aggregate each peer's per-remote wire metrics into one per-player total.
+    // Peer `i` holds a remote handle `PlayerHandle::new(j)` for every `j != i`
+    // (see the builder loop above); `peer_metrics` succeeds for any remote
+    // handle regardless of sync state.
+    let n_players = schedule.config.n_players;
+    let peer_wire: Vec<PeerWireTotals> = peers
+        .iter()
+        .enumerate()
+        .map(|(i, slot)| {
+            let mut totals = PeerWireTotals::default();
+            for j in 0..n_players {
+                if j == i {
+                    continue;
+                }
+                if let Ok(pm) = slot.session.peer_metrics(PlayerHandle::new(j)) {
+                    totals.add(&pm);
+                }
+            }
+            totals
+        })
+        .collect();
+
     let verdict = oracle.finalize(&recorded, &end_confirmed, &end_state);
     RunReport {
         verdict,
@@ -397,5 +516,6 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
         final_confirmed,
         net_stats: net.stats(),
         metrics,
+        peer_wire,
     }
 }

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -501,9 +501,13 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 if j == i {
                     continue;
                 }
-                if let Ok(pm) = slot.session.peer_metrics(PlayerHandle::new(j)) {
-                    totals.add(&pm);
-                }
+                let pm = slot
+                    .session
+                    .peer_metrics(PlayerHandle::new(j))
+                    .unwrap_or_else(|e| {
+                        panic!("peer {i}: peer_metrics(handle={j}) failed unexpectedly: {e:?}")
+                    });
+                totals.add(&pm);
             }
             totals
         })


### PR DESCRIPTION
## Summary

Foundational step toward the M2 §5.3 baseline sweep, which needs a per-player **bandwidth ledger**. Today the simulation runner's `RunReport` carries only `SessionMetrics`; the wire-level counters (bytes/packets/by-kind) live on each session's per-remote `PeerMetrics`, which the harness consumes and drops.

This adds the aggregation and a fleet consumer — no production or public-API change (test infrastructure only).

## Change

- **`RunReport.peer_wire: Vec<PeerWireTotals>`** — each peer's per-remote `PeerMetrics` folded into one per-player total: bytes/packets sent+received, per-`MessageKind` breakdown, and input pre/post-compression bytes. Aggregation runs at end-of-run over the peer's remote handles (`PlayerHandle::new(j)` for `j != i`; `peer_metrics` succeeds for any remote handle regardless of sync state).
  - By-kind arrays are positional in `MessageKind::ALL` order (the crate-private `MessageKind::index()` is unreachable from tests); `sent_by_kind` / `received_by_kind` read them by category. Instantaneous gauges (`pending_*`, `ping_ms`, `remote_frame_advantage`) are deliberately dropped — they are not additive across links.
- **Consumer:** `peer_wire_metrics_are_wired_across_smoke_fleet` asserts, per peer, the by-kind == packet-count identities (preserved by aggregation) and that real **bidirectional** wire traffic flowed (Input packets each way). This exercises `P2PSession::peer_metrics` end-to-end under randomized simulation — previously only covered by direct-call unit tests.

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json` — clean.
- `cargo nextest run -E 'test(simulation::)'` — 27 passed; `--features hot-join` (17-variant `MessageKind`) — 27 passed. New test green both feature sets.
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass.

The `peer_wire` field is deterministic and deliberately excluded from `trace_hash` (it's a metric, not a correctness invariant), so meta-determinism is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness and fleet assertions; no production or public API changes.
> 
> **Overview**
> Adds a **per-player bandwidth ledger** to the deterministic simulation harness so upcoming M2 §5.3 baseline sweeps can read wire totals from `RunReport` instead of dropping per-remote `PeerMetrics`.
> 
> **`RunReport.peer_wire`** holds one `PeerWireTotals` per peer, built at end-of-run by summing `P2PSession::peer_metrics` across every remote handle (`j != i`). Totals include bytes/packets sent and received, per-`MessageKind` counts (via `MessageKind::ALL` layout), and input pre/post-compression bytes; non-additive gauges (`pending_*`, ping, frame advantage) are omitted.
> 
> **`peer_wire_metrics_are_wired_across_smoke_fleet`** runs the PR smoke fleet (2–4 players, fixed seeds) and checks aggregation invariants (by-kind sums match packet counts), bidirectional traffic, Input traffic both ways, and non-zero compression byte counters—exercising `peer_metrics` end-to-end under randomized mesh sim. **`peer_wire` is not folded into `trace_hash`**, so meta-determinism tests stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f7e691babd3876edbcc479a69a5ea75725daf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->