### PR TITLE
Hardening M3 §6.1: PeerKill lifecycle op (peer crash) + oracle alive-mask

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -942,9 +942,9 @@ fn run_rejects_out_of_range_set_input_delay_peer() {
 /// 1 crashes at step 100 — the harness stops driving it and detaches it from the
 /// fabric, so it never returns (not even after `HealAll`). Under `ContinueWithout`
 /// the three survivors time it out, freeze its slot, and keep confirming together
-/// on their own timeline; the crashed peer is excluded from the oracle. `None`
-/// yields the identical schedule without the kill, the control the premise
-/// compares to.
+/// on their own timeline; the crashed peer is excluded from the oracle's
+/// liveness checks. `None` yields the identical schedule without the kill, the
+/// control the premise compares to.
 fn peer_kill_schedule(kill: Option<usize>) -> Schedule {
     let n = 4;
     let config = SimConfig {
@@ -1012,7 +1012,8 @@ fn peer_kill_survivors_converge_under_continue_without() {
     );
 
     // The three survivors kept confirming; the crashed peer stayed frozen far
-    // behind them (and was excluded from the oracle, so the run still passed).
+    // behind them (excluded from the oracle's liveness checks, so it does not
+    // fail end-progress and the run still passes).
     let confirmed = &killed_report.final_confirmed;
     for (peer, &c) in confirmed.iter().enumerate() {
         if peer == 1 {

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1066,6 +1066,35 @@ fn oracle_catches_seeded_divergence_under_peer_kill() {
     );
 }
 
+/// A peer that diverges *before* it crashes must not escape detection by being
+/// killed. Corrupt the soon-to-be-killed peer 1 from frame 40, then crash it at
+/// step 100: its pre-death recorded states (frames 40..~99) diverge from the
+/// survivors and must still surface as `StateDivergence`. The alive-mask excises
+/// a dead peer from the liveness checks, not from pre-death state agreement — so
+/// a determinism bug on a doomed peer cannot hide behind its own crash.
+#[test]
+fn oracle_catches_pre_kill_divergence_on_the_killed_peer() {
+    let schedule = peer_kill_schedule(Some(1));
+    let options = RunOptions {
+        corrupt_state_from: Some((1, 40)),
+        ..RunOptions::default()
+    };
+    let report = run(&schedule, &options);
+    assert!(
+        !report.verdict.passed(),
+        "a pre-crash divergence on the killed peer must fail the run"
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::StateDivergence { .. })),
+        "the killed peer's pre-death states must still be compared (b): {:?}",
+        report.verdict.failures
+    );
+}
+
 /// A `PeerKill` naming a peer outside the mesh must fail loudly with the same
 /// clear message as the other events (per-event fail-loud contract of the
 /// up-front validation).

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -941,10 +941,10 @@ fn run_rejects_out_of_range_set_input_delay_peer() {
 /// Builds a peer-kill schedule: a clean 4-mesh (`ContinueWithout`) in which peer
 /// 1 crashes at step 100 — the harness stops driving it and detaches it from the
 /// fabric, so it never returns (not even after `HealAll`). Under `ContinueWithout`
-/// the three
-/// survivors time it out, freeze its slot, and keep confirming together on their
-/// own timeline; the crashed peer is excluded from the oracle. `None` yields the
-/// identical schedule without the kill, the control the premise compares to.
+/// the three survivors time it out, freeze its slot, and keep confirming together
+/// on their own timeline; the crashed peer is excluded from the oracle. `None`
+/// yields the identical schedule without the kill, the control the premise
+/// compares to.
 fn peer_kill_schedule(kill: Option<usize>) -> Schedule {
     let n = 4;
     let config = SimConfig {

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -983,7 +983,8 @@ fn peer_kill_schedule(kill: Option<usize>) -> Schedule {
 /// Under `ContinueWithout`, crashing one peer must degrade gracefully: the three
 /// survivors converge on dropping it (freeze its slot to an agreed value) and
 /// keep confirming *together* — no fork among them. The crashed peer is excluded
-/// from the oracle (it can't be `Running`), which is the alive-mask this op adds.
+/// from the oracle's liveness checks (it can't be `Running`), which is the
+/// alive-mask this op adds.
 ///
 /// This is the green half — a clean single-peer removal is not a partition, so
 /// the survivors must stay byte-consistent (contrast the symmetric split-brain,

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -939,8 +939,9 @@ fn run_rejects_out_of_range_set_input_delay_peer() {
 }
 
 /// Builds a peer-kill schedule: a clean 4-mesh (`ContinueWithout`) in which peer
-/// 1 crashes at step 100 — its session is dropped and detached, so it never
-/// returns (not even after `HealAll`). Under `ContinueWithout` the three
+/// 1 crashes at step 100 — the harness stops driving it and detaches it from the
+/// fabric, so it never returns (not even after `HealAll`). Under `ContinueWithout`
+/// the three
 /// survivors time it out, freeze its slot, and keep confirming together on their
 /// own timeline; the crashed peer is excluded from the oracle. `None` yields the
 /// identical schedule without the kill, the control the premise compares to.

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -938,6 +938,145 @@ fn run_rejects_out_of_range_set_input_delay_peer() {
     let _ = run(&schedule, &RunOptions::default());
 }
 
+/// Builds a peer-kill schedule: a clean 4-mesh (`ContinueWithout`) in which peer
+/// 1 crashes at step 100 — its session is dropped and detached, so it never
+/// returns (not even after `HealAll`). Under `ContinueWithout` the three
+/// survivors time it out, freeze its slot, and keep confirming together on their
+/// own timeline; the crashed peer is excluded from the oracle. `None` yields the
+/// identical schedule without the kill, the control the premise compares to.
+fn peer_kill_schedule(kill: Option<usize>) -> Schedule {
+    let n = 4;
+    let config = SimConfig {
+        n_players: n,
+        steps: 900,
+        disconnect_behavior: DropPolicy::ContinueWithout,
+        noise: BackgroundNoise::Clean,
+        ..SimConfig::smoke(n)
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, LinkPolicy::clean()));
+            }
+        }
+    }
+    let heal_at = 650;
+    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
+    if let Some(peer) = kill {
+        events.push((100, ScheduleEvent::PeerKill { peer }));
+    }
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
+/// M3 §6.1 lifecycle vocabulary — the peer crash (`ScheduleEvent::PeerKill`).
+/// Under `ContinueWithout`, crashing one peer must degrade gracefully: the three
+/// survivors converge on dropping it (freeze its slot to an agreed value) and
+/// keep confirming *together* — no fork among them. The crashed peer is excluded
+/// from the oracle (it can't be `Running`), which is the alive-mask this op adds.
+///
+/// This is the green half — a clean single-peer removal is not a partition, so
+/// the survivors must stay byte-consistent (contrast the symmetric split-brain,
+/// which forks). Premise (with-vs-without the kill diverges the trace) and
+/// determinism are asserted directly; the negative control below proves the
+/// oracle still catches a real divergence among the survivors.
+#[test]
+fn peer_kill_survivors_converge_under_continue_without() {
+    let base = peer_kill_schedule(None);
+    let killed = peer_kill_schedule(Some(1));
+
+    let base_report = run(&base, &RunOptions::default());
+    base_report.expect_pass(&base);
+    let killed_report = run(&killed, &RunOptions::default());
+    killed_report.expect_pass(&killed);
+
+    let killed_again = run(&killed, &RunOptions::default());
+    assert_eq!(
+        killed_report.trace_hash, killed_again.trace_hash,
+        "a PeerKill schedule must reproduce its exact trace"
+    );
+    assert_ne!(
+        base_report.trace_hash, killed_report.trace_hash,
+        "the PeerKill must change execution — a silent no-op would leave the \
+         trace identical"
+    );
+
+    // The three survivors kept confirming; the crashed peer stayed frozen far
+    // behind them (and was excluded from the oracle, so the run still passed).
+    let confirmed = &killed_report.final_confirmed;
+    for (peer, &c) in confirmed.iter().enumerate() {
+        if peer == 1 {
+            continue;
+        }
+        assert!(
+            c > 200,
+            "survivor {peer} must keep confirming after the crash: {confirmed:?}"
+        );
+    }
+    assert!(
+        confirmed[1] < confirmed[0],
+        "the crashed peer 1 must stay frozen behind the survivors: {confirmed:?}"
+    );
+}
+
+/// Negative control for the peer crash: a real state divergence seeded into a
+/// *surviving* peer must still be caught while another peer is crashed — the
+/// alive-mask must exclude only the dead peer, never blind the oracle to the
+/// survivors (the HD-1 "silent instrument" failure mode, checked against the
+/// new op).
+#[test]
+fn oracle_catches_seeded_divergence_under_peer_kill() {
+    let schedule = peer_kill_schedule(Some(1));
+    // Corrupt peer 0 (a survivor) from frame 300 — *after* the crash at step
+    // 100. This specifically exercises the alive-mask: the state-agreement check
+    // spans the globally-confirmed prefix, and without excluding the crashed
+    // peer that prefix would be pinned at its frozen frame (~99), hiding every
+    // post-crash survivor divergence. Excluding it lets the check reach frame
+    // 300 and catch the corruption.
+    let options = RunOptions {
+        corrupt_state_from: Some((0, 300)),
+        ..RunOptions::default()
+    };
+    let report = run(&schedule, &options);
+    assert!(
+        !report.verdict.passed(),
+        "a seeded divergence in a survivor must fail the run even under a crash"
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::StateDivergence { .. })),
+        "the oracle's state comparison must reach the post-crash survivor prefix \
+         (alive-mask) and catch the divergence: {:?}",
+        report.verdict.failures
+    );
+}
+
+/// A `PeerKill` naming a peer outside the mesh must fail loudly with the same
+/// clear message as the other events (per-event fail-loud contract of the
+/// up-front validation).
+#[test]
+#[should_panic(expected = "out of range")]
+fn run_rejects_out_of_range_peer_kill() {
+    let mut schedule = peer_kill_schedule(None);
+    schedule
+        .events
+        .push((100, ScheduleEvent::PeerKill { peer: 9 }));
+    schedule.events.sort_by_key(|(step, _)| *step);
+    let _ = run(&schedule, &RunOptions::default());
+}
+
 /// Diagnostic probe for a failing schedule: prints per-peer progress every 50
 /// steps. `#[ignore]`d — run manually while investigating a repro.
 #[test]

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1037,11 +1037,14 @@ fn peer_kill_survivors_converge_under_continue_without() {
 fn oracle_catches_seeded_divergence_under_peer_kill() {
     let schedule = peer_kill_schedule(Some(1));
     // Corrupt peer 0 (a survivor) from frame 300 — *after* the crash at step
-    // 100. This specifically exercises the alive-mask: the state-agreement check
-    // spans the globally-confirmed prefix, and without excluding the crashed
-    // peer that prefix would be pinned at its frozen frame (~99), hiding every
-    // post-crash survivor divergence. Excluding it lets the check reach frame
-    // 300 and catch the corruption.
+    // 100. This exercises the alive-mask's effect on the recorded-state
+    // comparison (b): that check spans the globally-confirmed prefix, and
+    // without excluding the crashed peer the prefix would be pinned at its
+    // frozen frame (~99), so (b) would never reach frame 300. The in-band desync
+    // detector still catches the corruption independently (so the *run* fails
+    // either way) — the mask is what keeps the oracle's own state-agreement
+    // signal from going blind past the crash. Assert `StateDivergence`
+    // specifically, the class the mask restores.
     let options = RunOptions {
         corrupt_state_from: Some((0, 300)),
         ..RunOptions::default()
@@ -1057,8 +1060,8 @@ fn oracle_catches_seeded_divergence_under_peer_kill() {
             .failures
             .iter()
             .any(|f| matches!(f, OracleFailure::StateDivergence { .. })),
-        "the oracle's state comparison must reach the post-crash survivor prefix \
-         (alive-mask) and catch the divergence: {:?}",
+        "the state comparison (b) must reach the post-crash survivor prefix via \
+         the alive-mask and flag StateDivergence (not just the in-band detector): {:?}",
         report.verdict.failures
     );
 }

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -488,9 +488,9 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 ScheduleEvent::PeerKill { peer } => {
                     // Crash the peer: stop driving it, discard its inbox (so
                     // further traffic to it is dropped under the default
-                    // `UnattachedPolicy::Drop`), and exclude it from the oracle.
-                    // Its remaining mesh survives per the configured
-                    // `DisconnectBehavior`. Idempotent.
+                    // `UnattachedPolicy::Drop`), and exclude it from the oracle's
+                    // liveness checks. Its remaining mesh survives per the
+                    // configured `DisconnectBehavior`. Idempotent.
                     dead[*peer] = true;
                     net.detach(addrs[*peer]);
                     oracle.mark_peer_dead(*peer);

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -366,6 +366,10 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 *peer < n,
                 "SetInputDelay peer {peer} out of range for a {n}-peer mesh"
             ),
+            ScheduleEvent::PeerKill { peer } => assert!(
+                *peer < n,
+                "PeerKill peer {peer} out of range for a {n}-peer mesh"
+            ),
             ScheduleEvent::HealAll => {},
         }
     }
@@ -444,6 +448,9 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     // `step < stalled_until[i]`. `0` means never stalled; a `PeerStall` event
     // sets it to `step + steps`.
     let mut stalled_until: Vec<u32> = vec![0; n];
+    // Peers killed by a `PeerKill` event: no longer driven, detached from the
+    // fabric, and excluded from the oracle's end-of-run checks.
+    let mut dead: Vec<bool> = vec![false; n];
     // Confirmed-frame snapshot taken at `options.probe_confirmed_at`, if any.
     let mut probe_confirmed: Vec<i32> = Vec::new();
 
@@ -477,21 +484,32 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                         oracle.observe_advance_error(*peer, step, &error);
                     }
                 },
+                ScheduleEvent::PeerKill { peer } => {
+                    // Crash the peer: stop driving it, discard its inbox (so
+                    // further traffic to it is dropped under the default
+                    // `UnattachedPolicy::Drop`), and exclude it from the oracle.
+                    // Its remaining mesh survives per the configured
+                    // `DisconnectBehavior`. Idempotent.
+                    dead[*peer] = true;
+                    net.detach(addrs[*peer]);
+                    oracle.mark_peer_dead(*peer);
+                },
                 ScheduleEvent::HealAll => net.heal_all(),
             }
             next_event += 1;
         }
 
-        // Drive every peer in fixed order. A peer inside its stall window is
-        // frozen (a local hang): it does not poll, drain events, add input, or
-        // advance, and puts nothing on the wire until it resumes. Its state is
-        // still folded into the trace below so the digest stays uniform and the
-        // stall reproduces bit-for-bit.
+        // Drive every peer in fixed order. A peer that is stalled (a local hang:
+        // frozen for its stall window) or dead (crashed by `PeerKill`) is not
+        // driven — it does not poll, drain events, add input, or advance, and
+        // puts nothing on the wire. A stalled peer resumes when its window ends;
+        // a dead peer never does. Either way its state is still folded into the
+        // trace below so the digest stays uniform and reproduces bit-for-bit.
         for (i, slot) in peers.iter_mut().enumerate() {
             // Confirmed frame after this step's drive (or the frozen value for a
-            // stalled peer): read exactly once and reused for both the trace
-            // fold and any probe snapshot.
-            let confirmed = if step >= stalled_until[i] {
+            // stalled/dead peer): read exactly once and reused for both the
+            // trace fold and any probe snapshot.
+            let confirmed = if !dead[i] && step >= stalled_until[i] {
                 slot.session.poll_remote_clients();
 
                 let events: Vec<FortressEvent<StubConfig>> = slot.session.events().collect();
@@ -534,7 +552,8 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 }
                 confirmed
             } else {
-                // Frozen peer (local hang): no poll/advance, no wire traffic.
+                // Stalled (local hang) or dead (crashed): no poll/advance, no
+                // wire traffic — just its last confirmed frame, frozen.
                 slot.session.confirmed_frame()
             };
 

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -449,7 +449,8 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     // sets it to `step + steps`.
     let mut stalled_until: Vec<u32> = vec![0; n];
     // Peers killed by a `PeerKill` event: no longer driven, detached from the
-    // fabric, and excluded from the oracle's end-of-run checks.
+    // fabric, and excluded from the oracle's liveness checks (their pre-death
+    // observations still count for agreement).
     let mut dead: Vec<bool> = vec![false; n];
     // Confirmed-frame snapshot taken at `options.probe_confirmed_at`, if any.
     let mut probe_confirmed: Vec<i32> = Vec::new();

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -157,9 +157,7 @@ impl Oracle {
             "mark_peer_dead: peer {peer} out of range (dead-mask len {})",
             self.dead.len()
         );
-        if let Some(slot) = self.dead.get_mut(peer) {
-            *slot = true;
-        }
+        self.dead[peer] = true;
     }
 
     /// Whether `peer` was killed mid-run.

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -473,7 +473,7 @@ mod tests {
         )));
     }
 
-    /// A killed peer is excluded from the end-of-run checks: it cannot fail
+    /// A killed peer is excluded from the liveness checks: it cannot fail
     /// end-progress (crashed, so never `Running`), while the *same* shortfall on
     /// a live peer still fails — the alive-mask must exclude only the dead.
     #[test]

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -86,6 +86,10 @@ pub enum OracleFailure {
         confirmed: i32,
         required: i32,
     },
+    /// Every peer was killed: there is nothing left to verify, so the run is a
+    /// vacuous pass unless flagged. A schedule that crashes the whole mesh
+    /// proves no correctness property and must not report success.
+    NoLivePeers { n_players: usize },
 }
 
 /// Final verdict of a run.
@@ -273,6 +277,15 @@ impl Oracle {
                     required: MIN_END_CONFIRMED,
                 });
             }
+        }
+
+        // Guard against a vacuous pass: if every peer was killed, the excluded
+        // end-checks below all skip and the run would report success with
+        // nothing verified. A whole-mesh crash proves no property.
+        if self.n_players > 0 && (0..self.n_players).all(|peer| self.is_dead(peer)) {
+            self.push_failure(OracleFailure::NoLivePeers {
+                n_players: self.n_players,
+            });
         }
 
         // (b) state agreement over the globally confirmed prefix. The prefix is
@@ -487,6 +500,29 @@ mod tests {
                 .any(|f| matches!(f, OracleFailure::EndProgress { peer: 1, .. })),
             "a live peer with the same shortfall must fail: {:?}",
             control.failures
+        );
+    }
+
+    /// Killing *every* peer must not be a vacuous pass: with no live peer left,
+    /// the excluded end-checks all skip, so the oracle flags `NoLivePeers`
+    /// rather than reporting success for a mesh that proved nothing.
+    #[test]
+    fn oracle_flags_all_peers_killed_as_no_live_peers() {
+        let mut oracle = Oracle::new(2);
+        oracle.mark_peer_dead(0);
+        oracle.mark_peer_dead(1);
+        let verdict = oracle.finalize(
+            &[BTreeMap::new(), BTreeMap::new()],
+            &[Frame::new(500), Frame::new(500)],
+            &[SessionState::Running, SessionState::Running],
+        );
+        assert!(
+            verdict
+                .failures
+                .iter()
+                .any(|f| matches!(f, OracleFailure::NoLivePeers { n_players: 2 })),
+            "an all-crashed mesh must fail, not vacuously pass: {:?}",
+            verdict.failures
         );
     }
 

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -123,11 +123,13 @@ pub struct Oracle {
     /// guaranteed representation.
     per_class_cap: usize,
     /// Peers that were killed mid-run (`ScheduleEvent::PeerKill`). A crashed
-    /// peer is gone and no longer observable, so it is excluded from the
-    /// end-of-run checks: it cannot satisfy the `Running`/end-progress bar, and
-    /// its frozen confirmed frame must not drag the globally-confirmed prefix
-    /// below where the survivors actually agree. Pre-death observations already
-    /// entered the canonical stream and stand.
+    /// peer is excluded from the *liveness* checks only: it cannot satisfy the
+    /// `Running`/end-progress bar (c-lite), and its frozen confirmed frame must
+    /// not drag the globally-confirmed prefix below where the survivors agree.
+    /// Its **pre-death** observations still count — recorded states it produced
+    /// before crashing are compared in (b), and its confirmed-input samples
+    /// stand in (a) — so a peer that diverged before it died cannot escape
+    /// detection by being killed.
     dead: Vec<bool>,
 }
 
@@ -302,12 +304,13 @@ impl Oracle {
         // the result of simulating frame N with confirmed inputs ≤ N), so a
         // frame's state is final once the *previous* frame is confirmed;
         // comparing up to `global_confirmed` stays strictly inside the final
-        // region.
+        // region. Killed peers are NOT skipped here: their *pre-death* recorded
+        // states are real observations for the frames they produced, so a peer
+        // that diverged before it crashed is still caught (it cannot escape the
+        // check merely by being killed). They only lack states past their death,
+        // so they never contribute past the survivor prefix.
         let mut canonical_states: BTreeMap<i32, (usize, StateStub)> = BTreeMap::new();
         for (peer, states) in recorded.iter().enumerate() {
-            if self.is_dead(peer) {
-                continue;
-            }
             for (&frame, &state) in states.range(..=global_confirmed) {
                 match canonical_states.get(&frame) {
                     None => {

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -146,9 +146,17 @@ impl Oracle {
         }
     }
 
-    /// Marks `peer` as killed (crashed): it is excluded from the end-of-run
-    /// checks in [`Self::finalize`]. Idempotent; out-of-range is a no-op.
+    /// Marks `peer` as killed (crashed): it is excluded from the liveness
+    /// checks in [`Self::finalize`]. Idempotent for in-range peers. An
+    /// out-of-range peer is a programming error — the runner validates every
+    /// event's peer index up front — so it panics loudly rather than silently
+    /// leaving the mask unset.
     pub fn mark_peer_dead(&mut self, peer: usize) {
+        assert!(
+            peer < self.dead.len(),
+            "mark_peer_dead: peer {peer} out of range (dead-mask len {})",
+            self.dead.len()
+        );
         if let Some(slot) = self.dead.get_mut(peer) {
             *slot = true;
         }

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -118,6 +118,13 @@ pub struct Oracle {
     /// anti-pattern inside the oracle itself). Every class is now
     /// guaranteed representation.
     per_class_cap: usize,
+    /// Peers that were killed mid-run (`ScheduleEvent::PeerKill`). A crashed
+    /// peer is gone and no longer observable, so it is excluded from the
+    /// end-of-run checks: it cannot satisfy the `Running`/end-progress bar, and
+    /// its frozen confirmed frame must not drag the globally-confirmed prefix
+    /// below where the survivors actually agree. Pre-death observations already
+    /// entered the canonical stream and stand.
+    dead: Vec<bool>,
 }
 
 impl Oracle {
@@ -129,7 +136,21 @@ impl Oracle {
             failures: Vec::new(),
             failure_cap: 64,
             per_class_cap: 8,
+            dead: vec![false; n_players],
         }
+    }
+
+    /// Marks `peer` as killed (crashed): it is excluded from the end-of-run
+    /// checks in [`Self::finalize`]. Idempotent; out-of-range is a no-op.
+    pub fn mark_peer_dead(&mut self, peer: usize) {
+        if let Some(slot) = self.dead.get_mut(peer) {
+            *slot = true;
+        }
+    }
+
+    /// Whether `peer` was killed mid-run.
+    fn is_dead(&self, peer: usize) -> bool {
+        self.dead.get(peer).copied().unwrap_or(false)
     }
 
     fn push_failure(&mut self, failure: OracleFailure) {
@@ -229,8 +250,12 @@ impl Oracle {
         assert_eq!(end_confirmed.len(), self.n_players);
         assert_eq!(end_state.len(), self.n_players);
 
-        // (c-lite) end progress per peer.
+        // (c-lite) end progress per peer. Killed peers are excluded — a crashed
+        // peer cannot be `Running` and its frozen frame is not its own fault.
         for peer in 0..self.n_players {
+            if self.is_dead(peer) {
+                continue;
+            }
             let confirmed = end_confirmed
                 .get(peer)
                 .copied()
@@ -250,10 +275,14 @@ impl Oracle {
             }
         }
 
-        // (b) state agreement over the globally confirmed prefix.
+        // (b) state agreement over the globally confirmed prefix. The prefix is
+        // the minimum over *live* peers only — a killed peer's frozen confirmed
+        // frame must not shrink the window the survivors are checked across.
         let global_confirmed = end_confirmed
             .iter()
-            .map(|frame| frame.as_i32())
+            .enumerate()
+            .filter(|(peer, _)| !self.is_dead(*peer))
+            .map(|(_, frame)| frame.as_i32())
             .min()
             .unwrap_or(-1);
         // Recorded states are keyed by post-advance frame (frame N+1 holds
@@ -263,6 +292,9 @@ impl Oracle {
         // region.
         let mut canonical_states: BTreeMap<i32, (usize, StateStub)> = BTreeMap::new();
         for (peer, states) in recorded.iter().enumerate() {
+            if self.is_dead(peer) {
+                continue;
+            }
             for (&frame, &state) in states.range(..=global_confirmed) {
                 match canonical_states.get(&frame) {
                     None => {
@@ -417,6 +449,45 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    /// A killed peer is excluded from the end-of-run checks: it cannot fail
+    /// end-progress (crashed, so never `Running`), while the *same* shortfall on
+    /// a live peer still fails — the alive-mask must exclude only the dead.
+    #[test]
+    fn oracle_excludes_killed_peer_from_end_checks() {
+        // Peer 1 is dead (stuck in Synchronizing); peers 0 and 2 are healthy.
+        let recorded = [BTreeMap::new(), BTreeMap::new(), BTreeMap::new()];
+        let confirmed = [Frame::new(500), Frame::new(3), Frame::new(500)];
+        let states = [
+            SessionState::Running,
+            SessionState::Synchronizing,
+            SessionState::Running,
+        ];
+
+        let mut killed = Oracle::new(3);
+        killed.mark_peer_dead(1);
+        let verdict = killed.finalize(&recorded, &confirmed, &states);
+        assert!(
+            !verdict
+                .failures
+                .iter()
+                .any(|f| matches!(f, OracleFailure::EndProgress { peer: 1, .. })),
+            "a killed peer must not fail end-progress: {:?}",
+            verdict.failures
+        );
+
+        // Control: the identical shortfall on a *live* peer 1 does fail.
+        let live = Oracle::new(3);
+        let control = live.finalize(&recorded, &confirmed, &states);
+        assert!(
+            control
+                .failures
+                .iter()
+                .any(|f| matches!(f, OracleFailure::EndProgress { peer: 1, .. })),
+            "a live peer with the same shortfall must fail: {:?}",
+            control.failures
+        );
     }
 
     /// Negative control: a desync event and an `Error`-severity violation each

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -170,6 +170,14 @@ pub enum ScheduleEvent {
     /// Distinct from a network black-hole (`Block`), where the peer keeps
     /// running and observing. `HealAll` does not revive it.
     ///
+    /// Survivor byte-consistency after a kill is a property of
+    /// `DisconnectBehavior::ContinueWithout` over a clean-enough link (the
+    /// freeze-convergence path). Under `Halt` the mesh instead halts with
+    /// fabricated frames (defect D13), and under heavy loss a survivor could
+    /// confirm a fabricated slot value the dead peer had already contributed —
+    /// so the oracle's unmasked confirmed-input agreement is only sound for the
+    /// `ContinueWithout` case the planted tests use.
+    ///
     /// Planted by lifecycle tests, not yet emitted by the random generator.
     PeerKill { peer: usize },
     /// Reset every link to clean and release all held traffic.

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -166,8 +166,9 @@ pub enum ScheduleEvent {
     /// Permanently kill peer `peer`: the harness stops driving its session and
     /// detaches it from the fabric (its inbox is discarded; further traffic to
     /// it is dropped). Models a **crash** — the peer is gone for good and, being
-    /// no longer observable, is excluded from the oracle's end-of-run checks
-    /// (its remaining mesh survives per the configured `DisconnectBehavior`).
+    /// no longer observable, is excluded from the oracle's *liveness* checks
+    /// (its pre-death observations still count for agreement; its remaining mesh
+    /// survives per the configured `DisconnectBehavior`).
     /// Distinct from a network black-hole (`Block`), where the peer keeps
     /// running and observing. `HealAll` does not revive it.
     ///

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -51,7 +51,9 @@ impl From<DropPolicy> for DisconnectBehavior {
 ///   the bump.
 /// - `3`: adds [`ScheduleEvent::SetInputDelay`] (a mid-run input-delay change,
 ///   exercising the session's gap-fill/reconfiguration path).
-pub const SCHEDULE_SCHEMA_VERSION: u32 = 3;
+/// - `4`: adds [`ScheduleEvent::PeerKill`] (a peer crash — session dropped and
+///   detached from the fabric — modeled distinctly from a network black-hole).
+pub const SCHEDULE_SCHEMA_VERSION: u32 = 4;
 
 /// Background link-noise level applied to every directed link at start.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -160,6 +162,16 @@ pub enum ScheduleEvent {
     /// Like `PeerStall`, this is planted by lifecycle tests, not yet emitted by
     /// the random generator (that lands with the §6.1 storyline overhaul).
     SetInputDelay { peer: usize, delay: usize },
+    /// Permanently kill peer `peer`: the harness stops driving its session and
+    /// detaches it from the fabric (its inbox is discarded; further traffic to
+    /// it is dropped). Models a **crash** — the peer is gone for good and, being
+    /// no longer observable, is excluded from the oracle's end-of-run checks
+    /// (its remaining mesh survives per the configured `DisconnectBehavior`).
+    /// Distinct from a network black-hole (`Block`), where the peer keeps
+    /// running and observing. `HealAll` does not revive it.
+    ///
+    /// Planted by lifecycle tests, not yet emitted by the random generator.
+    PeerKill { peer: usize },
     /// Reset every link to clean and release all held traffic.
     HealAll,
 }
@@ -518,6 +530,9 @@ mod tests {
         schedule
             .events
             .push((250, ScheduleEvent::SetInputDelay { peer: 2, delay: 3 }));
+        schedule
+            .events
+            .push((300, ScheduleEvent::PeerKill { peer: 2 }));
         schedule.events.sort_by_key(|(step, _)| *step);
         let json = serde_json::to_string(&schedule).unwrap();
         let back: Schedule = serde_json::from_str(&json).unwrap();
@@ -533,5 +548,9 @@ mod tests {
             .events
             .iter()
             .any(|(_, ev)| matches!(ev, ScheduleEvent::SetInputDelay { peer: 2, delay: 3 })));
+        assert!(back
+            .events
+            .iter()
+            .any(|(_, ev)| matches!(ev, ScheduleEvent::PeerKill { peer: 2 })));
     }
 }

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -51,8 +51,9 @@ impl From<DropPolicy> for DisconnectBehavior {
 ///   the bump.
 /// - `3`: adds [`ScheduleEvent::SetInputDelay`] (a mid-run input-delay change,
 ///   exercising the session's gap-fill/reconfiguration path).
-/// - `4`: adds [`ScheduleEvent::PeerKill`] (a peer crash — session dropped and
-///   detached from the fabric — modeled distinctly from a network black-hole).
+/// - `4`: adds [`ScheduleEvent::PeerKill`] (a peer crash — the harness stops
+///   driving the peer and detaches it from the fabric — modeled distinctly from
+///   a network black-hole).
 pub const SCHEDULE_SCHEMA_VERSION: u32 = 4;
 
 /// Background link-noise level applied to every directed link at start.


### PR DESCRIPTION
## Summary

Third **M3 §6.1 lifecycle-vocabulary** op — and the first oracle-coupled one, so it introduces the **alive-mask** that §6.2 liveness needs. `ScheduleEvent::PeerKill { peer }` crashes a peer: the harness stops driving it and detaches it from the fabric (its inbox is discarded, further traffic dropped under the default `UnattachedPolicy::Drop`), and the oracle excludes it from end-of-run checks. Distinct from a network black-hole (`Block`), where the peer keeps running and observing; `HealAll` does not revive it.

## Changes (test-infra only — no `src/`, no public-crate API, no changelog)

- **`schedule.rs`**: `PeerKill { peer }`; `SCHEDULE_SCHEMA_VERSION` 3 → 4; the round-trip test covers all three lifecycle events. Random `generate()` untouched → existing seeds bit-identical.
- **`oracle.rs`**: a `dead` mask + `mark_peer_dead`; `finalize` excludes dead peers from the (c-lite) end-progress bar **and** takes the globally-confirmed prefix over **live peers only** — a crashed peer's frozen frame must not truncate the survivor state-agreement check. New unit test `oracle_excludes_killed_peer_from_end_checks` (dead excluded, live with the same shortfall still fails).
- **`harness/mod.rs`**: a `dead` mask; the PeerKill handler detaches + `mark_peer_dead`; the drive loop skips dead peers (folding their frozen state so the trace stays uniform); the `peer` index is validated in the shared up-front pass.
- **`fleet.rs`**:
  - `peer_kill_survivors_converge_under_continue_without` — **GREEN**: under `ContinueWithout`, a single crash degrades gracefully. The three survivors converge on dropping the crashed peer and keep confirming **together, byte-consistent** — no fork (contrast the symmetric split-brain, which forks, and Halt's D13 fabricated-frame divergence). Premise (with-vs-without the kill diverges the trace) + determinism.
  - `oracle_catches_seeded_divergence_under_peer_kill` — a survivor corrupted at frame **300, after the crash at step 100**. This specifically exercises the alive-mask: without excluding the crashed peer, the state-agreement prefix would be pinned at its frozen frame (~99) and every post-crash survivor divergence would be invisible to that check. **Verified load-bearing**: neutralizing the mask makes this test miss the `StateDivergence` (only the in-band detector still fires).
  - `run_rejects_out_of_range_peer_kill` — `should_panic` fail-loud contract.

## Red → green

- Premise: neutralizing the `PeerKill` handler leaves the trace identical → the premise assertion fails.
- Alive-mask: neutralizing `is_dead` makes `oracle_catches_seeded_divergence_under_peer_kill` miss the post-crash `StateDivergence` (`global_confirmed` pinned at the crashed peer's frozen ~99 < 300) — proving the mask is load-bearing, not decoration.

## Data

Crashing peer 1 of 4 under `ContinueWithout` keeps survivors {0,2,3} byte-consistent through end-of-run — the graceful-degradation counterpart to the split-brain fork and the Halt D13 divergence already pinned in the fleet.

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json` — clean
- `cargo nextest run` — 2360 passed · `--features hot-join` — 2599 passed · simulation binary — 99 passed
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test simulation harness and oracle; no production `src/` or public API changes.
> 
> **Overview**
> **M3 §6.1 lifecycle:** introduces `ScheduleEvent::PeerKill` and bumps schedule schema **3 → 4**. On kill, the harness stops driving the peer, detaches it from `SimNet`, and marks it dead in the oracle; `HealAll` does not revive it.
> 
> The oracle gains a **dead-peer mask**: killed peers skip end-progress liveness, **global confirmed prefix** is the min over **live** peers only (so a frozen crash frame does not shrink survivor state checks), pre-death recorded states still participate in agreement, and **all peers killed** yields `NoLivePeers` instead of a vacuous pass.
> 
> **Fleet tests** cover graceful survivor convergence under `ContinueWithout`, post-crash and pre-kill `StateDivergence` detection, determinism/premise, and out-of-range validation. Random `generate()` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d2ab88e8274eba11069927285ba6aefb4c045da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->