### PR TITLE
Hardening M3 §6.6-pre.2: per-peer clock skew (H-SKEW precondition)

### DIFF
--- a/tests/common/test_clock.rs
+++ b/tests/common/test_clock.rs
@@ -114,6 +114,40 @@ impl TestClock {
         Arc::new(move || *current.lock().expect("TestClock mutex poisoned"))
     }
 
+    /// Creates a [`ClockFn`](fortress_rollback::ClockFn) whose *rate* is skewed
+    /// by the integer ratio `num/den` relative to this clock's shared base —
+    /// modeling a peer whose local clock runs fast (`num > den`) or slow
+    /// (`num < den`) while the network (the base clock) keeps real time. The
+    /// skew applies to *elapsed* time only: `skewed = base_start +
+    /// base_elapsed * num / den`, so every skewed clock shares one epoch.
+    ///
+    /// Integer arithmetic (`u128`, saturating) keeps it **deterministic across
+    /// platforms** — no float rounding. Capture the base epoch by creating each
+    /// peer's skewed clock *before* the first [`advance`](Self::advance).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `den == 0`. The returned closure panics if the internal mutex
+    /// is poisoned.
+    // Used only by the simulation harness; unused in other test binaries that
+    // also compile `tests/common`.
+    #[allow(dead_code)]
+    pub fn as_skewed_protocol_clock(
+        &self,
+        num: u64,
+        den: u64,
+    ) -> Arc<dyn Fn() -> Instant + Send + Sync> {
+        assert!(den != 0, "clock-skew denominator must be nonzero");
+        let current = Arc::clone(&self.current);
+        let base_start = *self.current.lock().expect("TestClock mutex poisoned");
+        Arc::new(move || {
+            let base_now = *current.lock().expect("TestClock mutex poisoned");
+            let elapsed_ms = base_now.duration_since(base_start).as_millis();
+            let skewed_ms = elapsed_ms.saturating_mul(u128::from(num)) / u128::from(den);
+            base_start + Duration::from_millis(u64::try_from(skewed_ms).unwrap_or(u64::MAX))
+        })
+    }
+
     /// Creates a clock function for [`ChaosSocket::with_clock()`](fortress_rollback::ChaosSocket::with_clock).
     ///
     /// On non-WASM targets, `web_time::Instant` is the same type as

--- a/tests/common/test_clock.rs
+++ b/tests/common/test_clock.rs
@@ -142,7 +142,9 @@ impl TestClock {
         let base_start = *self.current.lock().expect("TestClock mutex poisoned");
         Arc::new(move || {
             let base_now = *current.lock().expect("TestClock mutex poisoned");
-            let elapsed_ms = base_now.duration_since(base_start).as_millis();
+            // `saturating_duration_since` (like `ping_millis`) — the base only
+            // advances, so `base_now >= base_start`, but stay defensive.
+            let elapsed_ms = base_now.saturating_duration_since(base_start).as_millis();
             let skewed_ms = elapsed_ms.saturating_mul(u128::from(num)) / u128::from(den);
             base_start + Duration::from_millis(u64::try_from(skewed_ms).unwrap_or(u64::MAX))
         })
@@ -317,5 +319,35 @@ mod tests {
         let t1 = clock.now();
 
         assert_eq!(t1 - t0, Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn skewed_clock_scales_elapsed_by_the_integer_ratio() {
+        let clock = TestClock::new();
+        let start = clock.now();
+        // Create every skewed clock BEFORE advancing so they share the epoch.
+        let double = clock.as_skewed_protocol_clock(2, 1); // 2x rate
+        let half = clock.as_skewed_protocol_clock(1, 2); // half rate
+        let unit = clock.as_skewed_protocol_clock(1, 1); // real time
+        let frozen = clock.as_skewed_protocol_clock(0, 1); // stopped clock
+
+        clock.advance(Duration::from_millis(100));
+
+        assert_eq!(double().duration_since(start), Duration::from_millis(200));
+        assert_eq!(half().duration_since(start), Duration::from_millis(50));
+        assert_eq!(unit().duration_since(start), Duration::from_millis(100));
+        assert_eq!(frozen().duration_since(start), Duration::from_millis(0));
+
+        // Skew scales elapsed, not the epoch: a second advance compounds.
+        clock.advance(Duration::from_millis(100));
+        assert_eq!(double().duration_since(start), Duration::from_millis(400));
+        assert_eq!(frozen().duration_since(start), Duration::from_millis(0));
+    }
+
+    #[test]
+    #[should_panic(expected = "denominator must be nonzero")]
+    fn skewed_clock_rejects_zero_denominator() {
+        let clock = TestClock::new();
+        let _ = clock.as_skewed_protocol_clock(1, 0);
     }
 }

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1212,6 +1212,82 @@ fn app_model_obey_wait_recommendation_stays_consistent() {
     }
 }
 
+/// Builds a clock-skew schedule: an `n`-mesh over clean links with a small
+/// symmetric delay (40ms each way, so RTT is non-zero and a skewed clock
+/// misreads it), and the given per-peer clock-rate skew in ppm.
+fn clock_skew_schedule(n: usize, skew: Vec<i32>) -> Schedule {
+    let config = SimConfig {
+        n_players: n,
+        steps: 900,
+        noise: BackgroundNoise::Clean,
+        clock_skew_ppm: skew,
+        ..SimConfig::smoke(n)
+    };
+    let delayed = LinkPolicy {
+        drop_rate: 0.0,
+        dup_rate: 0.0,
+        base_delay: Duration::from_millis(40),
+        jitter: Duration::ZERO,
+        burst_rate: 0.0,
+        burst_len: 0,
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, delayed.clone()));
+            }
+        }
+    }
+    let heal_at = 650;
+    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
+/// M3 §6.6-pre.2 — per-peer clock skew (H-SKEW precondition). Peers whose local
+/// clocks run at different rates than the network's real time must not diverge
+/// the mesh: the game logic is driven by per-(step, peer) inputs, not the clock,
+/// so a bounded skew only perturbs *timing-gated* behavior (RTT measurement,
+/// quality-report/keepalive cadence, frame-advantage estimate) — the confirmed
+/// state prefix stays byte-identical. This pins that a skewed peer is tolerated.
+///
+/// Premise: a skewed peer's clock demonstrably alters execution (the trace
+/// differs from the all-exact run) while both pass the oracle; determinism holds.
+#[test]
+fn clock_skew_is_tolerated_and_alters_execution() {
+    for n in [2usize, 4] {
+        let exact = clock_skew_schedule(n, Vec::new());
+        // Peer 0's local clock runs 10% fast; the rest keep real time.
+        let mut skew = vec![0; n];
+        skew[0] = 100_000;
+        let skewed = clock_skew_schedule(n, skew);
+
+        let exact_report = run(&exact, &RunOptions::default());
+        exact_report.expect_pass(&exact);
+        let skewed_report = run(&skewed, &RunOptions::default());
+        skewed_report.expect_pass(&skewed);
+
+        let skewed_again = run(&skewed, &RunOptions::default());
+        assert_eq!(
+            skewed_report.trace_hash, skewed_again.trace_hash,
+            "a clock-skew schedule must reproduce its exact trace (n={n})"
+        );
+        assert_ne!(
+            exact_report.trace_hash, skewed_report.trace_hash,
+            "a skewed clock must alter timing-gated execution (n={n})"
+        );
+    }
+}
+
 /// Diagnostic probe for a failing schedule: prints per-peer progress every 50
 /// steps. `#[ignore]`d — run manually while investigating a repro.
 #[test]

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1214,7 +1214,10 @@ fn app_model_obey_wait_recommendation_stays_consistent() {
 
 /// Builds a clock-skew schedule: an `n`-mesh over clean links with a small
 /// symmetric delay (40ms each way, so RTT is non-zero and a skewed clock
-/// misreads it), and the given per-peer clock-rate skew in ppm.
+/// misreads it), and the given per-peer clock-rate skew in ppm. The delay holds
+/// for the whole run — no `HealAll`, so `heal_all` never removes it — keeping
+/// RTT non-zero throughout (constant conditions, unlike the heal-and-drain
+/// schedules).
 fn clock_skew_schedule(n: usize, skew: Vec<i32>) -> Schedule {
     let config = SimConfig {
         n_players: n,
@@ -1239,17 +1242,15 @@ fn clock_skew_schedule(n: usize, skew: Vec<i32>) -> Schedule {
             }
         }
     }
-    let heal_at = 650;
-    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
-    events.sort_by_key(|(step, _)| *step);
     Schedule {
         schema_version: SCHEDULE_SCHEMA_VERSION,
         seed: 0,
         link_seed: 0,
         config,
         initial_links,
-        events,
-        heal_at,
+        events: Vec::new(),
+        // Past the last step: nothing to heal, the delay is constant.
+        heal_at: 900,
     }
 }
 

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -380,6 +380,13 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
             schedule.config.steps
         );
     }
+    for &ppm in &schedule.config.clock_skew_ppm {
+        assert!(
+            ppm >= -1_000_000,
+            "clock_skew_ppm must be >= -1_000_000 (-100% = a frozen clock); a \
+             lower value would run time backwards (got {ppm})"
+        );
+    }
 
     for (from, to, policy) in &schedule.initial_links {
         net.set_link(addrs[*from], addrs[*to], policy.clone());
@@ -399,7 +406,10 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
             let peer_clock = if ppm == 0 {
                 clock.as_protocol_clock()
             } else {
-                let num = u64::try_from((1_000_000_i64 + i64::from(ppm)).max(1)).unwrap_or(1);
+                // ratio (1e6 + ppm) / 1e6. `ppm == -1_000_000` (-100%) is a
+                // frozen clock (num = 0); anything below that would run time
+                // backwards and is rejected up front, so the fallback is unused.
+                let num = u64::try_from(1_000_000_i64 + i64::from(ppm)).unwrap_or(0);
                 clock.as_skewed_protocol_clock(num, 1_000_000)
             };
             let protocol_config = ProtocolConfig {

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -392,8 +392,18 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
         .map(|i| {
             let socket: SimSocket<Message> = net.attach(addrs[i]);
             let observer = Arc::new(CollectingObserver::new());
+            // Per-peer clock: the exact base clock at 0 ppm (byte-identical to
+            // before), or a rate-skewed clock modeling an unsynchronized local
+            // clock (H-SKEW). A missing/short skew vector means "no skew".
+            let ppm = schedule.config.clock_skew_ppm.get(i).copied().unwrap_or(0);
+            let peer_clock = if ppm == 0 {
+                clock.as_protocol_clock()
+            } else {
+                let num = u64::try_from((1_000_000_i64 + i64::from(ppm)).max(1)).unwrap_or(1);
+                clock.as_skewed_protocol_clock(num, 1_000_000)
+            };
             let protocol_config = ProtocolConfig {
-                clock: Some(clock.as_protocol_clock()),
+                clock: Some(peer_clock),
                 protocol_rng_seed: Some(fnv1a_hash(&(schedule.seed, i))),
                 ..ProtocolConfig::default()
             };

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -115,6 +115,14 @@ pub struct SimConfig {
     /// used) keeps pre-existing corpus artifacts replayable without a bump.
     #[serde(default)]
     pub app_model: AppModel,
+    /// Per-peer clock-rate skew in parts-per-million (peer `i` reads
+    /// `clock_skew_ppm[i]`; a missing/short entry means 0 = no skew). The
+    /// peer's local clock runs `ppm` faster (positive) or slower (negative)
+    /// than the network's real-time base, modeling unsynchronized clocks
+    /// (H-SKEW). `#[serde(default)]` (empty = every clock exact) keeps existing
+    /// corpus artifacts replayable without a bump.
+    #[serde(default)]
+    pub clock_skew_ppm: Vec<i32>,
 }
 
 impl SimConfig {
@@ -135,6 +143,7 @@ impl SimConfig {
             noise: BackgroundNoise::Mild,
             disconnect_behavior: DropPolicy::default(),
             app_model: AppModel::default(),
+            clock_skew_ppm: Vec::new(),
         }
     }
 
@@ -590,30 +599,37 @@ mod tests {
             .any(|(_, ev)| matches!(ev, ScheduleEvent::PeerKill { peer: 2 })));
     }
 
-    /// A corpus artifact predating the `app_model` axis (its `config` object has
-    /// no such field) must deserialize to `Ignore` — the open-loop behavior every
-    /// earlier run used — so old schedules replay bit-identically. This pins the
-    /// `#[serde(default)]` contract the "no schema bump" claim rests on.
+    /// A corpus artifact predating the `#[serde(default)]` config axes (its
+    /// `config` object lacks those fields) must deserialize to their defaults —
+    /// `app_model = Ignore` (open-loop) and `clock_skew_ppm = []` (no skew) —
+    /// so old schedules replay bit-identically. This pins the "no schema bump"
+    /// claim. Each field is asserted present-and-removed so the test can't pass
+    /// vacuously (a full config also deserializes fine).
     #[test]
-    fn config_without_app_model_field_defaults_to_ignore() {
+    fn config_without_serde_default_fields_uses_defaults() {
         let schedule = generate(42, SimConfig::smoke(2));
         let mut value = serde_json::to_value(&schedule).unwrap();
         let config = value
             .get_mut("config")
             .and_then(|c| c.as_object_mut())
             .expect("a serialized schedule must have a `config` object");
-        // The field must actually be present to remove — otherwise the test
-        // would pass vacuously (a full config also deserializes fine) without
-        // ever exercising the missing-field default it exists to pin.
         assert!(
             config.remove("app_model").is_some(),
             "config must serialize an `app_model` field for this test to remove"
+        );
+        assert!(
+            config.remove("clock_skew_ppm").is_some(),
+            "config must serialize a `clock_skew_ppm` field for this test to remove"
         );
         let back: Schedule = serde_json::from_value(value).unwrap();
         assert_eq!(
             back.config.app_model,
             AppModel::Ignore,
             "a pre-axis config (no app_model) must default to Ignore"
+        );
+        assert!(
+            back.config.clock_skew_ppm.is_empty(),
+            "a pre-axis config (no clock_skew_ppm) must default to no skew"
         );
     }
 }


### PR DESCRIPTION
## Summary

**M3 §6.6-pre.2** — adds per-peer clock skew to the DST harness. Every prior fleet run shared **one** clock, so clock offset/rate skew was unsimulatable and **H-SKEW** (and the symmetric H-OSC case) was blind. Now each session gets a clock running at an **integer-ratio rate** relative to the network's real-time base, so a peer's local clock can run fast/slow while the fabric keeps real time — the physical reality of unsynchronized clocks.

## Changes (test-infra only — no `src/`, no public-crate API, no changelog)

- **`test_clock.rs`**: `TestClock::as_skewed_protocol_clock(num, den)` — `skewed = base_start + base_elapsed * num / den`, all `u128` **integer** arithmetic, so it is **deterministic across platforms** (no float rounding — the concern that made a float-scaled clock a non-starter).
- **`schedule.rs`**: `SimConfig.clock_skew_ppm: Vec<i32>` (per-peer ppm; `#[serde(default)]` empty = no skew → existing seeds/corpus replay bit-identical, no schema bump). The serde-default test now covers it (asserting the field was present-and-removed, so it can't pass vacuously).
- **`harness/mod.rs`**: per-peer clock injection — the **exact base clock at 0 ppm** (byte-identical to before), a skewed clock otherwise.
- **`fleet.rs`**: `clock_skew_is_tolerated_and_alters_execution` (n∈{2,4}) over a 40ms-delay mesh (so RTT is non-zero and a skewed clock misreads it). Peer 0 at **+10%**: the mesh stays **byte-consistent** (the game logic is driven by per-`(step, peer)` inputs, not the clock) while the skew **demonstrably alters timing-gated execution** (RTT measurement, quality-report/keepalive cadence, frame-advantage estimate). Premise red-verified; determinism holds.

## Red → green

Neutralizing the skew (forcing the exact clock regardless of ppm) fails the premise:

```
assertion `left != right` failed: a skewed clock must alter timing-gated
execution (n=2)
```

## Scope

This is the **H-SKEW precondition infra** plus a short-run tolerance observation (a bounded skew is tolerated). The realistic experiment — 0.1% skew over an hour-equivalent run, measuring whether confirmed-lag creeps or recommendations go permanently one-sided — is a long-run probe, still owed. This also unblocks the **symmetric** H-OSC case (per-peer clock differences are a natural source of the transient advantage that symmetric *delay* alone doesn't produce).

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json` — clean
- `cargo nextest run` — 2365 · `--features hot-join` — 2604 · simulation binary — 104
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test/simulation infrastructure (`tests/common`, `tests/simulation`); production `src/` and public APIs are untouched, and default schedules remain byte-identical when skew is unset.
> 
> **Overview**
> Adds **M3 §6.6-pre.2 (H-SKEW)** support to the deterministic simulation harness so each peer can run a **rate-skewed** local clock while the shared network clock stays on real time.
> 
> **`TestClock::as_skewed_protocol_clock(num, den)`** scales elapsed time by an integer ratio (`base_start + elapsed * num / den`) using saturating `u128` math for cross-platform determinism. Unit tests cover scaling, frozen clocks, and a zero denominator panic.
> 
> **`SimConfig.clock_skew_ppm`** is a per-peer ppm skew vector with `#[serde(default)]` (empty = no skew, no schema bump). The harness maps ppm to `(1e6 + ppm) / 1e6`, rejects values below -1_000_000, and wires **0 ppm** peers to the same base clock as before.
> 
> **Fleet:** `clock_skew_is_tolerated_and_alters_execution` runs 2- and 4-player meshes with 40ms symmetric delay; peer 0 at **+10%** must still pass the oracle, change the trace vs an exact-clock run, and stay deterministic on replay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc3b3207e1e363d0a10ff509ef6f65c27d4a6bcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->