### PR TITLE
Hardening M3: clock-skew consistency probe + honest H-SKEW status (mechanism needs a skew-gated frame model)

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1289,6 +1289,85 @@ fn clock_skew_is_tolerated_and_alters_execution() {
     }
 }
 
+/// Builds an H-SKEW schedule: a 2-mesh over clean 30ms-delay links where peer 0's
+/// clock runs `ppm` fast for `steps` steps. Uncorrected (app model `Ignore`), so
+/// the skew's effect accumulates — the H-SKEW question is whether it stays
+/// bounded (the prediction window caps it) or the confirmed lag creeps.
+fn h_skew_schedule(steps: u32, ppm: i32) -> Schedule {
+    let config = SimConfig {
+        n_players: 2,
+        steps,
+        noise: BackgroundNoise::Clean,
+        clock_skew_ppm: vec![ppm, 0],
+        ..SimConfig::smoke(2)
+    };
+    let delayed = LinkPolicy {
+        drop_rate: 0.0,
+        dup_rate: 0.0,
+        base_delay: Duration::from_millis(30),
+        jitter: Duration::ZERO,
+        burst_rate: 0.0,
+        burst_len: 0,
+    };
+    let initial_links = vec![(0, 1, delayed.clone()), (1, 0, delayed)];
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events: Vec::new(),
+        heal_at: steps,
+    }
+}
+
+/// H-SKEW verdict probe (PLAN.md §13). H-SKEW feared that a realistic (0.1%)
+/// per-peer clock drift causes **unbounded confirmed-lag creep** OR
+/// **chronically one-sided `WaitRecommendation`s** toward the fast peer over a
+/// long run. **Verdict: NEITHER, at a realistic 0.1%** — measured over 10k steps
+/// on a 60ms-RTT mesh, confirmed lag stays bounded (max 5 ≪ the prediction
+/// window) and *zero* recommendations fire. The reason: the time-sync loop keys
+/// on RTT (an *instantaneous* ping, not accumulated clock time), so a 0.1% clock
+/// error scales RTT by 0.1% (~0.06ms of ~60ms) — far below the recommendation
+/// dead-band — and never accumulates. Realistic skew is fully absorbed. (Large
+/// skew *does* perturb timing — see `clock_skew_is_tolerated_and_alters_execution`
+/// at +10% — but even that stays consistent.) `#[ignore]`d as a long-run verdict
+/// probe (the plan's H-SKEW home is the nightly fleet), though 10k steps run in
+/// well under a second; the verdict is length-independent (the two mechanisms —
+/// the prediction-window cap and the negligible 0.1% ping error — do not depend
+/// on run length), so this is a sufficient, not merely indicative, verdict.
+#[test]
+#[ignore = "long-run H-SKEW verdict probe; run manually / in nightly"]
+fn h_skew_realistic_drift_is_absorbed_probe() {
+    let schedule = h_skew_schedule(10_000, 1_000); // peer 0 at +0.1%
+    let report = run(&schedule, &RunOptions::default());
+    report.expect_pass(&schedule); // full liveness + consistency over 10k steps
+
+    let lag_max: u64 = report
+        .metrics
+        .iter()
+        .map(|m| m.confirmation_lag_max)
+        .max()
+        .unwrap_or(0);
+    let total_recs: u64 = report.metrics.iter().map(|m| m.wait_recommendations).sum();
+
+    // Bounded lag: the prediction window caps how far a drifting peer runs ahead,
+    // so lag cannot creep unboundedly (H-SKEW's first fear — falsified).
+    assert!(
+        lag_max <= 4 * schedule.config.max_prediction as u64,
+        "confirmed lag must stay bounded under a +0.1% clock drift, not creep \
+         (lag_max={lag_max}, max_prediction={})",
+        schedule.config.max_prediction
+    );
+    // Absorbed: a 0.1% RTT-measurement error is far below the recommendation
+    // threshold, so realistic drift produces no time-sync recommendations at all
+    // (H-SKEW's second fear — chronic one-sided recommendations — falsified).
+    assert_eq!(
+        total_recs, 0,
+        "realistic 0.1% skew must not trigger WaitRecommendations (got {total_recs})"
+    );
+}
+
 /// Diagnostic probe for a failing schedule: prints per-peer progress every 50
 /// steps. `#[ignore]`d — run manually while investigating a repro.
 #[test]

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1359,10 +1359,19 @@ fn clock_skew_holds_consistency_over_a_long_run() {
     // skew-gated frame model had begun to reproduce the H-SKEW drift). In this
     // lockstep model it is 0; assert it stays within the prediction window.
     let confirmed = &report.final_confirmed;
-    let spread =
-        confirmed.iter().copied().max().unwrap_or(0) - confirmed.iter().copied().min().unwrap_or(0);
+    let max = confirmed
+        .iter()
+        .copied()
+        .max()
+        .expect("final_confirmed is non-empty");
+    let min = confirmed
+        .iter()
+        .copied()
+        .min()
+        .expect("final_confirmed is non-empty");
+    let spread = max - min;
     assert!(
-        spread <= schedule.config.max_prediction as i32,
+        (spread as usize) <= schedule.config.max_prediction,
         "skew must not drift the peers' confirmed frames apart (spread={spread}, \
          final_confirmed={confirmed:?})"
     );

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1289,11 +1289,13 @@ fn clock_skew_is_tolerated_and_alters_execution() {
     }
 }
 
-/// Builds an H-SKEW schedule: a 2-mesh over clean 30ms-delay links where peer 0's
-/// clock runs `ppm` fast for `steps` steps. Uncorrected (app model `Ignore`), so
-/// the skew's effect accumulates — the H-SKEW question is whether it stays
-/// bounded (the prediction window caps it) or the confirmed lag creeps.
-fn h_skew_schedule(steps: u32, ppm: i32) -> Schedule {
+/// Builds a long-run clock-skew schedule: a 2-mesh over clean 30ms-delay links
+/// where peer 0's clock runs `ppm` fast for `steps` steps, app model `Ignore`.
+/// The harness advances every peer one frame per step (lockstep) and reads the
+/// clock only for timestamps, so the skew perturbs timing-gated behavior (the
+/// RTT gauge, quality-report/keepalive cadence) but does NOT gate frame
+/// production — see the probe below for why this bounds what it can test.
+fn clock_skew_long_run_schedule(steps: u32, ppm: i32) -> Schedule {
     let config = SimConfig {
         n_players: 2,
         steps,
@@ -1321,50 +1323,48 @@ fn h_skew_schedule(steps: u32, ppm: i32) -> Schedule {
     }
 }
 
-/// H-SKEW verdict probe (PLAN.md §13). H-SKEW feared that a realistic (0.1%)
-/// per-peer clock drift causes **unbounded confirmed-lag creep** OR
-/// **chronically one-sided `WaitRecommendation`s** toward the fast peer over a
-/// long run. **Verdict: NEITHER, at a realistic 0.1%** — measured over 10k steps
-/// on a 60ms-RTT mesh, confirmed lag stays bounded (max 5 ≪ the prediction
-/// window) and *zero* recommendations fire. The reason: the time-sync loop keys
-/// on RTT (an *instantaneous* ping, not accumulated clock time), so a 0.1% clock
-/// error scales RTT by 0.1% (~0.06ms of ~60ms) — far below the recommendation
-/// dead-band — and never accumulates. Realistic skew is fully absorbed. (Large
-/// skew *does* perturb timing — see `clock_skew_is_tolerated_and_alters_execution`
-/// at +10% — but even that stays consistent.) `#[ignore]`d as a long-run verdict
-/// probe (the plan's H-SKEW home is the nightly fleet), though 10k steps run in
-/// well under a second; the verdict is length-independent (the two mechanisms —
-/// the prediction-window cap and the negligible 0.1% ping error — do not depend
-/// on run length), so this is a sufficient, not merely indicative, verdict.
+/// Clock-skew consistency over a long run — the floor a real H-SKEW experiment
+/// would build on, plus an honest note on why this harness cannot yet run that
+/// experiment.
+///
+/// **What this validly shows:** per-peer clock skew (peer 0 at +0.1% over 10k
+/// steps) does not break mesh **state consistency or liveness**. The skew shifts
+/// timing-gated behavior (the RTT gauge, quality-report/keepalive cadence), and
+/// the mesh still confirms a byte-identical prefix — the peers stay in step. It
+/// extends the short +10% `clock_skew_is_tolerated_and_alters_execution`
+/// observation to a realistic magnitude over a long run.
+///
+/// **What it does NOT do — H-SKEW (PLAN.md §13) is NOT executed here.** H-SKEW
+/// predicts a *rate* effect: a clock running 0.1% fast drives the frame loop
+/// 0.1% faster in wall-clock time, so the fast peer produces ~43 more frames/hour
+/// than the network confirms and `local_frame_advantage` accumulates. This
+/// harness advances **every peer exactly one frame per step** (`harness/mod.rs`,
+/// lockstep) and reads the clock only for timestamps, so that accumulation is
+/// **structurally absent**: the frame-advantage delta `floor(half_rtt*fps/1000)`
+/// stays 1 from 0% through ~+11% skew, so `average_frame_advantage` never reaches
+/// `MIN_RECOMMENDATION` at *any* ppm or run length. Asserting "no lag creep / no
+/// recommendations" here would be a tautology, not a falsification. **H-SKEW's
+/// lag-creep and one-sided-recommendation fears remain OWED**, blocked on a
+/// skew-gated frame model (advancing each peer at a rate driven by its own
+/// skewed clock).
 #[test]
-#[ignore = "long-run H-SKEW verdict probe; run manually / in nightly"]
-fn h_skew_realistic_drift_is_absorbed_probe() {
-    let schedule = h_skew_schedule(10_000, 1_000); // peer 0 at +0.1%
+#[ignore = "long-run consistency probe; run manually / in nightly"]
+fn clock_skew_holds_consistency_over_a_long_run() {
+    let schedule = clock_skew_long_run_schedule(10_000, 1_000); // peer 0 at +0.1%
     let report = run(&schedule, &RunOptions::default());
-    report.expect_pass(&schedule); // full liveness + consistency over 10k steps
+    report.expect_pass(&schedule); // state consistency + liveness over 10k steps
 
-    let lag_max: u64 = report
-        .metrics
-        .iter()
-        .map(|m| m.confirmation_lag_max)
-        .max()
-        .unwrap_or(0);
-    let total_recs: u64 = report.metrics.iter().map(|m| m.wait_recommendations).sum();
-
-    // Bounded lag: the prediction window caps how far a drifting peer runs ahead,
-    // so lag cannot creep unboundedly (H-SKEW's first fear — falsified).
+    // The peers must stay in step: a spread in their confirmed frames would be
+    // the *first* sign the skew leaked into frame production (i.e. that a future
+    // skew-gated frame model had begun to reproduce the H-SKEW drift). In this
+    // lockstep model it is 0; assert it stays within the prediction window.
+    let confirmed = &report.final_confirmed;
+    let spread =
+        confirmed.iter().copied().max().unwrap_or(0) - confirmed.iter().copied().min().unwrap_or(0);
     assert!(
-        lag_max <= 4 * schedule.config.max_prediction as u64,
-        "confirmed lag must stay bounded under a +0.1% clock drift, not creep \
-         (lag_max={lag_max}, max_prediction={})",
-        schedule.config.max_prediction
-    );
-    // Absorbed: a 0.1% RTT-measurement error is far below the recommendation
-    // threshold, so realistic drift produces no time-sync recommendations at all
-    // (H-SKEW's second fear — chronic one-sided recommendations — falsified).
-    assert_eq!(
-        total_recs, 0,
-        "realistic 0.1% skew must not trigger WaitRecommendations (got {total_recs})"
+        spread <= schedule.config.max_prediction as i32,
+        "skew must not drift the peers' confirmed frames apart (spread={spread}, \
+         final_confirmed={confirmed:?})"
     );
 }
 


### PR DESCRIPTION
## Summary

A long-run **clock-skew consistency** probe — and an honest status update on hypothesis **H-SKEW**.

> **Correction (adversarial review):** an earlier revision of this PR claimed to *falsify* H-SKEW. That was wrong, and the review caught it. This harness advances **every peer exactly one frame per step (lockstep)** and reads the clock only for timestamps, so the *rate*-drift mechanism H-SKEW predicts — a fast clock driving a faster **frame-production rate** (~43 frames/hour accumulation) — is **structurally absent**. The frame-advantage delta `floor(half_rtt*fps/1000)` stays `1` from 0% through ~+11% skew, so `average_frame_advantage` never reaches `MIN_RECOMMENDATION` at *any* ppm — "zero recommendations" was a **tautology, not a falsification**. So H-SKEW is **NOT executed here; it remains OWED**, blocked on a skew-gated frame model.

## What this validly shows

Per-peer clock skew (peer 0 at +0.1% over 10k steps) does **not break mesh state consistency or liveness**: the skew shifts timing-gated behavior (RTT gauge, quality-report/keepalive cadence) and the mesh still confirms a byte-identical prefix, peers in step. It extends the short +10% `clock_skew_is_tolerated_and_alters_execution` observation to a realistic magnitude over a long run — the consistency floor a real H-SKEW experiment would build on.

## Changes (test-infra only — no `src/`, no public-crate API, no changelog)

- **`fleet.rs`**: `clock_skew_long_run_schedule(steps, ppm)` + `clock_skew_holds_consistency_over_a_long_run` (`#[ignore]`d). Asserts consistency+liveness (`expect_pass`) and that the peers' confirmed-frame **spread stays bounded** (the first sign skew ever leaked into frame production). The doc states plainly that H-SKEW's lag-creep / one-sided-recommendation fears remain OWED and *why*.

## What a real H-SKEW test needs (future work)

A **skew-gated frame model**: advance each peer at a rate driven by *its own* skewed clock (the fast peer runs more `advance_frame`s per unit network-time), so `local_frame_advantage` can actually accumulate. Then the hour-equivalent run the plan specifies would surface (or not) the ~43-frames/hour drift. Recorded in PLAN.md §6.6-pre.2 / §13.

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json` — clean
- simulation suite clean; the probe passes under `--run-ignored`
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass

Reviewed by an adversarial sub-agent (which correctly rejected the original falsification claim) + GitHub Copilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test infrastructure only in `tests/simulation/fleet.rs`; no library or API changes.
> 
> **Overview**
> Adds **simulation-only** coverage for clock skew at realistic magnitude (+0.1% on peer 0 over 10k lockstep steps): a `clock_skew_long_run_schedule` builder and an `#[ignore]` test `clock_skew_holds_consistency_over_a_long_run` that runs the oracle pass and checks survivors’ **confirmed-frame spread** stays within `max_prediction`.
> 
> The new doc comments explicitly **do not claim H-SKEW falsification**—the harness still advances one frame per peer per step and uses skew only for timestamps, so rate-based lag creep remains **owed** until a skew-gated frame model exists. This extends the existing short +10% `clock_skew_is_tolerated_and_alters_execution` check as a long-run consistency floor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a339feb1fc5c435a24a6428474cd6d7f1fab2e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->