### PR TITLE
Hardening M3 §6.1: PeerStall lifecycle fault (peer hang) in the DST harness

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -804,6 +804,21 @@ fn oracle_catches_seeded_divergence_under_peer_hitch() {
     );
 }
 
+/// A malformed schedule (here: a `PeerStall` naming a peer outside the mesh, as
+/// a hand-edited or corrupt corpus artifact might) must fail loudly with a
+/// clear message, not panic on a raw slice index — the fail-loud contract the
+/// harness's up-front validation enforces for corpus replay.
+#[test]
+#[should_panic(expected = "out of range")]
+fn run_rejects_out_of_range_peer_index() {
+    let mut schedule = peer_hitch_schedule(2, None);
+    schedule
+        .events
+        .push((100, ScheduleEvent::PeerStall { peer: 9, steps: 10 }));
+    schedule.events.sort_by_key(|(step, _)| *step);
+    let _ = run(&schedule, &RunOptions::default());
+}
+
 /// Diagnostic probe for a failing schedule: prints per-peer progress every 50
 /// steps. `#[ignore]`d — run manually while investigating a repro.
 #[test]

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -636,6 +636,174 @@ fn partition_under_continue_without_forks_into_divergent_halves() {
     );
 }
 
+/// Step at which [`peer_hitch_schedule`] freezes peer 1. The recovery test
+/// derives its mid-run probe step from this so the two never drift.
+const PEER_HITCH_START: u32 = 200;
+
+/// Builds a peer-hitch schedule: an otherwise-clean `n`-mesh in which peer 1
+/// freezes for `stall` steps starting at [`PEER_HITCH_START`] — a *local* hang
+/// (GC pause, frame-time spike, blocked save), not a network fault. `stall` is
+/// kept well under the 2 s (~125-step) disconnect timeout, so the mesh predicts
+/// past the frozen peer to the prediction wall, stalls waiting for its inputs,
+/// then catches up when it resumes — a recoverable pause, never a drop. Passing
+/// `None` for `stall` yields the identical schedule *without* the hitch, the
+/// control the premise assertion compares against.
+fn peer_hitch_schedule(n: usize, stall: Option<u32>) -> Schedule {
+    let config = SimConfig {
+        n_players: n,
+        steps: 900,
+        noise: BackgroundNoise::Clean,
+        ..SimConfig::smoke(n)
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, LinkPolicy::clean()));
+            }
+        }
+    }
+    let heal_at = 650;
+    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
+    if let Some(steps) = stall {
+        events.push((
+            PEER_HITCH_START,
+            ScheduleEvent::PeerStall { peer: 1, steps },
+        ));
+    }
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
+/// M3 §6.1 lifecycle vocabulary — the peer-hitch fault (`ScheduleEvent::
+/// PeerStall`). A peer that hangs for a bounded window shorter than the
+/// disconnect timeout must be a *recoverable* pause: the mesh predicts past it
+/// to the prediction wall, stalls for its inputs, then catches up on resume,
+/// and the confirmed prefix stays byte-identical across every peer.
+///
+/// The test asserts the full freeze→recover arc, not just the converged
+/// end-state (a clean drain always converges, so end-state alone has no teeth):
+/// 1. **Premise** — the same clean schedule *with* and *without* the stall
+///    produces different traces (the hitch is effective, not a silent no-op),
+///    and two hitched runs fold the identical trace (determinism).
+/// 2. **Freeze** — mid-stall (probed at the last frozen step), the hitched
+///    mesh's confirmation is stalled far behind the clean run's: confirmation
+///    is gated by the frozen peer's missing inputs, so the *whole* mesh's
+///    confirmed frame is held back, not just the hitching peer's.
+/// 3. **Recovery** — by end-of-run the hitched peer has caught up to within the
+///    prediction window of the leader (no permanent lag — stronger than the
+///    coarse end-progress bar, which a recovered-but-lagging peer would pass).
+#[test]
+fn peer_hitch_recovers_with_consistent_mesh() {
+    const HITCH_STEPS: u32 = 50;
+    // Probe the last frozen step: the stall spans [START, START+STEPS), so the
+    // peer resumes at START+STEPS and START+STEPS-1 is the deepest freeze.
+    const PROBE_AT: u32 = PEER_HITCH_START + HITCH_STEPS - 1;
+
+    for n in [2usize, 4] {
+        let clean = peer_hitch_schedule(n, None);
+        let hitched = peer_hitch_schedule(n, Some(HITCH_STEPS));
+        let opts = RunOptions {
+            probe_confirmed_at: Some(PROBE_AT),
+            ..RunOptions::default()
+        };
+
+        let clean_report = run(&clean, &opts);
+        clean_report.expect_pass(&clean);
+        let hitched_report = run(&hitched, &opts);
+        hitched_report.expect_pass(&hitched);
+        let hitched_again = run(&hitched, &opts);
+
+        // (1) Premise + determinism.
+        assert_ne!(
+            clean_report.trace_hash, hitched_report.trace_hash,
+            "the PeerStall must change execution — a silent no-op would leave \
+             the trace identical (n={n})"
+        );
+        assert_eq!(
+            hitched_report.trace_hash, hitched_again.trace_hash,
+            "a PeerStall schedule must reproduce its exact trace (n={n})"
+        );
+
+        // (2) Freeze: mid-stall the whole hitched mesh trails the clean mesh —
+        // even the furthest-along hitched peer is well behind the least-along
+        // clean peer, because the frozen peer's missing inputs gate everyone's
+        // confirmation. (Expected gap ≈ HITCH_STEPS; require a conservative
+        // fraction so this is unambiguous, not a one-frame coincidence.)
+        let clean_slowest = clean_report
+            .probe_confirmed
+            .iter()
+            .copied()
+            .min()
+            .unwrap_or(-1);
+        let hitched_fastest = hitched_report
+            .probe_confirmed
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(-1);
+        assert!(
+            clean_slowest - hitched_fastest >= (HITCH_STEPS as i32) / 2,
+            "the hitch must freeze mesh-wide confirmation mid-stall \
+             (clean slowest={clean_slowest}, hitched fastest={hitched_fastest}, \
+             n={n}): clean={:?} hitched={:?}",
+            clean_report.probe_confirmed,
+            hitched_report.probe_confirmed,
+        );
+
+        // (3) Recovery: by end-of-run the hitched peer is within the prediction
+        // window of the leader — no permanent lag.
+        let confirmed = &hitched_report.final_confirmed;
+        let leader = confirmed.iter().copied().max().unwrap_or(-1);
+        let hitched_peer = confirmed[1];
+        assert!(
+            (leader - hitched_peer) as usize <= hitched.config.max_prediction,
+            "hitched peer 1 must catch up to within the prediction window \
+             (leader={leader}, peer1={hitched_peer}, max_prediction={}): {confirmed:?}",
+            hitched.config.max_prediction,
+        );
+    }
+}
+
+/// Negative control for the peer-hitch fault: a real state divergence seeded
+/// into a *surviving* peer must still be caught while another peer is
+/// hitching. A stall that blinded the oracle would make the fleet miss desyncs
+/// exactly when a peer is under stress — the HD-1 "silent instrument" failure
+/// mode (PLAN.md Part V), here checked against the new lifecycle op.
+#[test]
+fn oracle_catches_seeded_divergence_under_peer_hitch() {
+    let schedule = peer_hitch_schedule(4, Some(50));
+    // Corrupt peer 0 (a survivor, not the hitching peer 1) from frame 40 on —
+    // well before the stall window, so the divergence is already established
+    // and still live while peer 1 hitches.
+    let options = RunOptions {
+        corrupt_state_from: Some((0, 40)),
+        ..RunOptions::default()
+    };
+    let report = run(&schedule, &options);
+    assert!(
+        !report.verdict.passed(),
+        "a seeded divergence must fail the run even under a peer hitch"
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::StateDivergence { .. })),
+        "the oracle's state comparison must keep its teeth under a peer hitch: {:?}",
+        report.verdict.failures
+    );
+}
+
 /// Diagnostic probe for a failing schedule: prints per-peer progress every 50
 /// steps. `#[ignore]`d — run manually while investigating a repro.
 #[test]

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -419,7 +419,11 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                     net.set_holding(addrs[*from], addrs[*to], *holding);
                 },
                 ScheduleEvent::PeerStall { peer, steps } => {
-                    debug_assert!(
+                    // Always-on (not `debug_assert!`): the nightly fleet builds
+                    // `--release` and replays serialized corpus schedules, so a
+                    // malformed `steps: 0` must fail loudly in every profile
+                    // rather than silently freezing nothing.
+                    assert!(
                         *steps > 0,
                         "PeerStall steps must be > 0 (a 0-step stall freezes nothing)"
                     );
@@ -492,14 +496,12 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 &mut trace_hash,
                 &(step, i, slot.game.gs, confirmed.as_i32()),
             );
-        }
 
-        // Optional mid-run confirmation snapshot for recovery-dynamics tests.
-        if options.probe_confirmed_at == Some(step) {
-            probe_confirmed = peers
-                .iter()
-                .map(|slot| slot.session.confirmed_frame().as_i32())
-                .collect();
+            // Optional mid-run confirmation snapshot for recovery-dynamics
+            // tests, reusing the value already read for this peer above.
+            if options.probe_confirmed_at == Some(step) {
+                probe_confirmed.push(confirmed.as_i32());
+            }
         }
 
         if diagnose && step % 50 == 0 {

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -43,6 +43,11 @@ pub struct RunOptions {
     /// Corrupt `(peer, from_frame)`'s saved **checksums only** (states stay
     /// identical): exercises the in-band detector cross-check path.
     pub corrupt_checksum_from: Option<(usize, i32)>,
+    /// If set, snapshot every peer's confirmed frame at this step into
+    /// [`RunReport::probe_confirmed`]. Lets a test observe mid-run confirmation
+    /// (frozen during a hitch, converged after heal) — end-of-run state alone
+    /// hides recovery dynamics because a clean drain always converges.
+    pub probe_confirmed_at: Option<u32>,
 }
 
 /// Outcome of one simulation run.
@@ -53,6 +58,9 @@ pub struct RunReport {
     pub trace_hash: u64,
     /// Each peer's final confirmed frame.
     pub final_confirmed: Vec<i32>,
+    /// Each peer's confirmed frame sampled at [`RunOptions::probe_confirmed_at`]
+    /// (empty when no probe step was requested). Indexed by peer.
+    pub probe_confirmed: Vec<i32>,
     /// Network delivery/drop counters.
     pub net_stats: crate::common::sim_net::SimNetStats,
     /// Each peer's final [`SessionMetrics`] snapshot (indexed by peer).
@@ -387,6 +395,12 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     let mut oracle = Oracle::new(n);
     let mut trace_hash: u64 = 0xcbf2_9ce4_8422_2325; // FNV offset basis
     let mut next_event = 0usize;
+    // Per-peer stall deadline (exclusive step): peer `i` is frozen while
+    // `step < stalled_until[i]`. `0` means never stalled; a `PeerStall` event
+    // sets it to `step + steps`.
+    let mut stalled_until: Vec<u32> = vec![0; n];
+    // Confirmed-frame snapshot taken at `options.probe_confirmed_at`, if any.
+    let mut probe_confirmed: Vec<i32> = Vec::new();
 
     for step in 0..schedule.config.steps {
         // Apply control-plane events due at this step.
@@ -404,53 +418,88 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 ScheduleEvent::Hold { from, to, holding } => {
                     net.set_holding(addrs[*from], addrs[*to], *holding);
                 },
+                ScheduleEvent::PeerStall { peer, steps } => {
+                    debug_assert!(
+                        *steps > 0,
+                        "PeerStall steps must be > 0 (a 0-step stall freezes nothing)"
+                    );
+                    stalled_until[*peer] = step.saturating_add(*steps);
+                },
                 ScheduleEvent::HealAll => net.heal_all(),
             }
             next_event += 1;
         }
 
-        // Drive every peer in fixed order.
+        // Drive every peer in fixed order. A peer inside its stall window is
+        // frozen (a local hang): it does not poll, drain events, add input, or
+        // advance, and puts nothing on the wire until it resumes. Its state is
+        // still folded into the trace below so the digest stays uniform and the
+        // stall reproduces bit-for-bit.
         for (i, slot) in peers.iter_mut().enumerate() {
-            slot.session.poll_remote_clients();
+            // Confirmed frame after this step's drive (or the frozen value for a
+            // stalled peer): read exactly once and reused for both the trace
+            // fold and any probe snapshot.
+            let confirmed = if step >= stalled_until[i] {
+                slot.session.poll_remote_clients();
 
-            let events: Vec<FortressEvent<StubConfig>> = slot.session.events().collect();
-            for event in &events {
-                if let FortressEvent::DesyncDetected { frame, .. } = event {
-                    oracle.observe_desync_event(i, *frame);
+                let events: Vec<FortressEvent<StubConfig>> = slot.session.events().collect();
+                for event in &events {
+                    if let FortressEvent::DesyncDetected { frame, .. } = event {
+                        oracle.observe_desync_event(i, *frame);
+                    }
+                    fold_trace(&mut trace_hash, &format!("{event:?}"));
                 }
-                fold_trace(&mut trace_hash, &format!("{event:?}"));
-            }
 
-            if slot.session.current_state() == SessionState::Running {
-                for handle in slot.session.local_player_handles() {
-                    if let Err(error) = slot.session.add_local_input(handle, input_for(step, i)) {
-                        oracle.observe_advance_error(i, step, &error);
+                if slot.session.current_state() == SessionState::Running {
+                    for handle in slot.session.local_player_handles() {
+                        if let Err(error) = slot.session.add_local_input(handle, input_for(step, i))
+                        {
+                            oracle.observe_advance_error(i, step, &error);
+                        }
+                    }
+                    match slot.session.advance_frame() {
+                        Ok(requests) => slot.game.handle_requests(requests),
+                        Err(error) => oracle.observe_advance_error(i, step, &error),
                     }
                 }
-                match slot.session.advance_frame() {
-                    Ok(requests) => slot.game.handle_requests(requests),
-                    Err(error) => oracle.observe_advance_error(i, step, &error),
-                }
-            }
 
-            // Incrementally sample newly confirmed inputs (they evict).
-            let confirmed = slot.session.confirmed_frame();
-            if confirmed.is_valid() {
-                for frame in (slot.sampled_confirmed + 1)..=confirmed.as_i32() {
-                    match slot.session.confirmed_inputs_for_frame(Frame::new(frame)) {
-                        Ok(inputs) => oracle.observe_confirmed_inputs(i, frame, &inputs),
-                        Err(error) => {
-                            oracle.observe_confirmed_unavailable(i, frame, &format!("{error:?}"));
-                        },
+                // Incrementally sample newly confirmed inputs (they evict).
+                let confirmed = slot.session.confirmed_frame();
+                if confirmed.is_valid() {
+                    for frame in (slot.sampled_confirmed + 1)..=confirmed.as_i32() {
+                        match slot.session.confirmed_inputs_for_frame(Frame::new(frame)) {
+                            Ok(inputs) => oracle.observe_confirmed_inputs(i, frame, &inputs),
+                            Err(error) => {
+                                oracle.observe_confirmed_unavailable(
+                                    i,
+                                    frame,
+                                    &format!("{error:?}"),
+                                );
+                            },
+                        }
+                        slot.sampled_confirmed = frame;
                     }
-                    slot.sampled_confirmed = frame;
                 }
-            }
+                confirmed
+            } else {
+                // Frozen peer (local hang): no poll/advance, no wire traffic.
+                slot.session.confirmed_frame()
+            };
 
+            // Fold each peer's (possibly frozen) frame + confirmed state so the
+            // trace digest is defined every step, stalled or not.
             fold_trace(
                 &mut trace_hash,
                 &(step, i, slot.game.gs, confirmed.as_i32()),
             );
+        }
+
+        // Optional mid-run confirmation snapshot for recovery-dynamics tests.
+        if options.probe_confirmed_at == Some(step) {
+            probe_confirmed = peers
+                .iter()
+                .map(|slot| slot.session.confirmed_frame().as_i32())
+                .collect();
         }
 
         if diagnose && step % 50 == 0 {
@@ -522,6 +571,7 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
         verdict,
         trace_hash,
         final_confirmed,
+        probe_confirmed,
         net_stats: net.stats(),
         metrics,
         peer_wire,

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -46,7 +46,8 @@ pub struct RunOptions {
     /// If set, snapshot every peer's confirmed frame at this step into
     /// [`RunReport::probe_confirmed`]. Lets a test observe mid-run confirmation
     /// (frozen during a hitch, converged after heal) — end-of-run state alone
-    /// hides recovery dynamics because a clean drain always converges.
+    /// hides recovery dynamics because a clean drain always converges. Must be
+    /// within `0..steps` (asserted up front, so a requested probe always fires).
     pub probe_confirmed_at: Option<u32>,
 }
 
@@ -332,6 +333,46 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     let net: SimNet<Message> = SimNet::new(schedule.link_seed, clock.as_protocol_clock());
 
     let addrs: Vec<SocketAddr> = (0..n).map(peer_addr).collect();
+
+    // Validate every peer index up front so a malformed or hand-edited corpus
+    // schedule fails loudly with a clear message instead of panicking on a raw
+    // slice index deep in the run (or, for `PeerStall` steps, silently in a
+    // release build). Covers initial links, every event, and the probe step.
+    for (from, to, _) in &schedule.initial_links {
+        assert!(
+            *from < n && *to < n,
+            "initial link ({from} -> {to}) out of range for a {n}-peer mesh"
+        );
+    }
+    for (_, event) in &schedule.events {
+        match event {
+            ScheduleEvent::SetLink { from, to, .. }
+            | ScheduleEvent::Block { from, to, .. }
+            | ScheduleEvent::Hold { from, to, .. } => assert!(
+                *from < n && *to < n,
+                "schedule event link ({from} -> {to}) out of range for a {n}-peer mesh"
+            ),
+            ScheduleEvent::PeerStall { peer, steps } => {
+                assert!(
+                    *peer < n,
+                    "PeerStall peer {peer} out of range for a {n}-peer mesh"
+                );
+                assert!(
+                    *steps > 0,
+                    "PeerStall steps must be > 0 (a 0-step stall freezes nothing)"
+                );
+            },
+            ScheduleEvent::HealAll => {},
+        }
+    }
+    if let Some(probe) = options.probe_confirmed_at {
+        assert!(
+            probe < schedule.config.steps,
+            "probe_confirmed_at ({probe}) is outside the run (0..{})",
+            schedule.config.steps
+        );
+    }
+
     for (from, to, policy) in &schedule.initial_links {
         net.set_link(addrs[*from], addrs[*to], policy.clone());
     }
@@ -419,14 +460,7 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                     net.set_holding(addrs[*from], addrs[*to], *holding);
                 },
                 ScheduleEvent::PeerStall { peer, steps } => {
-                    // Always-on (not `debug_assert!`): the nightly fleet builds
-                    // `--release` and replays serialized corpus schedules, so a
-                    // malformed `steps: 0` must fail loudly in every profile
-                    // rather than silently freezing nothing.
-                    assert!(
-                        *steps > 0,
-                        "PeerStall steps must be > 0 (a 0-step stall freezes nothing)"
-                    );
+                    // `peer` in range and `steps > 0` are validated up front.
                     stalled_until[*peer] = step.saturating_add(*steps);
                 },
                 ScheduleEvent::HealAll => net.heal_all(),

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -42,7 +42,14 @@ impl From<DropPolicy> for DisconnectBehavior {
 }
 
 /// Schema version for serialized schedules (bump on breaking layout change).
-pub const SCHEDULE_SCHEMA_VERSION: u32 = 1;
+///
+/// - `1`: network-fault vocabulary only (`SetLink`/`Block`/`Hold`/`HealAll`).
+/// - `2`: adds the first lifecycle-vocabulary fault
+///   [`ScheduleEvent::PeerStall`] (a peer that hangs, not just a degraded
+///   link). A v1 reader cannot interpret a v2 schedule carrying a `PeerStall`,
+///   so the format capability — not just this generator's output — dictates
+///   the bump.
+pub const SCHEDULE_SCHEMA_VERSION: u32 = 2;
 
 /// Background link-noise level applied to every directed link at start.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -129,6 +136,18 @@ pub enum ScheduleEvent {
         to: usize,
         holding: bool,
     },
+    /// Freeze peer `peer` for `steps` steps: it stops polling, draining
+    /// events, adding input, and advancing — modeling a local hang (GC pause,
+    /// frame-time spike, blocked save) rather than a network fault. Unlike a
+    /// link fault, the peer emits *nothing* (no inputs, keepalives, or quality
+    /// reports) while frozen and resumes exactly where it left off.
+    ///
+    /// The stall must stay shorter than the mesh's disconnect timeout, or the
+    /// silence tips the peer into a genuine disconnect. The planted lifecycle
+    /// tests keep it well under that bound so the hitch is a recoverable pause,
+    /// not a drop; the random generator does not emit this event yet (it lands
+    /// with the M3 storyline overhaul, which re-blesses seed baselines).
+    PeerStall { peer: usize, steps: u32 },
     /// Reset every link to clean and release all held traffic.
     HealAll,
 }
@@ -473,5 +492,24 @@ mod tests {
             schedule, back,
             "corpus artifacts must round-trip losslessly"
         );
+    }
+
+    /// The lifecycle-vocabulary event must serialize losslessly — a corpus
+    /// artifact carrying a `PeerStall` has to replay the same hitch. The
+    /// generator does not yet emit it, so plant one explicitly.
+    #[test]
+    fn peer_stall_event_round_trips_through_json() {
+        let mut schedule = generate(42, SimConfig::smoke(3));
+        schedule
+            .events
+            .push((200, ScheduleEvent::PeerStall { peer: 1, steps: 40 }));
+        schedule.events.sort_by_key(|(step, _)| *step);
+        let json = serde_json::to_string(&schedule).unwrap();
+        let back: Schedule = serde_json::from_str(&json).unwrap();
+        assert_eq!(schedule, back, "PeerStall must round-trip losslessly");
+        assert!(back
+            .events
+            .iter()
+            .any(|(_, ev)| matches!(ev, ScheduleEvent::PeerStall { peer: 1, steps: 40 })));
     }
 }


### PR DESCRIPTION
## Summary

First entry in the **M3 §6.1 lifecycle vocabulary**: a `ScheduleEvent::PeerStall { peer, steps }` fault that freezes one peer for a bounded window — a **local hang** (GC pause, frame-time spike, blocked save), distinct from every fault the DST harness could express until now, which were all network-level (`SetLink`/`Block`/`Hold`). A stalled peer stops polling, draining events, adding input, and advancing, and puts **nothing** on the wire until it resumes.

This is deliberately the one lifecycle op that needs **no oracle-semantics change**: a hitch shorter than the disconnect timeout is a *recoverable* pause — the mesh predicts past the frozen peer to the prediction wall, stalls for its inputs, then catches up on resume — so the existing invariants apply unchanged. It also establishes the runner's per-peer participation-state machinery that later ops (`PeerKill`, `GracefulRemove`) will extend.

## Changes (test-infra only — no `src/`, no public-crate API, no changelog)

- **`schedule.rs`**: new `PeerStall { peer, steps }` variant; `SCHEDULE_SCHEMA_VERSION` 1 → 2 (a v1 reader cannot interpret a v2 schedule carrying the event, so the *format capability* dictates the bump); serde round-trip test. The random `generate()` is **deliberately untouched**, so every existing seed — including the pinned D8 cold-start regression — stays bit-identical. Generator integration lands with the M3 storyline overhaul that re-blesses baselines.
- **`harness/mod.rs`**: per-peer `stalled_until` deadline (a stalled peer skips its drive body but still folds its frozen `(step, i, gs, confirmed)` tuple, so the trace digest is defined every step and reproduces bit-for-bit); a reusable **mid-run `probe_confirmed_at` snapshot** on `RunOptions`/`RunReport` (end-of-run state hides recovery dynamics because a clean drain always converges — the lifecycle vocabulary needs mid-run observation); `debug_assert!(steps > 0)`; `confirmed_frame()` read once per peer-step.
- **`fleet.rs`**: `peer_hitch_recovers_with_consistent_mesh` (n∈{2,4}) asserts the full **freeze → recover** arc, not just a converged end-state:
  1. **Premise + determinism** — the same clean schedule *with* vs *without* the stall diverges the trace (the hitch is effective, not a silent no-op), and two hitched runs fold the identical trace.
  2. **Freeze** — probed at the deepest frozen step, the whole hitched mesh trails the clean run by ≈ the stall length (the frozen peer's missing inputs gate *everyone's* confirmation): measured **clean `[244, 245]` vs frozen `[195, 195]`** (a 49-frame gap for a 50-step stall).
  3. **Recovery** — by end-of-run the hitched peer is within the prediction window of the leader (no permanent lag — strictly stronger than the coarse `≥ 30` end-progress bar, which a recovered-but-lagging peer would still pass).
  - `oracle_catches_seeded_divergence_under_peer_hitch` — a real state divergence seeded into a *surviving* peer still trips `StateDivergence` while another peer hitches: the oracle keeps its teeth under the new op (the HD-1 "silent instrument" guard, PLAN.md Part V).

## Red → green

With the `PeerStall` handler neutralized to a no-op, the premise assertion fails:

```
assertion `left != right` failed: the PeerStall must change execution —
a silent no-op would leave the trace identical (n=2)
```

Restoring the handler makes it green — the assertions have real teeth.

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json` — clean
- `cargo nextest run` — 2352 passed · `--features hot-join` — 2591 passed
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass

This change was reviewed by an adversarial sub-agent (verdict: solid, no correctness/determinism/schema issues); its one substantive finding — the original end-of-run recovery bound had weak teeth on a converged clean drain — is addressed by the mid-run freeze probe above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulation test infrastructure; no production `src/` or public API surface is modified.
> 
> **Overview**
> Adds **M3 §6.1 lifecycle vocabulary** to the DST harness: **`ScheduleEvent::PeerStall`** models a bounded local peer hang (no poll/advance/wire traffic), bumps **`SCHEDULE_SCHEMA_VERSION` to 2**, and keeps random **`generate()`** unchanged so existing seed baselines stay identical.
> 
> The runner tracks per-peer **`stalled_until`**, skips the drive loop while frozen but still folds frozen state into the trace hash, validates peer indices and stall parameters up front, and exposes **`RunOptions::probe_confirmed_at`** / **`RunReport::probe_confirmed`** for mid-run confirmation snapshots.
> 
> New fleet tests cover **freeze → recover** (trace differs from clean control, mesh-wide confirmation lag mid-stall, hitched peer catches up within **`max_prediction`**), **oracle still catches seeded divergence under hitch**, and **reject out-of-range `PeerStall` peer**; schedule JSON round-trip for **`PeerStall`** is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b6f93757f68718ff73489fddf54cda18573737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->