### PR TITLE
Hardening M3 §6.1: SetInputDelay lifecycle op (mid-run input-delay change)

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -819,6 +819,106 @@ fn run_rejects_out_of_range_peer_index() {
     let _ = run(&schedule, &RunOptions::default());
 }
 
+/// Builds an input-delay-change schedule: a clean `n`-mesh in which peer 1
+/// raises its local input delay from the smoke default (1) to `delay` frames at
+/// step 100 — a mid-session *increase*, which gap-fills the newly delayed
+/// frames with replicated confirmed inputs and flushes them to every remote (a
+/// reconfiguration path a fixed-delay fleet never exercises). `None` yields the
+/// identical schedule without the change, the control the premise compares to.
+fn input_delay_change_schedule(n: usize, delay: Option<usize>) -> Schedule {
+    let config = SimConfig {
+        n_players: n,
+        steps: 600,
+        noise: BackgroundNoise::Clean,
+        ..SimConfig::smoke(n)
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, LinkPolicy::clean()));
+            }
+        }
+    }
+    let heal_at = 400;
+    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
+    if let Some(delay) = delay {
+        events.push((100, ScheduleEvent::SetInputDelay { peer: 1, delay }));
+    }
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
+/// M3 §6.1 lifecycle vocabulary — the mid-run input-delay change
+/// (`ScheduleEvent::SetInputDelay`). Raising a peer's input delay mid-session
+/// drives `P2PSession::set_input_delay`'s gap-fill/flush reconfiguration path
+/// (replicated confirmed inputs pushed to every remote, connect-status stamped,
+/// pending output flushed) — untouched by a fixed-delay fleet. The change is
+/// local to one peer, so the mesh must still agree on every confirmed frame and
+/// keep progressing.
+///
+/// The premise is asserted directly: the same clean schedule *with* and
+/// *without* the delay change must produce different traces (the reconfiguration
+/// demonstrably took effect, not a silent no-op), while both pass the oracle;
+/// two changed runs fold the identical trace (determinism).
+#[test]
+fn input_delay_increase_keeps_mesh_consistent() {
+    for n in [2usize, 4] {
+        let base = input_delay_change_schedule(n, None);
+        let changed = input_delay_change_schedule(n, Some(3));
+
+        let base_report = run(&base, &RunOptions::default());
+        base_report.expect_pass(&base);
+        let changed_report = run(&changed, &RunOptions::default());
+        changed_report.expect_pass(&changed);
+
+        let changed_again = run(&changed, &RunOptions::default());
+        assert_eq!(
+            changed_report.trace_hash, changed_again.trace_hash,
+            "a SetInputDelay schedule must reproduce its exact trace (n={n})"
+        );
+        assert_ne!(
+            base_report.trace_hash, changed_report.trace_hash,
+            "the SetInputDelay must change execution — a silent no-op would \
+             leave the trace identical (n={n})"
+        );
+    }
+}
+
+/// Negative control for the input-delay change: a real state divergence seeded
+/// into a survivor must still be caught while a peer reconfigures its input
+/// delay — the reconfiguration path must not blind the oracle.
+#[test]
+fn oracle_catches_seeded_divergence_under_input_delay_change() {
+    let schedule = input_delay_change_schedule(4, Some(3));
+    let options = RunOptions {
+        corrupt_state_from: Some((0, 40)),
+        ..RunOptions::default()
+    };
+    let report = run(&schedule, &options);
+    assert!(
+        !report.verdict.passed(),
+        "a seeded divergence must fail the run even under an input-delay change"
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::StateDivergence { .. })),
+        "the oracle's state comparison must keep its teeth under a delay change: {:?}",
+        report.verdict.failures
+    );
+}
+
 /// Diagnostic probe for a failing schedule: prints per-peer progress every 50
 /// steps. `#[ignore]`d — run manually while investigating a repro.
 #[test]

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -820,12 +820,14 @@ fn run_rejects_out_of_range_peer_index() {
 }
 
 /// Builds an input-delay-change schedule: a clean `n`-mesh in which peer 1
-/// raises its local input delay from the smoke default (1) to `delay` frames at
-/// step 100 — a mid-session *increase*, which gap-fills the newly delayed
-/// frames with replicated confirmed inputs and flushes them to every remote (a
-/// reconfiguration path a fixed-delay fleet never exercises). `None` yields the
-/// identical schedule without the change, the control the premise compares to.
-fn input_delay_change_schedule(n: usize, delay: Option<usize>) -> Schedule {
+/// raises its local input delay by `increase` frames at step 100 — a mid-session
+/// *increase*, which gap-fills the newly delayed frames with replicated confirmed
+/// inputs and flushes them to every remote (a reconfiguration path a fixed-delay
+/// fleet never exercises). The new delay is `config.input_delay + increase`, so
+/// it is always a genuine increase regardless of the config default (never a
+/// silent no-op that would hollow out the premise). `None` yields the identical
+/// schedule without the change, the control the premise compares to.
+fn input_delay_change_schedule(n: usize, increase: Option<usize>) -> Schedule {
     let config = SimConfig {
         n_players: n,
         steps: 600,
@@ -842,7 +844,8 @@ fn input_delay_change_schedule(n: usize, delay: Option<usize>) -> Schedule {
     }
     let heal_at = 400;
     let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
-    if let Some(delay) = delay {
+    if let Some(increase) = increase {
+        let delay = config.input_delay + increase;
         events.push((100, ScheduleEvent::SetInputDelay { peer: 1, delay }));
     }
     events.sort_by_key(|(step, _)| *step);
@@ -873,7 +876,7 @@ fn input_delay_change_schedule(n: usize, delay: Option<usize>) -> Schedule {
 fn input_delay_increase_keeps_mesh_consistent() {
     for n in [2usize, 4] {
         let base = input_delay_change_schedule(n, None);
-        let changed = input_delay_change_schedule(n, Some(3));
+        let changed = input_delay_change_schedule(n, Some(2));
 
         let base_report = run(&base, &RunOptions::default());
         base_report.expect_pass(&base);
@@ -898,7 +901,7 @@ fn input_delay_increase_keeps_mesh_consistent() {
 /// delay — the reconfiguration path must not blind the oracle.
 #[test]
 fn oracle_catches_seeded_divergence_under_input_delay_change() {
-    let schedule = input_delay_change_schedule(4, Some(3));
+    let schedule = input_delay_change_schedule(4, Some(2));
     let options = RunOptions {
         corrupt_state_from: Some((0, 40)),
         ..RunOptions::default()
@@ -917,6 +920,22 @@ fn oracle_catches_seeded_divergence_under_input_delay_change() {
         "the oracle's state comparison must keep its teeth under a delay change: {:?}",
         report.verdict.failures
     );
+}
+
+/// A `SetInputDelay` naming a peer outside the mesh must fail loudly with the
+/// same clear message as the other events, not panic on a raw slice index — the
+/// per-event fail-loud contract of the up-front validation (parallels
+/// `run_rejects_out_of_range_peer_index`, since each event arm has its own
+/// message and would otherwise be unexercised).
+#[test]
+#[should_panic(expected = "out of range")]
+fn run_rejects_out_of_range_set_input_delay_peer() {
+    let mut schedule = input_delay_change_schedule(2, None);
+    schedule
+        .events
+        .push((100, ScheduleEvent::SetInputDelay { peer: 9, delay: 3 }));
+    schedule.events.sort_by_key(|(step, _)| *step);
+    let _ = run(&schedule, &RunOptions::default());
 }
 
 /// Diagnostic probe for a failing schedule: prints per-peer progress every 50

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -362,6 +362,10 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                     "PeerStall steps must be > 0 (a 0-step stall freezes nothing)"
                 );
             },
+            ScheduleEvent::SetInputDelay { peer, .. } => assert!(
+                *peer < n,
+                "SetInputDelay peer {peer} out of range for a {n}-peer mesh"
+            ),
             ScheduleEvent::HealAll => {},
         }
     }
@@ -462,6 +466,16 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 ScheduleEvent::PeerStall { peer, steps } => {
                     // `peer` in range and `steps > 0` are validated up front.
                     stalled_until[*peer] = step.saturating_add(*steps);
+                },
+                ScheduleEvent::SetInputDelay { peer, delay } => {
+                    // Reconfigure the peer's own local input delay mid-run. A
+                    // mid-session increase gap-fills and flushes to remotes; a
+                    // failure (e.g. pending-output full) is a real error the
+                    // oracle must surface, not swallow.
+                    let handle = PlayerHandle::new(*peer);
+                    if let Err(error) = peers[*peer].session.set_input_delay(handle, *delay) {
+                        oracle.observe_advance_error(*peer, step, &error);
+                    }
                 },
                 ScheduleEvent::HealAll => net.heal_all(),
             }

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -49,7 +49,9 @@ impl From<DropPolicy> for DisconnectBehavior {
 ///   link). A v1 reader cannot interpret a v2 schedule carrying a `PeerStall`,
 ///   so the format capability — not just this generator's output — dictates
 ///   the bump.
-pub const SCHEDULE_SCHEMA_VERSION: u32 = 2;
+/// - `3`: adds [`ScheduleEvent::SetInputDelay`] (a mid-run input-delay change,
+///   exercising the session's gap-fill/reconfiguration path).
+pub const SCHEDULE_SCHEMA_VERSION: u32 = 3;
 
 /// Background link-noise level applied to every directed link at start.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -148,6 +150,16 @@ pub enum ScheduleEvent {
     /// not a drop; the random generator does not emit this event yet (it lands
     /// with the M3 storyline overhaul, which re-blesses seed baselines).
     PeerStall { peer: usize, steps: u32 },
+    /// Set peer `peer`'s local input delay to `delay` frames mid-run
+    /// (`P2PSession::set_input_delay`). A mid-session *increase* is the
+    /// interesting case: it gap-fills the newly delayed frames with replicated
+    /// confirmed inputs and flushes them to every remote — a reconfiguration
+    /// path a fixed-delay fleet never exercises. Values are per-peer local, so
+    /// the mesh must still agree on every confirmed frame across the change.
+    ///
+    /// Like `PeerStall`, this is planted by lifecycle tests, not yet emitted by
+    /// the random generator (that lands with the §6.1 storyline overhaul).
+    SetInputDelay { peer: usize, delay: usize },
     /// Reset every link to clean and release all held traffic.
     HealAll,
 }
@@ -494,22 +506,32 @@ mod tests {
         );
     }
 
-    /// The lifecycle-vocabulary event must serialize losslessly — a corpus
-    /// artifact carrying a `PeerStall` has to replay the same hitch. The
-    /// generator does not yet emit it, so plant one explicitly.
+    /// The lifecycle-vocabulary events must serialize losslessly — a corpus
+    /// artifact carrying them has to replay the same faults. The generator does
+    /// not yet emit them, so plant them explicitly.
     #[test]
-    fn peer_stall_event_round_trips_through_json() {
+    fn lifecycle_events_round_trip_through_json() {
         let mut schedule = generate(42, SimConfig::smoke(3));
         schedule
             .events
             .push((200, ScheduleEvent::PeerStall { peer: 1, steps: 40 }));
+        schedule
+            .events
+            .push((250, ScheduleEvent::SetInputDelay { peer: 2, delay: 3 }));
         schedule.events.sort_by_key(|(step, _)| *step);
         let json = serde_json::to_string(&schedule).unwrap();
         let back: Schedule = serde_json::from_str(&json).unwrap();
-        assert_eq!(schedule, back, "PeerStall must round-trip losslessly");
+        assert_eq!(
+            schedule, back,
+            "lifecycle events must round-trip losslessly"
+        );
         assert!(back
             .events
             .iter()
             .any(|(_, ev)| matches!(ev, ScheduleEvent::PeerStall { peer: 1, steps: 40 })));
+        assert!(back
+            .events
+            .iter()
+            .any(|(_, ev)| matches!(ev, ScheduleEvent::SetInputDelay { peer: 2, delay: 3 })));
     }
 }


### PR DESCRIPTION
## Summary

Second **M3 §6.1 lifecycle-vocabulary** op: `ScheduleEvent::SetInputDelay { peer, delay }` raises a peer's local input delay mid-run, driving `P2PSession::set_input_delay`'s **mid-session gap-fill / flush reconfiguration path** — replicated confirmed inputs pushed to every remote, connect-status stamped, pending output flushed. That path is never exercised by the fixed-delay fleet, so this closes a real coverage gap. The change is local to one peer, so the mesh must still agree on every confirmed frame and keep progressing across it.

Follows the [`PeerStall` (#198)](https://github.com/wallstop/fortress-rollback/pull/198) pattern exactly.

## Changes (test-infra only — no `src/`, no public-crate API, no changelog)

- **`schedule.rs`**: new `SetInputDelay { peer, delay }` variant; `SCHEDULE_SCHEMA_VERSION` 2 → 3; the round-trip test now covers both lifecycle events. The random `generate()` is left untouched → existing seeds stay bit-identical.
- **`harness/mod.rs`**: the event handler calls `set_input_delay` on the peer's local handle and **surfaces any error via the oracle** (e.g. pending-output-full — never swallowed); `peer` index is validated in the shared up-front pass.
- **`fleet.rs`**:
  - `input_delay_increase_keeps_mesh_consistent` (n∈{2,4}) — the same clean schedule *with* vs *without* the delay change produces different traces (the reconfiguration demonstrably took effect, not a silent no-op) and reproduces deterministically, while both pass the oracle (the mesh stays byte-consistent across the change).
  - `oracle_catches_seeded_divergence_under_input_delay_change` — a real divergence seeded into a survivor still trips `StateDivergence` while a peer reconfigures its delay (the oracle keeps its teeth).

## Red → green

Neutralizing the `SetInputDelay` handler to a no-op fails the premise assertion:

```
assertion `left != right` failed: the SetInputDelay must change execution —
a silent no-op would leave the trace identical (n=2)
```

Restoring it makes it green.

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json` — clean
- `cargo nextest run` — 2355 passed · `--features hot-join` — 2594 passed · simulation binary — 94 passed
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulation test infrastructure; production `src/` and public APIs are untouched, with only additive schedule schema and harness behavior.
> 
> **Overview**
> Adds **M3 §6.1** simulation support for mid-run **input delay increases** via a new `ScheduleEvent::SetInputDelay { peer, delay }`, mirroring the existing `PeerStall` lifecycle pattern. **`SCHEDULE_SCHEMA_VERSION` bumps 2 → 3**; random `generate()` is unchanged so PR smoke seeds stay identical.
> 
> The harness **validates peer indices** for the new event and, at the scheduled step, calls **`P2PSession::set_input_delay`** on that peer—**reporting failures to the oracle** instead of swallowing them. **`fleet.rs`** adds planted schedules and tests: mesh consistency and trace determinism when delay rises vs a control run, oracle **StateDivergence** under seeded corruption during reconfiguration, and **out-of-range peer** rejection for `SetInputDelay`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb09582f422f6de29304b52775107d7f6715bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->