### PR TITLE
Hardening M2 §5.2: HotJoinMetrics — joiner hot-join handshake latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Spectators expose the same per-host wire metrics via `SpectatorSession::peer_metrics(host_index)`, which
   returns `Option<PeerMetrics>` (`None` for an out-of-range index) — hosts are addressed by dense index in
   `0..num_hosts()` in builder-priority order, since a spectator has no player handles for its upstream hosts.
+- With the `hot-join` feature, `P2PSession::hot_join_metrics() -> Option<HotJoinMetrics>` reports a joiner's
+  hot-join handshake latency: `completed` (whether the joiner applied the host snapshot and reached
+  `Running`), `polls_to_running` (`poll_remote_clients` iterations spent `HotJoining`), and
+  `millis_to_running` (elapsed time on the injectable protocol clock, so it is deterministic under the
+  simulation harness). Returns `None` for any session that did not hot-join (a host, or a peer that
+  synchronized normally). `HotJoinMetrics` is `#[non_exhaustive]`, `Copy`, and offers `to_json()` /
+  `to_json_pretty()` under the `json` feature.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,8 @@ pub use error::{
 /// ```
 pub type FortressResult<T, E = FortressError> = std::result::Result<T, E>;
 
+#[cfg(feature = "hot-join")]
+pub use metrics::HotJoinMetrics;
 pub use metrics::{
     EventKind, EventKindCounts, MessageKind, MessageKindCounts, PeerMetrics,
     RollbackDepthHistogram, SessionMetrics,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -549,6 +549,62 @@ impl SessionMetrics {
     }
 }
 
+/// Hot-join handshake timing for a session that joined an in-progress game via
+/// [`SessionBuilder::start_hot_join_session`](crate::SessionBuilder::start_hot_join_session).
+///
+/// Read one with
+/// [`P2PSession::hot_join_metrics`](crate::P2PSession::hot_join_metrics), which
+/// returns `None` for any session that did not hot-join (a host, or a normally
+/// synchronized peer). Timings are measured on the session's injectable protocol
+/// clock, so they are deterministic under the simulation harness (no wall clock).
+///
+/// Only available with the `hot-join` feature.
+#[cfg(feature = "hot-join")]
+#[non_exhaustive]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[must_use = "HotJoinMetrics should be inspected after being queried"]
+pub struct HotJoinMetrics {
+    /// Whether the join has completed — the joiner applied the host snapshot and
+    /// reached [`SessionState::Running`](crate::SessionState::Running). While
+    /// `false`, [`polls_to_running`](Self::polls_to_running) is still climbing
+    /// and [`millis_to_running`](Self::millis_to_running) stays `0`.
+    pub completed: bool,
+
+    /// [`poll_remote_clients`](crate::P2PSession::poll_remote_clients) iterations
+    /// spent in [`HotJoining`](crate::SessionState::HotJoining) — how many polls
+    /// the join took (or has taken so far, when not yet
+    /// [`completed`](Self::completed)).
+    pub polls_to_running: u64,
+
+    /// Virtual milliseconds on the injected protocol clock from join start
+    /// (session construction) to reaching `Running`. `0` while not yet
+    /// [`completed`](Self::completed); once completed it is the measured latency,
+    /// which may itself be `0` if the clock did not advance between construction
+    /// and activation — read [`completed`](Self::completed), not this field, to
+    /// tell whether the join has finished.
+    pub millis_to_running: u64,
+}
+
+#[cfg(all(feature = "hot-join", feature = "json"))]
+impl HotJoinMetrics {
+    /// Serializes this snapshot to a compact JSON string.
+    ///
+    /// Returns `None` if serialization fails — not expected for a few integers,
+    /// but possible (for example, an allocation failure inside `serde_json`).
+    #[must_use]
+    pub fn to_json(&self) -> Option<String> {
+        serde_json::to_string(self).ok()
+    }
+
+    /// Serializes this snapshot to a pretty-printed JSON string.
+    ///
+    /// Like [`to_json`](Self::to_json), but indented for readability.
+    #[must_use]
+    pub fn to_json_pretty(&self) -> Option<String> {
+        serde_json::to_string_pretty(self).ok()
+    }
+}
+
 /// The category of a protocol message, independent of its payload.
 ///
 /// Mirrors the crate's internal wire-message variants one-to-one so per-peer

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -5744,9 +5744,8 @@ impl<T: Config> P2PSession<T> {
     /// host, or a peer that synchronized normally).
     ///
     /// The timings are measured on the injectable protocol clock (the
-    /// `clock` field of [`ProtocolConfig`](crate::ProtocolConfig)), so they are
-    /// deterministic under the simulation harness. Available only with the
-    /// `hot-join` feature.
+    /// `clock` field of [`ProtocolConfig`]), so they are deterministic under the
+    /// simulation harness. Available only with the `hot-join` feature.
     #[cfg(feature = "hot-join")]
     #[must_use]
     pub fn hot_join_metrics(&self) -> Option<HotJoinMetrics> {

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -1,5 +1,7 @@
 use crate::error::{allocation_failed, FortressError, InternalErrorKind, InvalidRequestKind};
 use crate::frame_info::PlayerInput;
+#[cfg(feature = "hot-join")]
+use crate::metrics::HotJoinMetrics;
 use crate::metrics::{PeerMetrics, SessionMetrics};
 use crate::network::messages::ConnectionStatus;
 #[cfg(feature = "hot-join")]
@@ -8,6 +10,8 @@ use crate::network::network_stats::NetworkStats;
 use crate::network::protocol::UdpProtocol;
 use crate::replay::{Replay, ReplayRecorder};
 use crate::safe_frame_sub;
+#[cfg(feature = "hot-join")]
+use crate::sessions::config::ClockFn;
 use crate::sessions::config::{DisconnectBehavior, ProtocolConfig, SaveMode};
 use crate::sessions::player_registry::PlayerRegistry;
 use crate::sessions::session_trait::Session;
@@ -238,6 +242,42 @@ where
     /// Feature-gated behind `hot-join`; absent (and zero-cost) otherwise.
     #[cfg(feature = "hot-join")]
     hot_join: HotJoinState<T>,
+
+    /// Joiner-side hot-join handshake timing (surfaced via
+    /// [`hot_join_metrics`](P2PSession::hot_join_metrics)). Inert on a host or a
+    /// normally-synchronized session (`join_started_at` is `None`).
+    #[cfg(feature = "hot-join")]
+    hot_join_timing: HotJoinTiming,
+}
+
+/// Joiner-side hot-join handshake timing, measured on the injectable protocol
+/// clock. Populated only on a session built via
+/// [`SessionBuilder::start_hot_join_session`](crate::SessionBuilder::start_hot_join_session);
+/// backs [`P2PSession::hot_join_metrics`].
+#[cfg(feature = "hot-join")]
+#[derive(Debug, Default, Clone, Copy)]
+struct HotJoinTiming {
+    /// When the joiner session was constructed (entered `HotJoining`). `None` on
+    /// a non-joiner, which is how [`hot_join_metrics`](P2PSession::hot_join_metrics)
+    /// distinguishes "did not hot-join" from "join in progress".
+    join_started_at: Option<web_time::Instant>,
+    /// When the joiner first reached `Running` (snapshot applied, activated).
+    /// `None` until then.
+    became_running_at: Option<web_time::Instant>,
+    /// `poll_remote_clients` iterations observed while still `HotJoining`.
+    polls_while_joining: u64,
+}
+
+/// Reads the current instant from the injected protocol clock, falling back to
+/// the system clock when none is configured — the same rule the protocol
+/// endpoints use, so session-level and endpoint-level timings share a basis and
+/// stay deterministic under the simulation harness.
+#[cfg(feature = "hot-join")]
+fn clock_now(clock: Option<&ClockFn>) -> web_time::Instant {
+    match clock {
+        Some(clock_fn) => clock_fn(),
+        None => web_time::Instant::now(),
+    }
 }
 
 /// Per-session hot-join orchestration state.
@@ -832,6 +872,19 @@ impl<T: Config> P2PSession<T> {
             state
         };
 
+        // Stamp the join-start time for a joiner (read the injected clock before
+        // `protocol_config` is moved into the session below). `None` on any
+        // non-joiner marks "did not hot-join" for `hot_join_metrics`.
+        #[cfg(feature = "hot-join")]
+        let hot_join_timing = HotJoinTiming {
+            join_started_at: hot_join
+                .joiner
+                .is_some()
+                .then(|| clock_now(protocol_config.clock.as_ref())),
+            became_running_at: None,
+            polls_while_joining: 0,
+        };
+
         // For each reserved (but not-yet-joined) slot, freeze its input queue and
         // mark it disconnected so it behaves exactly like a Feature-5 dropped slot
         // from frame 0: frozen default input, ignored by `confirmed_frame`. The
@@ -937,6 +990,8 @@ impl<T: Config> P2PSession<T> {
                 pending_reactivation: None,
                 npeer_closed_attempt_frames: BTreeMap::new(),
             },
+            #[cfg(feature = "hot-join")]
+            hot_join_timing,
         })
     }
 
@@ -1284,6 +1339,14 @@ impl<T: Config> P2PSession<T> {
     /// Fortress Rollback will receive packets, distribute them to corresponding endpoints, handle all occurring events and send all outgoing packets.
     pub fn poll_remote_clients(&mut self) {
         let _violation_scope = self.scoped_violation_observer();
+        // Hot-join joiner latency: count every poll spent still `HotJoining`.
+        // Only a joiner is ever `HotJoining` (a host never is), so this needs no
+        // further guard. Placed before the body so early returns cannot skip it.
+        #[cfg(feature = "hot-join")]
+        if self.state == SessionState::HotJoining {
+            self.hot_join_timing.polls_while_joining =
+                self.hot_join_timing.polls_while_joining.saturating_add(1);
+        }
         // Get all packets and distribute them to associated endpoints.
         // The endpoints will handle their packets, which will trigger both events and UPD replies.
         for (from_addr, msg) in &self.socket.receive_all_messages() {
@@ -4399,6 +4462,7 @@ impl<T: Config> P2PSession<T> {
             joiner.ack_resends_remaining = ack_resends;
         }
         self.state = SessionState::Running;
+        self.record_hot_join_activation();
     }
 
     /// Re-roots the joiner's checksum-send anchor onto the host grid at apply
@@ -5286,6 +5350,7 @@ impl<T: Config> P2PSession<T> {
             joiner.pending_backfill = pending_backfill;
         }
         self.state = SessionState::Running;
+        self.record_hot_join_activation();
     }
 
     /// Returns the configured [`DisconnectBehavior`] for this session.
@@ -5652,6 +5717,53 @@ impl<T: Config> P2PSession<T> {
             }
             .into()),
         }
+    }
+
+    /// The current instant on this session's injectable protocol clock (or the
+    /// system clock if none was configured). Deterministic under the DST harness.
+    #[cfg(feature = "hot-join")]
+    fn now(&self) -> web_time::Instant {
+        clock_now(self.protocol_config.clock.as_ref())
+    }
+
+    /// Records that a hot-join joiner has reached `Running`, stamping the
+    /// activation time on the first call. Idempotent, and a no-op on any session
+    /// that did not hot-join (`join_started_at` is `None`), so it is safe to call
+    /// from every joiner-activation site.
+    #[cfg(feature = "hot-join")]
+    fn record_hot_join_activation(&mut self) {
+        if self.hot_join_timing.join_started_at.is_some()
+            && self.hot_join_timing.became_running_at.is_none()
+        {
+            self.hot_join_timing.became_running_at = Some(self.now());
+        }
+    }
+
+    /// Returns hot-join handshake timing for a session that joined an
+    /// in-progress game, or `None` for any session that did not hot-join (a
+    /// host, or a peer that synchronized normally).
+    ///
+    /// The timings are measured on the injectable protocol clock (the
+    /// `clock` field of [`ProtocolConfig`](crate::ProtocolConfig)), so they are
+    /// deterministic under the simulation harness. Available only with the
+    /// `hot-join` feature.
+    #[cfg(feature = "hot-join")]
+    #[must_use]
+    pub fn hot_join_metrics(&self) -> Option<HotJoinMetrics> {
+        let started = self.hot_join_timing.join_started_at?;
+        let (completed, millis_to_running) = match self.hot_join_timing.became_running_at {
+            Some(end) => (
+                true,
+                u64::try_from(end.saturating_duration_since(started).as_millis())
+                    .unwrap_or(u64::MAX),
+            ),
+            None => (false, 0),
+        };
+        Some(HotJoinMetrics {
+            completed,
+            polls_to_running: self.hot_join_timing.polls_while_joining,
+            millis_to_running,
+        })
     }
 
     /// Populates the checksum-related fields in NetworkStats.
@@ -7759,6 +7871,13 @@ impl<T: Config> P2PSession<T> {
 
         // everyone is synchronized, so we can change state and accept input
         self.state = SessionState::Running;
+        // A hot-join joiner that was fail-closed to `Synchronizing` mid-handshake
+        // (before applying a snapshot) resumes to `Running` here rather than via
+        // the snapshot-apply sites — instrument this path too so a joiner's
+        // `hot_join_metrics().completed` is never stuck false while `Running`.
+        // Idempotent and a no-op for a non-joiner.
+        #[cfg(feature = "hot-join")]
+        self.record_hot_join_activation();
     }
 
     /// Roll back to `min_confirmed` frame and resimulate the game with most up-to-date input data.

--- a/tests/sessions/hot_join.rs
+++ b/tests/sessions/hot_join.rs
@@ -267,7 +267,12 @@ fn hot_join_metrics_records_joiner_latency() -> Result<(), FortressError> {
     for _ in 0..200 {
         host.poll_remote_clients();
         if host.current_state() == SessionState::Running {
-            let _ = advance_session(&mut host, &mut host_stub, PlayerHandle::new(0), 7);
+            // The host is paused (returns `NotSynchronized`) while serving the
+            // joiner's snapshot; tolerate that, but surface any other error.
+            match advance_session(&mut host, &mut host_stub, PlayerHandle::new(0), 7) {
+                Ok(()) | Err(FortressError::NotSynchronized) => {},
+                Err(e) => return Err(e),
+            }
         }
         joiner.poll_remote_clients();
         clock.advance(POLL_INTERVAL_DETERMINISTIC);
@@ -288,15 +293,18 @@ fn hot_join_metrics_records_joiner_latency() -> Result<(), FortressError> {
         after.completed,
         "join should be marked completed: {after:?}"
     );
+    // A 2-peer join spans multiple polls (sync handshake, then snapshot serve
+    // and ack on later polls), and the clock advances each poll — so the latency
+    // is a positive multiple of the poll step. Asserting `polls > 1` makes that
+    // precondition explicit rather than relying on `millis > 0` directly (which
+    // the type documents can be 0 for a hypothetical <=1-poll join).
     assert!(
-        after.polls_to_running > 0,
-        "should have counted HotJoining polls: {after:?}"
+        after.polls_to_running > 1,
+        "a 2-peer join should span multiple HotJoining polls: {after:?}"
     );
-    // The clock advanced by 50ms per poll during the join, so latency is
-    // positive and a multiple of that step (deterministic virtual time).
     assert!(
         after.millis_to_running > 0,
-        "clock advanced during the join, so latency must be positive: {after:?}"
+        "the clock advanced across those polls, so latency is positive: {after:?}"
     );
 
     // The completed metric is stable — later polls/reads do not move it.

--- a/tests/sessions/hot_join.rs
+++ b/tests/sessions/hot_join.rs
@@ -229,6 +229,88 @@ fn drain_events(sess: &mut P2PSession<StubConfig>) -> Vec<FortressEvent<StubConf
     sess.events().collect()
 }
 
+/// Drives a 2-peer join to completion and asserts `hot_join_metrics()` captures
+/// the joiner's latency on the injectable clock: `None` for the host, present
+/// but incomplete while `HotJoining`, then completed with a positive
+/// poll/millisecond latency once the joiner reaches `Running`.
+#[test]
+fn hot_join_metrics_records_joiner_latency() -> Result<(), FortressError> {
+    let clock = TestClock::new();
+    let (host_socket, joiner_socket, host_addr, joiner_addr) = crate::common::create_channel_pair();
+
+    let mut host = SessionBuilder::<StubConfig>::new()
+        .with_protocol_config(protocol_config(&clock))
+        .with_num_players(2)?
+        .add_player(PlayerType::Local, PlayerHandle::new(0))?
+        .add_reserved_player(joiner_addr, PlayerHandle::new(1))?
+        .start_p2p_session(host_socket)?;
+
+    // A host never hot-joins, so it has no hot-join metrics.
+    assert_eq!(host.hot_join_metrics(), None);
+
+    let mut joiner = SessionBuilder::<StubConfig>::new()
+        .with_protocol_config(protocol_config(&clock))
+        .with_num_players(2)?
+        .add_player(PlayerType::Remote(host_addr), PlayerHandle::new(0))?
+        .add_player(PlayerType::Local, PlayerHandle::new(1))?
+        .start_hot_join_session(joiner_socket, host_addr)?;
+    assert_eq!(joiner.current_state(), SessionState::HotJoining);
+
+    // While HotJoining the metrics exist but the join is not yet complete.
+    let before = joiner
+        .hot_join_metrics()
+        .expect("a joiner has hot-join metrics");
+    assert!(!before.completed, "join not complete yet: {before:?}");
+    assert_eq!(before.millis_to_running, 0);
+
+    let mut host_stub = GameStub::new();
+    for _ in 0..200 {
+        host.poll_remote_clients();
+        if host.current_state() == SessionState::Running {
+            let _ = advance_session(&mut host, &mut host_stub, PlayerHandle::new(0), 7);
+        }
+        joiner.poll_remote_clients();
+        clock.advance(POLL_INTERVAL_DETERMINISTIC);
+        if joiner.current_state() == SessionState::Running {
+            break;
+        }
+    }
+    assert_eq!(
+        joiner.current_state(),
+        SessionState::Running,
+        "joiner should complete the join within the poll budget"
+    );
+
+    let after = joiner
+        .hot_join_metrics()
+        .expect("a joiner has hot-join metrics");
+    assert!(
+        after.completed,
+        "join should be marked completed: {after:?}"
+    );
+    assert!(
+        after.polls_to_running > 0,
+        "should have counted HotJoining polls: {after:?}"
+    );
+    // The clock advanced by 50ms per poll during the join, so latency is
+    // positive and a multiple of that step (deterministic virtual time).
+    assert!(
+        after.millis_to_running > 0,
+        "clock advanced during the join, so latency must be positive: {after:?}"
+    );
+
+    // The completed metric is stable — later polls/reads do not move it.
+    joiner.poll_remote_clients();
+    clock.advance(POLL_INTERVAL_DETERMINISTIC);
+    assert_eq!(
+        joiner.hot_join_metrics().expect("metrics"),
+        after,
+        "a completed hot-join metric must not change on later polls"
+    );
+
+    Ok(())
+}
+
 // ============================================================================
 // Checkpoint A: host with a reserved slot runs solo
 // ============================================================================


### PR DESCRIPTION
## Summary

Completes the M2 §5.2 metrics surface. Adds a `hot-join`-feature-gated public `HotJoinMetrics`, read via `P2PSession::hot_join_metrics() -> Option<HotJoinMetrics>` (`None` for any session that did not hot-join — a host, or a peer that synchronized normally). It reports a joiner's handshake latency:

- `completed` — whether the joiner reached `Running`.
- `polls_to_running` — `poll_remote_clients` iterations spent `HotJoining`.
- `millis_to_running` — elapsed time on the **injectable protocol clock**, so it is deterministic under the DST/simulation harness (no wall clock).

## Design

- **Clock access** reuses the session's already-stored `protocol_config.clock` via a `clock_now`/`now()` helper byte-identical to the protocol endpoint's — session- and endpoint-level timings share a basis.
- `join_started_at` is stamped at construction for a joiner (read before `protocol_config` is moved into the session); `became_running_at` is stamped by an **idempotent** `record_hot_join_activation()` (only stamps once, no-op for a non-joiner).
- **Every-path completeness (the D9 lesson):** a joiner reaches `Running` at three sites — 2-peer snapshot apply, N-peer snapshot apply, and `check_initial_sync` (reachable when a joiner is fail-closed to `Synchronizing` mid-handshake and later resumes without applying a snapshot). All three call the shared idempotent helper, so `completed` can never be permanently stuck `false` while the session is genuinely `Running`. **The `check_initial_sync` site was found by an internal adversarial review** — my first pass instrumented only the two apply sites; the review proved the fail-closed→resume path reaches `Running` uninstrumented.
- Type matches `SessionMetrics`/`PeerMetrics` conventions: `#[non_exhaustive]`, `Copy`, `serde::Serialize`, `to_json()`/`to_json_pretty()` under `json`.

## Tests

`hot_join_metrics_records_joiner_latency` drives a full 2-peer join and asserts: host → `None`; joiner incomplete (with `millis == 0`) while `HotJoining`; completed with positive `polls_to_running` and `millis_to_running` after activation; and a stable completed metric across later polls. The N-peer and fail-closed sites reuse the same validated idempotent helper (the N-peer joiner tests use a low-level `ManualJoiner`, not a `P2PSession`, so they can't exercise the accessor directly).

## Validation

- `cargo clippy --workspace --all-targets` on both `tokio,json` and `hot-join,tokio,json` — clean.
- `cargo nextest run` — 2349 passed; `--features hot-join` — 2588 passed.
- `cargo doc --no-deps --features hot-join,tokio,json,sync-send --document-private-items` — clean.
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass.

Compiles cleanly with and without `hot-join` (all new items feature-gated; no dead code under `#![deny(warnings)]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only, feature-gated instrumentation on existing hot-join activation paths; no wire or handshake behavior changes.
> 
> **Overview**
> With the **`hot-join`** feature, this PR adds a public **`HotJoinMetrics`** type and **`P2PSession::hot_join_metrics() -> Option<HotJoinMetrics>`**. Hosts and normally synchronized peers get **`None`**; joiners get **`completed`**, **`polls_to_running`** (increments on each **`poll_remote_clients`** while **`HotJoining`**), and **`millis_to_running`** on the session’s **`ProtocolConfig::clock`** (deterministic under simulation).
> 
> **`P2PSession`** stores joiner-side **`HotJoinTiming`**: join start at construction, activation via idempotent **`record_hot_join_activation()`** at all three paths to **`Running`** (2-peer snapshot apply, N-peer apply, and **`check_initial_sync`** after fail-closed resume). Optional **`to_json()`** / **`to_json_pretty()`** match other metrics types. Changelog and an integration test **`hot_join_metrics_records_joiner_latency`** cover the full 2-peer join flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d877905ca6ddcf23e35c4ce96b78ad32c615adf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->