### PR TITLE
Hardening M3 §6.6-pre.6h: event-loss oracle — D9 fleet coverage via a starved app model

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1435,3 +1435,116 @@ fn budget_probe_eight_player_long_schedule() {
     );
     report.expect_pass(&schedule);
 }
+
+/// §6.6-pre.6h — the event-loss oracle. The harness normally drains every
+/// peer's event queue each step, so the D9 event-discard telemetry
+/// (`events_discarded_*`) never fires in the fleet. A *starved* peer — one whose
+/// app model never services [`P2PSession::events`] — lets the session's bounded
+/// queue fill until it trims the oldest events, exercising that overflow path
+/// end-to-end.
+///
+/// Fire: on a Clean N=8 mesh with a small (10-slot) queue, the starved peer's
+/// cold-start sync burst (`Synchronizing`, one per remote per retry) overflows
+/// the queue (D9 > 0) while every draining peer stays clean. Neutralize: the
+/// identical schedule with every peer draining discards nothing — proving
+/// starvation, not the mesh itself, is the cause. Both runs pass the full
+/// oracle: not servicing events must not desync or stall the mesh.
+///
+/// A Clean mesh is deliberate — the discards come from the initial sync
+/// handshake (which every mesh runs regardless of noise), so the count is
+/// deterministic and N-scaled rather than dependent on random faults.
+///
+/// **N and the cap are load-bearing together.** A *draining* peer empties its
+/// queue every step, so its high-water mark is the largest single-poll burst:
+/// ≈`N − 1` `Synchronizing` events (one per remote) during cold start. That
+/// must stay strictly under the cap or a draining peer overflows too and the
+/// "draining peers discard nothing" assertion fails. At N=8 the burst is 7 < 10
+/// (margin 3, and the starved peer still accumulates ≈25 discards across polls);
+/// the relation breaks at N≥12 (burst ≥ 11 > 10). If you bump N, raise the cap
+/// past `N − 1` in step — the sub-assertion fails loudly if you forget, so this
+/// stays honest, but keep them paired.
+fn event_starvation_config(starve: bool) -> SimConfig {
+    let n = 8;
+    SimConfig {
+        n_players: n,
+        steps: 900,
+        noise: BackgroundNoise::Clean,
+        event_queue_size: Some(10),
+        starve_events: if starve { vec![0] } else { Vec::new() },
+        ..SimConfig::smoke(n)
+    }
+}
+
+#[test]
+fn event_starvation_overflows_the_bounded_event_queue() {
+    let seed = 0xE7A2;
+    let n = event_starvation_config(true).n_players;
+
+    // Fire: peer 0 never drains its 10-slot queue; the session trims the
+    // overflow and D9 fires — for peer 0 only.
+    let starved_schedule = generate(seed, event_starvation_config(true));
+    let starved = run(&starved_schedule, &RunOptions::default());
+    // Starvation must not break the mesh (events are informational): the full
+    // oracle still passes even though peer 0 ignores its event queue.
+    starved.expect_pass(&starved_schedule);
+    assert!(
+        starved.metrics[0].events_discarded_total > 0,
+        "starved peer 0 must overflow its bounded event queue (D9 telemetry); \
+         got discards={} — too few events, raise N or lower the cap",
+        starved.metrics[0].events_discarded_total
+    );
+    // Draining peers must NOT overflow: each empties its queue every step, so
+    // its high-water is one cold-start poll burst (≈N-1 < cap at N=8). This is
+    // load-bearing on N — see `event_starvation_config` (it fails loudly, not
+    // silently, if a future N-bump pushes the burst past the cap).
+    for i in 1..n {
+        assert_eq!(
+            starved.metrics[i].events_discarded_total, 0,
+            "a draining peer must not overflow (single-poll burst < cap): \
+             peer {i} discarded {}",
+            starved.metrics[i].events_discarded_total
+        );
+    }
+
+    // Neutralize: identical schedule, every peer draining → nobody overflows,
+    // isolating starvation as the sole cause of D9.
+    let drained_schedule = generate(seed, event_starvation_config(false));
+    let drained = run(&drained_schedule, &RunOptions::default());
+    drained.expect_pass(&drained_schedule);
+    for i in 0..n {
+        assert_eq!(
+            drained.metrics[i].events_discarded_total, 0,
+            "with every peer draining, no queue may overflow — starvation is the \
+             only cause of D9: peer {i} discarded {}",
+            drained.metrics[i].events_discarded_total
+        );
+    }
+}
+
+/// A `starve_events` entry naming a peer outside the mesh (a hand-edited or
+/// corrupt corpus artifact) must fail loudly up front, not silently no-op —
+/// the same fail-loud contract the event-index validation enforces.
+#[test]
+#[should_panic(expected = "out of range")]
+fn run_rejects_out_of_range_starve_events_peer() {
+    let config = SimConfig {
+        n_players: 2,
+        starve_events: vec![9],
+        ..SimConfig::smoke(2)
+    };
+    let _ = run(&generate(0, config), &RunOptions::default());
+}
+
+/// An `event_queue_size` below the library minimum (10) must be rejected up
+/// front with a clear message, mirroring `SessionBuilder::with_event_queue_size`,
+/// rather than surfacing as a builder error deep in session construction.
+#[test]
+#[should_panic(expected = "event_queue_size must be >= 10")]
+fn run_rejects_too_small_event_queue_size() {
+    let config = SimConfig {
+        n_players: 2,
+        event_queue_size: Some(5),
+        ..SimConfig::smoke(2)
+    };
+    let _ = run(&generate(0, config), &RunOptions::default());
+}

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -442,11 +442,12 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 .with_protocol_config(protocol_config)
                 .with_violation_observer(Arc::clone(&observer) as Arc<_>);
             if let Some(size) = schedule.config.event_queue_size {
-                // Validated `>= 10` up front, so the builder's min-cap check
-                // cannot reject it here.
-                builder = builder
-                    .with_event_queue_size(size)
-                    .expect("event_queue_size >= 10 (validated up front)");
+                // Validated `>= 10` up front, so the current min-cap check
+                // cannot reject it; surface the real error (not a fixed string)
+                // if the builder ever grows stricter validation.
+                builder = builder.with_event_queue_size(size).unwrap_or_else(|error| {
+                    panic!("with_event_queue_size({size}) rejected a pre-validated size: {error:?}")
+                });
             }
             for (j, addr) in addrs.iter().enumerate() {
                 let player_type = if j == i {
@@ -500,10 +501,12 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     // wedged event consumer). Their bounded `event_queue` fills and the session
     // trims oldest events, firing the D9 `events_discarded_*` telemetry. Because
     // the harness normally drains (and feeds) events per step, starvation is the
-    // only fleet path that exercises that overflow.
-    let starves: Vec<bool> = (0..n)
-        .map(|i| schedule.config.starve_events.contains(&i))
-        .collect();
+    // only fleet path that exercises that overflow. Built by direct index (peers
+    // validated in-range above) — O(n + |starve_events|), no per-peer rescan.
+    let mut starves = vec![false; n];
+    for &peer in &schedule.config.starve_events {
+        starves[peer] = true;
+    }
     // Confirmed-frame snapshot taken at `options.probe_confirmed_at`, if any.
     let mut probe_confirmed: Vec<i32> = Vec::new();
 

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -387,6 +387,18 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
              lower value would run time backwards (got {ppm})"
         );
     }
+    for &peer in &schedule.config.starve_events {
+        assert!(
+            peer < n,
+            "starve_events peer {peer} out of range for a {n}-peer mesh"
+        );
+    }
+    if let Some(size) = schedule.config.event_queue_size {
+        assert!(
+            size >= 10,
+            "event_queue_size must be >= 10 (SessionBuilder rejects smaller); got {size}"
+        );
+    }
 
     for (from, to, policy) in &schedule.initial_links {
         net.set_link(addrs[*from], addrs[*to], policy.clone());
@@ -429,6 +441,13 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 .with_disconnect_behavior(schedule.config.disconnect_behavior.into())
                 .with_protocol_config(protocol_config)
                 .with_violation_observer(Arc::clone(&observer) as Arc<_>);
+            if let Some(size) = schedule.config.event_queue_size {
+                // Validated `>= 10` up front, so the builder's min-cap check
+                // cannot reject it here.
+                builder = builder
+                    .with_event_queue_size(size)
+                    .expect("event_queue_size >= 10 (validated up front)");
+            }
             for (j, addr) in addrs.iter().enumerate() {
                 let player_type = if j == i {
                     PlayerType::Local
@@ -477,6 +496,14 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     // does not advance, letting the others catch up — the closed time-sync loop.
     let app_model = schedule.config.app_model;
     let mut wait_skip: Vec<u32> = vec![0; n];
+    // Peers whose app model never drains the session event queue (models a
+    // wedged event consumer). Their bounded `event_queue` fills and the session
+    // trims oldest events, firing the D9 `events_discarded_*` telemetry. Because
+    // the harness normally drains (and feeds) events per step, starvation is the
+    // only fleet path that exercises that overflow.
+    let starves: Vec<bool> = (0..n)
+        .map(|i| schedule.config.starve_events.contains(&i))
+        .collect();
     // Confirmed-frame snapshot taken at `options.probe_confirmed_at`, if any.
     let mut probe_confirmed: Vec<i32> = Vec::new();
 
@@ -538,19 +565,29 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
             let confirmed = if !dead[i] && step >= stalled_until[i] {
                 slot.session.poll_remote_clients();
 
-                let events: Vec<FortressEvent<StubConfig>> = slot.session.events().collect();
-                for event in &events {
-                    if let FortressEvent::DesyncDetected { frame, .. } = event {
-                        oracle.observe_desync_event(i, *frame);
-                    }
-                    // Closed-loop app model: obey a `WaitRecommendation` by owing
-                    // that many skipped advances (max so a stronger one wins).
-                    if app_model == AppModel::Obey {
-                        if let FortressEvent::WaitRecommendation { skip_frames } = event {
-                            wait_skip[i] = wait_skip[i].max(*skip_frames);
+                // A starved peer never drains its event queue (models a wedged
+                // event consumer): the session's bounded queue fills and trims,
+                // firing D9. Skipping the drain forgoes only this peer's own
+                // event signals — its self-observed `DesyncDetected` and its
+                // event trace folds. The oracle keeps full teeth on it anyway:
+                // the primary state-agreement check reads its recorded state
+                // directly, and any real divergence is still caught in-band by
+                // its neighbors' own desync detection over the wire.
+                if !starves[i] {
+                    let events: Vec<FortressEvent<StubConfig>> = slot.session.events().collect();
+                    for event in &events {
+                        if let FortressEvent::DesyncDetected { frame, .. } = event {
+                            oracle.observe_desync_event(i, *frame);
                         }
+                        // Closed-loop app model: obey a `WaitRecommendation` by owing
+                        // that many skipped advances (max so a stronger one wins).
+                        if app_model == AppModel::Obey {
+                            if let FortressEvent::WaitRecommendation { skip_frames } = event {
+                                wait_skip[i] = wait_skip[i].max(*skip_frames);
+                            }
+                        }
+                        fold_trace(&mut trace_hash, &format!("{event:?}"));
                     }
-                    fold_trace(&mut trace_hash, &format!("{event:?}"));
                 }
 
                 if slot.session.current_state() == SessionState::Running {

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -123,6 +123,27 @@ pub struct SimConfig {
     /// corpus artifacts replayable without a bump.
     #[serde(default)]
     pub clock_skew_ppm: Vec<i32>,
+    /// Peers (by index) whose app model **never drains the session event
+    /// queue** — modeling an application that stops servicing
+    /// `P2PSession::events` (a wedged UI thread, a dropped event consumer). The
+    /// session keeps polling and advancing, so its bounded `event_queue` fills;
+    /// the session then trims the oldest events, incrementing the D9
+    /// `events_discarded_*` telemetry (`§6.6-pre.6h` event-loss oracle). A
+    /// starved peer is excluded only from *event-derived* oracle signals (the
+    /// secondary `DesyncDetected` observation); the primary state-agreement,
+    /// confirmed-prefix, and liveness checks read `confirmed_frame`/recorded
+    /// state directly and keep full teeth. `#[serde(default)]` (empty = every
+    /// peer drains every step, the behavior every prior run used) keeps existing
+    /// corpus artifacts replayable without a schema bump.
+    #[serde(default)]
+    pub starve_events: Vec<usize>,
+    /// Optional override for every session's event-queue capacity
+    /// (`SessionBuilder::with_event_queue_size`, min 10). `#[serde(default)]`
+    /// (`None` = the library default of 100) keeps existing corpus artifacts
+    /// replayable without a bump. A small cap makes event-starvation overflow
+    /// (D9) reachable within a short schedule.
+    #[serde(default)]
+    pub event_queue_size: Option<usize>,
 }
 
 impl SimConfig {
@@ -144,6 +165,8 @@ impl SimConfig {
             disconnect_behavior: DropPolicy::default(),
             app_model: AppModel::default(),
             clock_skew_ppm: Vec::new(),
+            starve_events: Vec::new(),
+            event_queue_size: None,
         }
     }
 
@@ -621,6 +644,14 @@ mod tests {
             config.remove("clock_skew_ppm").is_some(),
             "config must serialize a `clock_skew_ppm` field for this test to remove"
         );
+        assert!(
+            config.remove("starve_events").is_some(),
+            "config must serialize a `starve_events` field for this test to remove"
+        );
+        assert!(
+            config.remove("event_queue_size").is_some(),
+            "config must serialize an `event_queue_size` field for this test to remove"
+        );
         let back: Schedule = serde_json::from_value(value).unwrap();
         assert_eq!(
             back.config.app_model,
@@ -630,6 +661,14 @@ mod tests {
         assert!(
             back.config.clock_skew_ppm.is_empty(),
             "a pre-axis config (no clock_skew_ppm) must default to no skew"
+        );
+        assert!(
+            back.config.starve_events.is_empty(),
+            "a pre-axis config (no starve_events) must default to every peer draining"
+        );
+        assert_eq!(
+            back.config.event_queue_size, None,
+            "a pre-axis config (no event_queue_size) must default to the library cap"
         );
     }
 }


### PR DESCRIPTION
## Summary

Lands the **§6.6-pre.6h event-loss oracle** — the first *fleet-level* coverage of the D9 event-discard telemetry (`SessionMetrics::events_discarded_*`), which until now was only unit-tested.

The DST harness drains every peer's event queue every step, so a session's bounded `event_queue` never overflows in the fleet and D9 never fires. This adds a **starved-peer** app model: a peer that never services `P2PSession::events`, so its bounded queue fills and the session trims the oldest events — exercising the overflow/`record_event_discard` path end-to-end.

## What the test proves (both directions)

`event_starvation_overflows_the_bounded_event_queue` — a **Clean N=8** mesh, 10-slot queue, peer 0 starved:

- **Fire:** peer 0's cold-start sync burst (`Synchronizing`, one per remote per retry) overflows the 10-slot queue → `events_discarded_total > 0` for peer 0 (measured ≈25), and **0 for every draining peer** (no single poll step hands a draining peer more than the cap).
- **Neutralize (teeth):** the *identical* schedule with every peer draining discards **nothing** — isolating starvation, not the mesh, as the sole cause of D9.
- **Both runs `expect_pass` the full oracle:** not servicing events is informational-only and must not desync or stall the mesh. A starved peer forgoes only the *secondary* `DesyncDetected` event signal; the oracle's **primary** state-agreement, confirmed-prefix, and liveness checks read `confirmed_frame`/recorded state directly and keep full teeth.

Clean noise is deliberate: the discards come from the initial sync handshake (run by every mesh regardless of noise), so the count is **deterministic and N-scaled** rather than dependent on random faults.

## Changes (test-infra only — no `src/`, no public API, no changelog)

- **`schedule.rs`**: two `#[serde(default)]` `SimConfig` fields — `starve_events: Vec<usize>` (peers that never drain events) and `event_queue_size: Option<usize>` (session event-queue cap override, min 10). Both default to today's behavior (empty / library default 100), so existing corpus artifacts replay **bit-identically, no schema bump**. Serde-default test extended to pin both (present-and-removable → non-vacuous).
- **`mod.rs`**: up-front fail-loud validation (`starve_events` peer `< n`; cap `>= 10`, mirroring `SessionBuilder`); apply `.with_event_queue_size` when set; a per-peer `starves` mask gates the event-drain block.
- **`fleet.rs`**: the event-loss test + two `#[should_panic]` validation tests.

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json` — clean
- full simulation suite: **47 passed** (existing seeds bit-identical — the serde-default guarantee)
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass

Reviewed by an adversarial sub-agent (tautology / vacuous-assertion / oracle-weakening probes) + GitHub Copilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulation tests and harness schedule/run logic; no production `src/` or public API changes, with defaults preserving prior fleet behavior.
> 
> **Overview**
> **§6.6-pre.6h event-loss oracle** — first fleet-level coverage of D9 event-discard metrics, which the harness previously never triggered because every peer drains `P2PSession::events` each step.
> 
> `SimConfig` gains **`starve_events`** (peers that never drain the event queue) and **`event_queue_size`** (optional queue cap, min 10), both `#[serde(default)]` so existing corpus schedules replay unchanged. The harness validates indices and cap up front, applies `with_event_queue_size` when set, and skips event draining (and event-derived oracle signals) only for starved peers while state-agreement checks stay unchanged.
> 
> **`event_starvation_overflows_the_bounded_event_queue`** on a Clean N=8 mesh with a 10-slot queue: peer 0 starved → `events_discarded_total > 0`; draining peers stay at 0; the same seed with all peers draining discards nothing; both runs still **`expect_pass`**. Two **`#[should_panic]`** tests cover out-of-range `starve_events` and sub-minimum `event_queue_size`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80a725f1a047db597cb7af98ce6784d85a0cd70e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->