### PR TITLE
Hardening M3 §6.6-pre.3: WaitRecommendation-obeying app model (H-OSC probe)

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -6,7 +6,7 @@
 //! proves nothing.
 
 use super::harness::schedule::{
-    generate, BackgroundNoise, DropPolicy, Schedule, ScheduleEvent, SimConfig,
+    generate, AppModel, BackgroundNoise, DropPolicy, Schedule, ScheduleEvent, SimConfig,
     SCHEDULE_SCHEMA_VERSION,
 };
 use super::harness::{oracle::OracleFailure, run, RunOptions};
@@ -1110,6 +1110,99 @@ fn run_rejects_out_of_range_peer_kill() {
         .push((100, ScheduleEvent::PeerKill { peer: 9 }));
     schedule.events.sort_by_key(|(step, _)| *step);
     let _ = run(&schedule, &RunOptions::default());
+}
+
+/// Builds a schedule that reliably drives `WaitRecommendation`s: an `n`-mesh
+/// over clean links with **asymmetric one-way delay** (lower→higher index 20ms,
+/// the reverse 120ms). The asymmetry biases the RTT/2 frame-advantage estimate
+/// (defect D11), so a persistent advantage builds and the time-sync loop emits
+/// skip recommendations — a symmetric delay produces none (both peers lockstep).
+/// `app_model` selects whether the harness obeys them.
+fn wait_rec_schedule(n: usize, app_model: AppModel) -> Schedule {
+    let config = SimConfig {
+        n_players: n,
+        steps: 900,
+        noise: BackgroundNoise::Clean,
+        app_model,
+        ..SimConfig::smoke(n)
+    };
+    let link = |ms: u64| LinkPolicy {
+        drop_rate: 0.0,
+        dup_rate: 0.0,
+        base_delay: Duration::from_millis(ms),
+        jitter: Duration::ZERO,
+        burst_rate: 0.0,
+        burst_len: 0,
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                let ms = if from < to { 20 } else { 120 };
+                initial_links.push((from, to, link(ms)));
+            }
+        }
+    }
+    let heal_at = 650;
+    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
+/// M3 §6.6-pre.3 — the WaitRecommendation-obeying app model (H-OSC precondition).
+/// The reference client and every prior fleet run *ignore* `WaitRecommendation`,
+/// leaving the time-sync loop open. Obeying it (skip the recommended advances)
+/// closes the loop; the question H-OSC asks is whether the closed loop stays
+/// damped or oscillates. Here it must stay **consistent and live** under
+/// symmetric delay: the mesh confirms a byte-identical prefix whether obeying or
+/// ignoring, so obeying does not diverge or deadlock it.
+///
+/// Premise: the same delayed schedule generates real `WaitRecommendation`s
+/// (asserted via metrics), and obeying vs ignoring produces different execution
+/// traces (the skips actually happened) — while both pass the oracle.
+#[test]
+fn app_model_obey_wait_recommendation_stays_consistent() {
+    for n in [2usize, 4] {
+        let ignore = wait_rec_schedule(n, AppModel::Ignore);
+        let obey = wait_rec_schedule(n, AppModel::Obey);
+
+        let ignore_report = run(&ignore, &RunOptions::default());
+        ignore_report.expect_pass(&ignore);
+        let obey_report = run(&obey, &RunOptions::default());
+        obey_report.expect_pass(&obey);
+
+        // The schedule must actually generate WaitRecommendations, or the app
+        // model has nothing to obey (the H-OSC precondition).
+        let total_wait_recs: u64 = ignore_report
+            .metrics
+            .iter()
+            .map(|m| m.wait_recommendations)
+            .sum();
+        assert!(
+            total_wait_recs > 0,
+            "the delayed schedule must emit WaitRecommendations to probe H-OSC \
+             (n={n}, got {total_wait_recs})"
+        );
+
+        let obey_again = run(&obey, &RunOptions::default());
+        assert_eq!(
+            obey_report.trace_hash, obey_again.trace_hash,
+            "an Obey run must reproduce its exact trace (n={n})"
+        );
+        assert_ne!(
+            ignore_report.trace_hash, obey_report.trace_hash,
+            "obeying WaitRecommendation must change execution — the skips must \
+             actually happen (n={n})"
+        );
+    }
 }
 
 /// Diagnostic probe for a failing schedule: prints per-peer progress every 50

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1157,17 +1157,23 @@ fn wait_rec_schedule(n: usize, app_model: AppModel) -> Schedule {
     }
 }
 
-/// M3 §6.6-pre.3 — the WaitRecommendation-obeying app model (H-OSC precondition).
-/// The reference client and every prior fleet run *ignore* `WaitRecommendation`,
-/// leaving the time-sync loop open. Obeying it (skip the recommended advances)
-/// closes the loop; the question H-OSC asks is whether the closed loop stays
-/// damped or oscillates. Here it must stay **consistent and live** under
-/// symmetric delay: the mesh confirms a byte-identical prefix whether obeying or
-/// ignoring, so obeying does not diverge or deadlock it.
+/// M3 §6.6-pre.3 — the WaitRecommendation-obeying app model. The reference
+/// client and every prior fleet run *ignore* `WaitRecommendation`, leaving the
+/// time-sync control loop **open**, so oscillation (H-OSC) is unobservable.
+/// Obeying it (skip the recommended advances) closes the loop.
 ///
-/// Premise: the same delayed schedule generates real `WaitRecommendation`s
-/// (asserted via metrics), and obeying vs ignoring produces different execution
-/// traces (the skips actually happened) — while both pass the oracle.
+/// This is the H-OSC *precondition infra* plus an asymmetric-delay
+/// side-observation — **not** the full H-OSC experiment, which is symmetric
+/// delay + Obey (mutual-sleep contention, FM-3) and is still owed. Under this
+/// one-sided (asymmetric-delay) obedience the closed loop must stay consistent
+/// and live: every peer confirms a byte-identical *state* prefix whether obeying
+/// or ignoring (both pass the oracle), even though the execution *trace* differs
+/// (Obey paces the ahead peer differently). Obeying must not diverge or deadlock
+/// the mesh.
+///
+/// Premise: under Obey (the run whose obedience is under test) the schedule
+/// emits real `WaitRecommendation`s, and obeying vs ignoring produces different
+/// traces (the skips actually happened).
 #[test]
 fn app_model_obey_wait_recommendation_stays_consistent() {
     for n in [2usize, 4] {
@@ -1179,17 +1185,18 @@ fn app_model_obey_wait_recommendation_stays_consistent() {
         let obey_report = run(&obey, &RunOptions::default());
         obey_report.expect_pass(&obey);
 
-        // The schedule must actually generate WaitRecommendations, or the app
-        // model has nothing to obey (the H-OSC precondition).
-        let total_wait_recs: u64 = ignore_report
+        // The Obey run itself must emit WaitRecommendations, or there was
+        // nothing to obey (the H-OSC precondition — measured on the run under
+        // test, not the Ignore control).
+        let obey_wait_recs: u64 = obey_report
             .metrics
             .iter()
             .map(|m| m.wait_recommendations)
             .sum();
         assert!(
-            total_wait_recs > 0,
-            "the delayed schedule must emit WaitRecommendations to probe H-OSC \
-             (n={n}, got {total_wait_recs})"
+            obey_wait_recs > 0,
+            "the delayed schedule must emit WaitRecommendations under Obey to \
+             probe H-OSC (n={n}, got {obey_wait_recs})"
         );
 
         let obey_again = run(&obey, &RunOptions::default());

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -28,7 +28,7 @@ use fortress_rollback::{
     SessionBuilder, SessionState,
 };
 use oracle::{Oracle, Verdict};
-use schedule::{Schedule, ScheduleEvent};
+use schedule::{AppModel, Schedule, ScheduleEvent};
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -452,6 +452,11 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     // fabric, and excluded from the oracle's liveness checks (their pre-death
     // observations still count for agreement).
     let mut dead: Vec<bool> = vec![false; n];
+    // Per-peer count of advances still owed to an obeyed `WaitRecommendation`
+    // (only accumulates under `AppModel::Obey`). While > 0 the peer polls but
+    // does not advance, letting the others catch up — the closed time-sync loop.
+    let app_model = schedule.config.app_model;
+    let mut wait_skip: Vec<u32> = vec![0; n];
     // Confirmed-frame snapshot taken at `options.probe_confirmed_at`, if any.
     let mut probe_confirmed: Vec<i32> = Vec::new();
 
@@ -518,10 +523,22 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                     if let FortressEvent::DesyncDetected { frame, .. } = event {
                         oracle.observe_desync_event(i, *frame);
                     }
+                    // Closed-loop app model: obey a `WaitRecommendation` by owing
+                    // that many skipped advances (max so a stronger one wins).
+                    if app_model == AppModel::Obey {
+                        if let FortressEvent::WaitRecommendation { skip_frames } = event {
+                            wait_skip[i] = wait_skip[i].max(*skip_frames);
+                        }
+                    }
                     fold_trace(&mut trace_hash, &format!("{event:?}"));
                 }
 
-                if slot.session.current_state() == SessionState::Running {
+                if wait_skip[i] > 0 {
+                    // Obeying a WaitRecommendation: poll/receive this step (done
+                    // above) but skip the advance so the ahead peer lets the
+                    // others catch up — the time-sync loop, now closed.
+                    wait_skip[i] -= 1;
+                } else if slot.session.current_state() == SessionState::Running {
                     for handle in slot.session.local_player_handles() {
                         if let Err(error) = slot.session.add_local_input(handle, input_for(step, i))
                         {

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -533,21 +533,28 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                     fold_trace(&mut trace_hash, &format!("{event:?}"));
                 }
 
-                if wait_skip[i] > 0 {
-                    // Obeying a WaitRecommendation: poll/receive this step (done
-                    // above) but skip the advance so the ahead peer lets the
-                    // others catch up — the time-sync loop, now closed.
-                    wait_skip[i] -= 1;
-                } else if slot.session.current_state() == SessionState::Running {
-                    for handle in slot.session.local_player_handles() {
-                        if let Err(error) = slot.session.add_local_input(handle, input_for(step, i))
-                        {
-                            oracle.observe_advance_error(i, step, &error);
+                if slot.session.current_state() == SessionState::Running {
+                    if wait_skip[i] > 0 {
+                        // Obeying a WaitRecommendation: poll/receive this step
+                        // (done above) but skip the advance so the ahead peer
+                        // lets the others catch up. Count down only on steps that
+                        // would otherwise advance (i.e. while `Running`) — a peer
+                        // that briefly leaves `Running` mid-wait (transient
+                        // resync) must not silently consume its owed skips, or it
+                        // would stop obeying once it resumes.
+                        wait_skip[i] -= 1;
+                    } else {
+                        for handle in slot.session.local_player_handles() {
+                            if let Err(error) =
+                                slot.session.add_local_input(handle, input_for(step, i))
+                            {
+                                oracle.observe_advance_error(i, step, &error);
+                            }
                         }
-                    }
-                    match slot.session.advance_frame() {
-                        Ok(requests) => slot.game.handle_requests(requests),
-                        Err(error) => oracle.observe_advance_error(i, step, &error),
+                        match slot.session.advance_frame() {
+                            Ok(requests) => slot.game.handle_requests(requests),
+                            Err(error) => oracle.observe_advance_error(i, step, &error),
+                        }
                     }
                 }
 

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -589,4 +589,23 @@ mod tests {
             .iter()
             .any(|(_, ev)| matches!(ev, ScheduleEvent::PeerKill { peer: 2 })));
     }
+
+    /// A corpus artifact predating the `app_model` axis (its `config` object has
+    /// no such field) must deserialize to `Ignore` — the open-loop behavior every
+    /// earlier run used — so old schedules replay bit-identically. This pins the
+    /// `#[serde(default)]` contract the "no schema bump" claim rests on.
+    #[test]
+    fn config_without_app_model_field_defaults_to_ignore() {
+        let schedule = generate(42, SimConfig::smoke(2));
+        let mut value = serde_json::to_value(&schedule).unwrap();
+        if let Some(config) = value.get_mut("config").and_then(|c| c.as_object_mut()) {
+            config.remove("app_model");
+        }
+        let back: Schedule = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            back.config.app_model,
+            AppModel::Ignore,
+            "a pre-axis config (no app_model) must default to Ignore"
+        );
+    }
 }

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -41,6 +41,26 @@ impl From<DropPolicy> for DisconnectBehavior {
     }
 }
 
+/// How the harness's app model reacts to `FortressEvent::WaitRecommendation`.
+///
+/// The real time-sync control loop is only closed if the application actually
+/// *obeys* the recommendation (skips the recommended frames to let peers catch
+/// up). The reference client and every prior fleet run **ignore** it, leaving
+/// the loop open — so oscillation (H-OSC) is unobservable. This makes the app
+/// behavior an explicit, per-run axis.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AppModel {
+    /// Ignore `WaitRecommendation` — the open-loop behavior of the reference
+    /// client (and of every fleet run before this axis existed). The default,
+    /// so pre-existing schedules replay identically.
+    #[default]
+    Ignore,
+    /// Obey `WaitRecommendation`: skip `skip_frames` advances (poll but do not
+    /// advance) so the ahead peer lets the others catch up — closing the
+    /// time-sync loop the H-OSC hypothesis probes.
+    Obey,
+}
+
 /// Schema version for serialized schedules (bump on breaking layout change).
 ///
 /// - `1`: network-fault vocabulary only (`SetLink`/`Block`/`Hold`/`HealAll`).
@@ -90,6 +110,11 @@ pub struct SimConfig {
     /// replayable without a schema bump.
     #[serde(default)]
     pub disconnect_behavior: DropPolicy,
+    /// How every peer's app model reacts to `WaitRecommendation`.
+    /// `#[serde(default)]` (= `Ignore`, the open-loop behavior every prior run
+    /// used) keeps pre-existing corpus artifacts replayable without a bump.
+    #[serde(default)]
+    pub app_model: AppModel,
 }
 
 impl SimConfig {
@@ -109,6 +134,7 @@ impl SimConfig {
             desync_interval: 30,
             noise: BackgroundNoise::Mild,
             disconnect_behavior: DropPolicy::default(),
+            app_model: AppModel::default(),
         }
     }
 

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -598,9 +598,17 @@ mod tests {
     fn config_without_app_model_field_defaults_to_ignore() {
         let schedule = generate(42, SimConfig::smoke(2));
         let mut value = serde_json::to_value(&schedule).unwrap();
-        if let Some(config) = value.get_mut("config").and_then(|c| c.as_object_mut()) {
-            config.remove("app_model");
-        }
+        let config = value
+            .get_mut("config")
+            .and_then(|c| c.as_object_mut())
+            .expect("a serialized schedule must have a `config` object");
+        // The field must actually be present to remove — otherwise the test
+        // would pass vacuously (a full config also deserializes fine) without
+        // ever exercising the missing-field default it exists to pin.
+        assert!(
+            config.remove("app_model").is_some(),
+            "config must serialize an `app_model` field for this test to remove"
+        );
         let back: Schedule = serde_json::from_value(value).unwrap();
         assert_eq!(
             back.config.app_model,


### PR DESCRIPTION
## Summary

**M3 §6.6-pre.3** — closes the time-sync control loop in the DST harness. The harness driver (like `ex_game` and every prior fleet run) **ignored** `FortressEvent::WaitRecommendation`, leaving the loop *open*, so time-sync oscillation (hypothesis **H-OSC**, the strongest finding of the 2026-07-03 research pass — §24.5) was unobservable. This adds an explicit `AppModel { Ignore, Obey }` axis: `Obey` skips the recommended advances (poll but do not advance) so the ahead peer lets the others catch up.

## Changes (test-infra only — no `src/`, no public-crate API, no changelog)

- **`schedule.rs`**: `AppModel` enum (default `Ignore` via `#[serde(default)]`, mirroring `DropPolicy` — existing seeds/corpus replay **bit-identical**, no schema bump); `SimConfig.app_model`.
- **`harness/mod.rs`**: a per-peer `wait_skip` counter; under `Obey`, accumulate `skip_frames` from `WaitRecommendation` events (max, so a stronger one wins), and while owed, poll but skip the advance. The `Ignore` path is behaviorally identical to before (`wait_skip` stays 0 → same advance logic).
- **`fleet.rs`**: `app_model_obey_wait_recommendation_stays_consistent` (n∈{2,4}) over **asymmetric-delay** links (20ms one way, 120ms the other). Symmetric delay emits *no* recommendations — the D11 RTT/2 one-way-delay bias is what builds a persistent advantage. Asserts: the schedule actually emits `WaitRecommendation`s (via metrics — the H-OSC precondition), Obey vs Ignore **diverges the trace** (the skips happened), determinism, and **both pass the oracle**.

## Red → green

Neutralizing the wait-skip accumulation (Obey does nothing) fails the premise:

```
assertion `left != right` failed: obeying WaitRecommendation must change
execution — the skips must actually happen (n=2)
```

## H-OSC precondition data (asymmetric side-observation)

This lands the **closed-loop instrument** H-OSC needs; it is *not* the H-OSC experiment itself (which is symmetric delay + Obey — the FM-3 mutual-sleep case — still owed). As an asymmetric-delay side-observation, the one-sided closed loop is **well-damped**: obeying costs only ~0–2 frames of progress over 900 steps and never breaks consistency or liveness.

| n | WaitRecs | Ignore final_confirmed | Obey final_confirmed |
|---|---|---|---|
| 2 | 9 | `[835, 836]` | `[833, 833]` |
| 4 | 8 | `[592, 591, 591, 592]` | `[591, 591, 591, 592]` |

No oscillation/mutual-stall — that would require *symmetric* obedience (FM-3); and per §24.5-A10d a production handler should smear skips (1 per k) rather than sleep N at once. This lands the closed-loop instrument H-OSC needs; the symmetric-obedience and cooldown/skip-cap sweeps (§16-A10) build on it.

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json` — clean
- `cargo nextest run` — 2363 · `--features hot-join` — 2602 · simulation binary — 102
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test simulation harness and schedules; default Ignore preserves prior run behavior and corpus replay.
> 
> **Overview**
> **M3 §6.6-pre.3** — simulation test infra only (no `src/` changes). The DST harness previously always **ignored** `FortressEvent::WaitRecommendation`, so the time-sync loop stayed open and H-OSC-style behavior could not be exercised.
> 
> Adds **`AppModel { Ignore, Obey }`** on `SimConfig` (serde default `Ignore`, no schema bump). Under **`Obey`**, the harness accumulates `skip_frames` from recommendations and, while owed, **polls but skips `advance_frame`** so the ahead peer can catch up.
> 
> New fleet test **`app_model_obey_wait_recommendation_stays_consistent`** runs 2- and 4-player meshes with **asymmetric one-way delay** to force recommendations; it checks oracle pass for both modes, nonzero wait recs under Obey, trace determinism, and **Ignore vs Obey trace divergence**. A unit test pins missing `app_model` in JSON deserializing to `Ignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffedcba809d5686e42c2ef31eba5eeac60aed169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->