### PR TITLE
Hardening M3 §6.2(c): bounded post-heal liveness + (i) metastability report

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1552,6 +1552,21 @@ fn run_rejects_too_small_event_queue_size() {
     let _ = run(&generate(0, config), &RunOptions::default());
 }
 
+/// A `step_dt_ms` of 0 never advances virtual time and makes the derived (c)
+/// recovery window (`RECOVERY_WINDOW_MS / step_dt_ms`) meaningless — the runner
+/// must reject it up front rather than let `recovery_window_steps()`'s
+/// div-by-zero `.max(1)` guard silently paper over a broken config.
+#[test]
+#[should_panic(expected = "step_dt_ms must be >= 1")]
+fn run_rejects_zero_step_dt() {
+    let config = SimConfig {
+        n_players: 2,
+        step_dt_ms: 0,
+        ..SimConfig::smoke(2)
+    };
+    let _ = run(&generate(0, config), &RunOptions::default());
+}
+
 /// Heal step + length for the (c) bounded post-heal liveness tests. The recovery
 /// window B (`recovery_window_steps`, 250 at 16ms/step) plus slack must fit
 /// before `STEPS`, so the recovery anchor (`heal_at + B = 650`) is a genuine
@@ -1674,6 +1689,42 @@ fn post_heal_liveness_is_inert_without_a_heal() {
             .iter()
             .any(|f| matches!(f, OracleFailure::PostHealLiveness { .. })),
         "(c) must not fire without a heal: {:?}",
+        report.verdict.failures
+    );
+}
+
+/// (c) NEGATIVE CONTROL 3: when `step_dt_ms` is coarse enough that the recovery
+/// window B is narrower than the G-frame floor (here 500ms/step ⇒ B=8 steps < G=10),
+/// a healthy peer confirming ~1 frame/step physically cannot advance G frames in
+/// the window. (c) must degrade to indeterminate (`None`) rather than charge a
+/// false `PostHealLiveness` against every healthy peer — the run still passes.
+#[test]
+fn post_heal_liveness_is_indeterminate_when_window_narrower_than_g() {
+    let mut schedule = heal_liveness_schedule(None, true);
+    schedule.config.step_dt_ms = 500;
+    assert!(
+        schedule.config.recovery_window_steps() < u32::try_from(POST_HEAL_MIN_ADVANCE).unwrap(),
+        "premise: this step_dt must make B narrower than G"
+    );
+    let report = run(&schedule, &RunOptions::default());
+    report.expect_pass(&schedule);
+    assert_eq!(
+        report.recovered_within_b, None,
+        "(c) must be indeterminate when the window is narrower than G, not a false failure"
+    );
+    assert!(
+        report.confirmed_at_heal.is_empty() && report.confirmed_after_recovery.is_empty(),
+        "an indeterminate (c) samples no anchors: at_heal={:?} after={:?}",
+        report.confirmed_at_heal,
+        report.confirmed_after_recovery
+    );
+    assert!(
+        !report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::PostHealLiveness { .. })),
+        "(c) must not fire a false failure on a too-narrow window: {:?}",
         report.verdict.failures
     );
 }

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -9,7 +9,10 @@ use super::harness::schedule::{
     generate, AppModel, BackgroundNoise, DropPolicy, Schedule, ScheduleEvent, SimConfig,
     SCHEDULE_SCHEMA_VERSION,
 };
-use super::harness::{oracle::OracleFailure, run, RunOptions};
+use super::harness::{
+    oracle::{OracleFailure, POST_HEAL_MIN_ADVANCE},
+    run, RunOptions,
+};
 use crate::common::sim_net::LinkPolicy;
 use std::time::Duration;
 
@@ -1547,4 +1550,182 @@ fn run_rejects_too_small_event_queue_size() {
         ..SimConfig::smoke(2)
     };
     let _ = run(&generate(0, config), &RunOptions::default());
+}
+
+/// Heal step + length for the (c) bounded post-heal liveness tests. The recovery
+/// window B (`recovery_window_steps`, 250 at 16ms/step) plus slack must fit
+/// before `STEPS`, so the recovery anchor (`heal_at + B = 650`) is a genuine
+/// mid-drain sample rather than an end-of-run clamp.
+const HEAL_LIVENESS_HEAL_AT: u32 = 400;
+const HEAL_LIVENESS_STEPS: u32 = 700;
+
+/// Builds a schedule for the (c) bounded post-heal liveness checks: a clean
+/// 4-mesh (`ContinueWithout`) that optionally emits a `HealAll` at
+/// `HEAL_LIVENESS_HEAL_AT` and optionally freezes peer 1 for `stall` steps from
+/// that same step. `heal = false` emits no `HealAll` (heal_at = steps) — the
+/// "never heals" control, where (c) must stay inert. A short `stall` hitches
+/// peer 1 but it catches up within the window (passes (c)); a `stall` spanning
+/// the whole window pins it (fails (c)). The two differ only in stall length, so
+/// the pair is a clean red-green premise.
+fn heal_liveness_schedule(stall: Option<u32>, heal: bool) -> Schedule {
+    let n = 4;
+    let config = SimConfig {
+        n_players: n,
+        steps: HEAL_LIVENESS_STEPS,
+        noise: BackgroundNoise::Clean,
+        // ContinueWithout so the three survivors drop a long-pinned peer and
+        // keep confirming — the (c) failure then isolates to the pinned peer,
+        // rather than Halt taking the whole mesh down with it.
+        disconnect_behavior: DropPolicy::ContinueWithout,
+        ..SimConfig::smoke(n)
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, LinkPolicy::clean()));
+            }
+        }
+    }
+    let mut events = Vec::new();
+    if let Some(steps) = stall {
+        events.push((
+            HEAL_LIVENESS_HEAL_AT,
+            ScheduleEvent::PeerStall { peer: 1, steps },
+        ));
+    }
+    let heal_at = if heal {
+        events.push((HEAL_LIVENESS_HEAL_AT, ScheduleEvent::HealAll));
+        HEAL_LIVENESS_HEAL_AT
+    } else {
+        HEAL_LIVENESS_STEPS
+    };
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
+/// (c) POSITIVE: peer 1 hitches for 60 steps at the heal — well under the
+/// recovery window B — and the mesh catches up, so every live peer advances ≥ G
+/// and (c) passes with `recovered_within_b == Some(true)`. Also proves (c)
+/// actually ran (anchors sampled per peer, each clears the floor) — not silently
+/// inert.
+#[test]
+fn post_heal_liveness_passes_when_a_hitched_peer_recovers() {
+    let schedule = heal_liveness_schedule(Some(60), true);
+    let report = run(&schedule, &RunOptions::default());
+    report.expect_pass(&schedule);
+    assert_eq!(
+        report.recovered_within_b,
+        Some(true),
+        "(c) must run and pass on a mesh that recovers: at_heal={:?} after={:?}",
+        report.confirmed_at_heal,
+        report.confirmed_after_recovery
+    );
+    assert_eq!(
+        report.confirmed_at_heal.len(),
+        4,
+        "one heal anchor per peer"
+    );
+    assert_eq!(
+        report.confirmed_after_recovery.len(),
+        4,
+        "one recovery anchor per peer"
+    );
+    for peer in 0..4 {
+        let advanced = report.confirmed_after_recovery[peer] - report.confirmed_at_heal[peer];
+        assert!(
+            advanced >= POST_HEAL_MIN_ADVANCE,
+            "peer {peer} must clear the G floor post-heal: advanced={advanced}"
+        );
+    }
+}
+
+/// (c) NEGATIVE CONTROL 1: a schedule that never emits `HealAll` must leave (c)
+/// inert — `recovered_within_b == None`, no anchors sampled, no `PostHealLiveness`
+/// failure. Pins that `heal_at` alone (without a `HealAll` event) is NOT treated
+/// as a heal.
+#[test]
+fn post_heal_liveness_is_inert_without_a_heal() {
+    let schedule = heal_liveness_schedule(None, false);
+    let report = run(&schedule, &RunOptions::default());
+    report.expect_pass(&schedule);
+    assert_eq!(
+        report.recovered_within_b, None,
+        "(c) must be inert when the schedule never heals"
+    );
+    assert!(
+        report.confirmed_at_heal.is_empty() && report.confirmed_after_recovery.is_empty(),
+        "no HealAll ⇒ no heal anchors: at_heal={:?} after={:?}",
+        report.confirmed_at_heal,
+        report.confirmed_after_recovery
+    );
+    assert!(
+        !report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::PostHealLiveness { .. })),
+        "(c) must not fire without a heal: {:?}",
+        report.verdict.failures
+    );
+}
+
+/// (c) NEGATIVE CONTROL 2: the same mesh, but peer 1 is frozen across the ENTIRE
+/// recovery window (B + 10 steps) — it cannot advance, so (c) must fire on it
+/// (and only it) while the other three recover. The inverse is the positive test
+/// above (identical schedule minus the long freeze), so the pin is provably what
+/// flips (c) — the premise has teeth.
+#[test]
+fn post_heal_liveness_fires_on_a_pinned_peer() {
+    let b = SimConfig::smoke(4).recovery_window_steps();
+    let schedule = heal_liveness_schedule(Some(b + 10), true);
+    let report = run(&schedule, &RunOptions::default());
+    assert!(!report.verdict.passed(), "a pinned peer must fail the run");
+    assert_eq!(
+        report.recovered_within_b,
+        Some(false),
+        "(i) must report non-recovery when a peer is pinned"
+    );
+    let pinned = report
+        .verdict
+        .failures
+        .iter()
+        .filter(|f| matches!(f, OracleFailure::PostHealLiveness { peer: 1, .. }))
+        .count();
+    assert_eq!(
+        pinned, 1,
+        "(c) must fire on the pinned peer 1: {:?}",
+        report.verdict.failures
+    );
+    assert!(
+        !report.verdict.failures.iter().any(|f| matches!(f,
+            OracleFailure::PostHealLiveness { peer, .. } if *peer != 1)),
+        "only the pinned peer may fail (c): {:?}",
+        report.verdict.failures
+    );
+}
+
+/// (c)/(i) HALT INVERSE: a symmetric partition healed under `Halt` never recovers
+/// (all peers halt in `Synchronizing`), so (c) legitimately reports
+/// `Some(false)` — healed network, metastable mesh. This is a TRUE non-recovery
+/// (the headline metastability case), not a false positive; (c) discriminates
+/// recovered-vs-not, it does not merely pass.
+#[test]
+fn post_heal_liveness_reports_non_recovery_under_halt() {
+    let schedule = split_brain_schedule(DropPolicy::Halt);
+    let report = run(&schedule, &RunOptions::default());
+    assert!(!report.verdict.passed());
+    assert_eq!(
+        report.recovered_within_b,
+        Some(false),
+        "a Halt-halted mesh healed but never recovered — (i) must say so"
+    );
 }

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -417,6 +417,14 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
             "event_queue_size must be >= 10 (SessionBuilder rejects smaller); got {size}"
         );
     }
+    // A 0ms step never advances virtual time and makes the derived (c) recovery
+    // window (`RECOVERY_WINDOW_MS / step_dt_ms`) meaningless — reject it loudly
+    // rather than let `recovery_window_steps()`'s `.max(1)` div-by-zero guard
+    // silently paper over a broken config.
+    assert!(
+        schedule.config.step_dt_ms >= 1,
+        "step_dt_ms must be >= 1 (a 0ms step never advances virtual time)"
+    );
 
     for (from, to, policy) in &schedule.initial_links {
         net.set_link(addrs[*from], addrs[*to], policy.clone());
@@ -549,12 +557,24 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
         .max();
     let b_steps = schedule.config.recovery_window_steps();
     let last_step = schedule.config.steps.saturating_sub(1);
+    // A healthy peer confirms ~1 frame per step post-heal, so the observed
+    // window (in steps) must be at least G wide for the G-frame floor to be
+    // clearable at all; a narrower window cannot distinguish a pinned peer from
+    // a healthy one, so (c) is indeterminate (`None`) rather than a false
+    // `Some(false)` charged against every healthy run. Unreachable at the
+    // default 16ms step_dt (span ~250 ≫ G=10); guards a pathologically coarse
+    // step_dt / tiny B (and the exact-boundary B-1 span).
+    let g_floor = u32::try_from(POST_HEAL_MIN_ADVANCE).unwrap_or(0);
     let (run_c, heal_anchor_at, recovery_anchor_at) = match heal_step {
-        Some(heal_at) if schedule.config.steps.saturating_sub(heal_at) >= b_steps => (
-            true,
-            heal_at.min(last_step),
-            heal_at.saturating_add(b_steps).min(last_step),
-        ),
+        Some(heal_at) if schedule.config.steps.saturating_sub(heal_at) >= b_steps => {
+            let heal_anchor = heal_at.min(last_step);
+            let recovery_anchor = heal_at.saturating_add(b_steps).min(last_step);
+            if recovery_anchor.saturating_sub(heal_anchor) >= g_floor {
+                (true, heal_anchor, recovery_anchor)
+            } else {
+                (false, 0, 0)
+            }
+        },
         _ => (false, 0, 0),
     };
     let mut confirmed_at_heal: Vec<i32> = Vec::new();

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -70,17 +70,22 @@ pub struct RunReport {
     /// remote links from the always-on `PeerMetrics` counters (indexed by peer).
     /// This is the per-player bandwidth ledger the M2 baseline sweep consumes.
     pub peer_wire: Vec<PeerWireTotals>,
-    /// (c) each peer's confirmed frame sampled at the last `HealAll`
-    /// (`schedule.heal_at`); empty when the schedule never heals. Indexed by peer.
+    /// (c) each peer's confirmed frame sampled at the heal anchor — the step of
+    /// the last actual `ScheduleEvent::HealAll` (derived from the event stream,
+    /// not `schedule.heal_at`, which can drift or be set without a `HealAll`);
+    /// empty when the schedule never heals. Indexed by peer.
     pub confirmed_at_heal: Vec<i32>,
-    /// (c) each peer's confirmed frame sampled B steps after the heal (clamped
-    /// to end of run); empty when the schedule never heals. Indexed by peer.
+    /// (c) each peer's confirmed frame sampled at the recovery anchor — B steps
+    /// after the heal, or the run's last step when that lands past the end (an
+    /// exact-boundary drain, span B-1); empty when the schedule never heals.
+    /// Indexed by peer.
     pub confirmed_after_recovery: Vec<i32>,
     /// (i) metastability: `Some(true/false)` iff the (c) bounded post-heal
-    /// liveness check ran (the schedule healed and the post-heal window was ≥ B)
-    /// — the explicit "recovered within B steps of heal: yes/no". `None` when
-    /// (c) was inert (no heal) or indeterminate (window < B). Mirrors
-    /// [`Verdict::recovered_within_b`].
+    /// liveness check ran — a `HealAll` fired and both anchors are observable (a
+    /// full recovery window; span B, or B-1 at an exact-boundary drain). The
+    /// explicit "recovered within B steps of heal: yes/no". `None` when (c) was
+    /// inert (no heal), the window was too short to observe, or every peer was
+    /// killed. Mirrors [`Verdict::recovered_within_b`].
     pub recovered_within_b: Option<bool>,
 }
 
@@ -528,11 +533,14 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     // without emitting a heal (e.g. a no-fault clock-skew run sets it to `steps`
     // with no event), and a hand-authored schedule's `heal_at` field could drift
     // from where its event actually fires. Deriving both the anchor and the
-    // window from the event keeps them consistent. (c) runs only if a heal fired
-    // AND a full recovery window (≥ B steps) follows it, so recovery is fully
-    // observable; otherwise it is inert/indeterminate. The recovery anchor
-    // clamps to the last step, so its span is B, or B-1 at an exact-boundary
-    // drain — the runner reports that real span to the oracle.
+    // window from the event keeps them consistent. (c) runs only when a heal
+    // fired AND enough post-heal drain remains for both anchors to be observable
+    // (`steps - heal_at >= B`, i.e. the recovery anchor `heal_at + B` is at most
+    // the run's end); otherwise it is inert (no heal) or indeterminate (window
+    // too short). The recovery anchor clamps to the last recorded step only at
+    // the exact boundary `heal_at + B == steps`, giving a span of B-1 there and
+    // exactly B otherwise — the runner reports that real span to the oracle, so
+    // no case is silently mislabelled a full-B window.
     let heal_step = schedule
         .events
         .iter()

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -27,7 +27,7 @@ use fortress_rollback::{
     MessageKind, P2PSession, PeerMetrics, PlayerHandle, PlayerType, ProtocolConfig, RequestVec,
     SessionBuilder, SessionState,
 };
-use oracle::{Oracle, Verdict};
+use oracle::{HealLiveness, Oracle, Verdict, POST_HEAL_MIN_ADVANCE};
 use schedule::{AppModel, Schedule, ScheduleEvent};
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
@@ -70,6 +70,18 @@ pub struct RunReport {
     /// remote links from the always-on `PeerMetrics` counters (indexed by peer).
     /// This is the per-player bandwidth ledger the M2 baseline sweep consumes.
     pub peer_wire: Vec<PeerWireTotals>,
+    /// (c) each peer's confirmed frame sampled at the last `HealAll`
+    /// (`schedule.heal_at`); empty when the schedule never heals. Indexed by peer.
+    pub confirmed_at_heal: Vec<i32>,
+    /// (c) each peer's confirmed frame sampled B steps after the heal (clamped
+    /// to end of run); empty when the schedule never heals. Indexed by peer.
+    pub confirmed_after_recovery: Vec<i32>,
+    /// (i) metastability: `Some(true/false)` iff the (c) bounded post-heal
+    /// liveness check ran (the schedule healed and the post-heal window was ≥ B)
+    /// — the explicit "recovered within B steps of heal: yes/no". `None` when
+    /// (c) was inert (no heal) or indeterminate (window < B). Mirrors
+    /// [`Verdict::recovered_within_b`].
+    pub recovered_within_b: Option<bool>,
 }
 
 /// One peer's cumulative wire traffic, summed across every remote link it holds.
@@ -170,12 +182,13 @@ impl RunReport {
     pub fn expect_pass(&self, schedule: &Schedule) {
         assert!(
             self.verdict.passed(),
-            "simulation failed — reproduce with:\n  FORTRESS_SIM_REPRO seed={} n_players={} steps={} noise={:?}\nfinal_confirmed={:?}\nnet={:?}\nfailures ({}):\n{}",
+            "simulation failed — reproduce with:\n  FORTRESS_SIM_REPRO seed={} n_players={} steps={} noise={:?}\nfinal_confirmed={:?}\nrecovered_within_b={:?}\nnet={:?}\nfailures ({}):\n{}",
             schedule.seed,
             schedule.config.n_players,
             schedule.config.steps,
             schedule.config.noise,
             self.final_confirmed,
+            self.recovered_within_b,
             self.net_stats,
             self.verdict.failures.len(),
             self.verdict
@@ -510,6 +523,22 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     // Confirmed-frame snapshot taken at `options.probe_confirmed_at`, if any.
     let mut probe_confirmed: Vec<i32> = Vec::new();
 
+    // (c) bounded post-heal liveness anchors. "Healed" is decided by an actual
+    // `HealAll` event, NOT by `heal_at < steps` — a schedule can set `heal_at`
+    // without emitting a heal (e.g. a no-fault clock-skew run), and that is "no
+    // heal". We snapshot each peer's confirmed frame at the heal step and again
+    // B steps later (clamped into the run); the oracle compares the delta.
+    let heals = schedule
+        .events
+        .iter()
+        .any(|(_, event)| matches!(event, ScheduleEvent::HealAll));
+    let b_steps = schedule.config.recovery_window_steps();
+    let last_step = schedule.config.steps.saturating_sub(1);
+    let heal_anchor_at = schedule.heal_at.min(last_step);
+    let recovery_anchor_at = schedule.heal_at.saturating_add(b_steps).min(last_step);
+    let mut confirmed_at_heal: Vec<i32> = Vec::new();
+    let mut confirmed_after_recovery: Vec<i32> = Vec::new();
+
     for step in 0..schedule.config.steps {
         // Apply control-plane events due at this step.
         while let Some((event_step, event)) = schedule.events.get(next_event) {
@@ -654,6 +683,16 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
             if options.probe_confirmed_at == Some(step) {
                 probe_confirmed.push(confirmed.as_i32());
             }
+
+            // (c) heal-anchored snapshots, reusing the same confirmed value. The
+            // peer loop runs in fixed order, so each vector ends up indexed by
+            // peer. Only populated when the schedule actually heals.
+            if heals && step == heal_anchor_at {
+                confirmed_at_heal.push(confirmed.as_i32());
+            }
+            if heals && step == recovery_anchor_at {
+                confirmed_after_recovery.push(confirmed.as_i32());
+            }
         }
 
         if diagnose && step % 50 == 0 {
@@ -720,7 +759,23 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
         })
         .collect();
 
+    // Hand the oracle the (c) bounded post-heal liveness inputs. `post_heal_window`
+    // is only meaningful when a heal actually fired; 0 otherwise keeps (c) inert.
+    let post_heal_window = if heals {
+        schedule.config.steps.saturating_sub(schedule.heal_at)
+    } else {
+        0
+    };
+    oracle.set_heal_liveness(HealLiveness {
+        healed: heals,
+        post_heal_window,
+        window_steps: b_steps,
+        required_advance: POST_HEAL_MIN_ADVANCE,
+        confirmed_at_heal: confirmed_at_heal.clone(),
+        confirmed_after: confirmed_after_recovery.clone(),
+    });
     let verdict = oracle.finalize(&recorded, &end_confirmed, &end_state);
+    let recovered_within_b = verdict.recovered_within_b;
     RunReport {
         verdict,
         trace_hash,
@@ -729,5 +784,8 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
         net_stats: net.stats(),
         metrics,
         peer_wire,
+        confirmed_at_heal,
+        confirmed_after_recovery,
+        recovered_within_b,
     }
 }

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -523,19 +523,32 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     // Confirmed-frame snapshot taken at `options.probe_confirmed_at`, if any.
     let mut probe_confirmed: Vec<i32> = Vec::new();
 
-    // (c) bounded post-heal liveness anchors. "Healed" is decided by an actual
-    // `HealAll` event, NOT by `heal_at < steps` — a schedule can set `heal_at`
-    // without emitting a heal (e.g. a no-fault clock-skew run), and that is "no
-    // heal". We snapshot each peer's confirmed frame at the heal step and again
-    // B steps later (clamped into the run); the oracle compares the delta.
-    let heals = schedule
+    // (c) bounded post-heal liveness anchors. The heal step is the ACTUAL last
+    // `HealAll` event, not `schedule.heal_at` — a schedule can set `heal_at`
+    // without emitting a heal (e.g. a no-fault clock-skew run sets it to `steps`
+    // with no event), and a hand-authored schedule's `heal_at` field could drift
+    // from where its event actually fires. Deriving both the anchor and the
+    // window from the event keeps them consistent. (c) runs only if a heal fired
+    // AND a full recovery window (≥ B steps) follows it, so recovery is fully
+    // observable; otherwise it is inert/indeterminate. The recovery anchor
+    // clamps to the last step, so its span is B, or B-1 at an exact-boundary
+    // drain — the runner reports that real span to the oracle.
+    let heal_step = schedule
         .events
         .iter()
-        .any(|(_, event)| matches!(event, ScheduleEvent::HealAll));
+        .filter(|(_, event)| matches!(event, ScheduleEvent::HealAll))
+        .map(|(step, _)| *step)
+        .max();
     let b_steps = schedule.config.recovery_window_steps();
     let last_step = schedule.config.steps.saturating_sub(1);
-    let heal_anchor_at = schedule.heal_at.min(last_step);
-    let recovery_anchor_at = schedule.heal_at.saturating_add(b_steps).min(last_step);
+    let (run_c, heal_anchor_at, recovery_anchor_at) = match heal_step {
+        Some(heal_at) if schedule.config.steps.saturating_sub(heal_at) >= b_steps => (
+            true,
+            heal_at.min(last_step),
+            heal_at.saturating_add(b_steps).min(last_step),
+        ),
+        _ => (false, 0, 0),
+    };
     let mut confirmed_at_heal: Vec<i32> = Vec::new();
     let mut confirmed_after_recovery: Vec<i32> = Vec::new();
 
@@ -686,11 +699,14 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
 
             // (c) heal-anchored snapshots, reusing the same confirmed value. The
             // peer loop runs in fixed order, so each vector ends up indexed by
-            // peer. Only populated when the schedule actually heals.
-            if heals && step == heal_anchor_at {
+            // peer. Only populated when (c) runs (a heal fired with a full
+            // recovery window). Captured for every peer — a stalled/dead peer
+            // falls through to here with its frozen confirmed frame, so the
+            // vectors stay length-n and correctly peer-indexed.
+            if run_c && step == heal_anchor_at {
                 confirmed_at_heal.push(confirmed.as_i32());
             }
-            if heals && step == recovery_anchor_at {
+            if run_c && step == recovery_anchor_at {
                 confirmed_after_recovery.push(confirmed.as_i32());
             }
         }
@@ -759,17 +775,13 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
         })
         .collect();
 
-    // Hand the oracle the (c) bounded post-heal liveness inputs. `post_heal_window`
-    // is only meaningful when a heal actually fired; 0 otherwise keeps (c) inert.
-    let post_heal_window = if heals {
-        schedule.config.steps.saturating_sub(schedule.heal_at)
-    } else {
-        0
-    };
+    // Hand the oracle the (c) bounded post-heal liveness inputs. `window_steps`
+    // is the ACTUAL anchor span (B, or B-1 at an exact-boundary drain where the
+    // recovery anchor clamped to the last step), so the failure reports the real
+    // window rather than a nominal one.
     oracle.set_heal_liveness(HealLiveness {
-        healed: heals,
-        post_heal_window,
-        window_steps: b_steps,
+        ran: run_c,
+        window_steps: recovery_anchor_at.saturating_sub(heal_anchor_at),
         required_advance: POST_HEAL_MIN_ADVANCE,
         confirmed_at_heal: confirmed_at_heal.clone(),
         confirmed_after: confirmed_after_recovery.clone(),

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -41,6 +41,17 @@ use std::collections::BTreeMap;
 /// network; a healthy mesh confirms hundreds of frames there.
 pub const MIN_END_CONFIRMED: i32 = 30;
 
+/// Minimum confirmed-frame advance (G) every live peer must make within the
+/// bounded recovery window B after the last `HealAll` — the (c) liveness floor.
+///
+/// A floor, not a rate target: the harness advances one frame per step while
+/// `Running`, so a healthy peer confirms ≈B frames (hundreds) over the window,
+/// clearing this by ~25×. It is set `> max_prediction` (default 8) so a peer
+/// that merely re-fills its prediction window once without truly resuming
+/// confirmation does not clear it, and `< MIN_END_CONFIRMED` (30) so (c) stays a
+/// strictly per-window bound complementary to (c-lite)'s absolute end bar.
+pub const POST_HEAL_MIN_ADVANCE: i32 = 10;
+
 /// One concrete invariant violation, with enough context to debug.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OracleFailure {
@@ -90,12 +101,58 @@ pub enum OracleFailure {
     /// vacuous pass unless flagged. A schedule that crashes the whole mesh
     /// proves no correctness property and must not report success.
     NoLivePeers { n_players: usize },
+    /// (c): a **live** peer failed the bounded post-heal liveness bar — after
+    /// the last `HealAll`, its `confirmed_frame` did not advance by at least
+    /// `required` (G) frames within `window_steps` (B) steps. Catches a peer
+    /// pinned post-heal (or a mutual deadlock) that the coarse end-progress bar
+    /// (c-lite) can miss — a peer may recover late and still clear the absolute
+    /// end bar. Killed peers are excluded (dead, not pinned); the check is inert
+    /// when the schedule never heals and skipped when the post-heal window is
+    /// shorter than B. `advanced` is `after - at_heal` and may read negative
+    /// under the documented transient `confirmed_frame` dip — recorded raw so a
+    /// dip is visible in the repro rather than hidden.
+    PostHealLiveness {
+        peer: usize,
+        at_heal: i32,
+        after: i32,
+        advanced: i32,
+        required: i32,
+        window_steps: u32,
+    },
+}
+
+/// Inputs for the (c) bounded post-heal liveness check, assembled by the runner
+/// from the heal-anchored confirmed-frame snapshots. The [`Default`] is inert
+/// (`healed = false`), so an oracle that is never handed a `HealLiveness` — or
+/// a schedule that never heals — simply skips (c).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HealLiveness {
+    /// The schedule emitted a `HealAll` (else (c) is inert).
+    pub healed: bool,
+    /// Steps of drain available after the heal (`steps - heal_at`).
+    pub post_heal_window: u32,
+    /// The bounded-recovery window B in steps (derived from `step_dt`).
+    pub window_steps: u32,
+    /// Minimum confirmed-frame advance required within B (G).
+    pub required_advance: i32,
+    /// Confirmed frame per peer at the heal anchor (indexed by peer; empty if
+    /// `!healed`).
+    pub confirmed_at_heal: Vec<i32>,
+    /// Confirmed frame per peer at the recovery anchor (indexed by peer; empty
+    /// if `!healed`).
+    pub confirmed_after: Vec<i32>,
 }
 
 /// Final verdict of a run.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Verdict {
     pub failures: Vec<OracleFailure>,
+    /// (i) metastability: `Some(true)` iff the schedule healed, the post-heal
+    /// window was ≥ B, and every live peer advanced ≥ G within B (the (c) check
+    /// ran and passed); `Some(false)` when it ran and at least one live peer was
+    /// pinned; `None` when (c) was inert (no heal) or indeterminate (window < B).
+    /// The explicit "recovered within B steps of heal: yes/no" signal.
+    pub recovered_within_b: Option<bool>,
 }
 
 impl Verdict {
@@ -131,6 +188,11 @@ pub struct Oracle {
     /// stand in (a) — so a peer that diverged before it died cannot escape
     /// detection by being killed.
     dead: Vec<bool>,
+    /// (c) bounded post-heal liveness inputs. Inert by default; the runner sets
+    /// it via [`Self::set_heal_liveness`] once it has the heal-anchored
+    /// confirmed snapshots. Oracle unit tests never set it, so (c) stays inert
+    /// for them.
+    heal: HealLiveness,
 }
 
 impl Oracle {
@@ -143,7 +205,15 @@ impl Oracle {
             failure_cap: 64,
             per_class_cap: 8,
             dead: vec![false; n_players],
+            heal: HealLiveness::default(),
         }
+    }
+
+    /// Hands the oracle the (c) bounded post-heal liveness inputs (heal-anchored
+    /// confirmed snapshots + the derived B/G bounds). Called once by the runner
+    /// before [`Self::finalize`]; left unset (inert) by the oracle unit tests.
+    pub fn set_heal_liveness(&mut self, heal: HealLiveness) {
+        self.heal = heal;
     }
 
     /// Marks `peer` as killed (crashed): it is excluded from the liveness
@@ -337,8 +407,50 @@ impl Oracle {
             }
         }
 
+        // (c) bounded post-heal liveness. Inert unless the schedule healed AND
+        // the post-heal drain window is at least B (else the anchors would
+        // sample an incomplete recovery — indeterminate, never a failure). Dead
+        // peers are excluded exactly like (c-lite): a crashed peer cannot
+        // advance and that is not its own fault. A *live* peer whose confirmed
+        // frame did not advance by G within B steps is pinned (or mutually
+        // deadlocked) — fail it, per peer. This is orthogonal to (c-lite): a
+        // peer can clear the absolute end bar (recovered late, ends ≥ 30) yet
+        // fail this bounded bar (did not advance ≥ G within B), which is exactly
+        // the metastable stall (c-lite) misses.
+        // (c) runs only when the schedule healed AND the drain window is at
+        // least B; otherwise it stays inert (no heal) or indeterminate
+        // (window < B) — `None`, never a pass or a fail.
+        let run_check = self.heal.healed && self.heal.post_heal_window >= self.heal.window_steps;
+        let recovered_within_b = run_check.then(|| {
+            let mut all_live_ok = true;
+            for peer in 0..self.n_players {
+                if self.is_dead(peer) {
+                    continue;
+                }
+                // A missing per-peer entry would be a runner bug; read it as
+                // NULL (-1) so a plumbing bug fails the bar loudly rather than
+                // panicking on an index.
+                let at_heal = self.heal.confirmed_at_heal.get(peer).copied().unwrap_or(-1);
+                let after = self.heal.confirmed_after.get(peer).copied().unwrap_or(-1);
+                let advanced = after.saturating_sub(at_heal);
+                if advanced < self.heal.required_advance {
+                    all_live_ok = false;
+                    self.push_failure(OracleFailure::PostHealLiveness {
+                        peer,
+                        at_heal,
+                        after,
+                        advanced,
+                        required: self.heal.required_advance,
+                        window_steps: self.heal.window_steps,
+                    });
+                }
+            }
+            all_live_ok
+        });
+
         Verdict {
             failures: self.failures,
+            recovered_within_b,
         }
     }
 }

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -123,23 +123,29 @@ pub enum OracleFailure {
 
 /// Inputs for the (c) bounded post-heal liveness check, assembled by the runner
 /// from the heal-anchored confirmed-frame snapshots. The [`Default`] is inert
-/// (`healed = false`), so an oracle that is never handed a `HealLiveness` — or
-/// a schedule that never heals — simply skips (c).
+/// (`ran = false`), so an oracle that is never handed a `HealLiveness` — or a
+/// schedule that never heals — simply skips (c).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct HealLiveness {
-    /// The schedule emitted a `HealAll` (else (c) is inert).
-    pub healed: bool,
-    /// Steps of drain available after the heal (`steps - heal_at`).
-    pub post_heal_window: u32,
-    /// The bounded-recovery window B in steps (derived from `step_dt`).
+    /// The (c) check should run: an actual `HealAll` event fired AND the run
+    /// leaves a full recovery window (≥ B steps) after it to observe. The runner
+    /// owns this decision (heal detection + drain length); `false` ⇒ (c) is
+    /// inert (no heal) or indeterminate (window < B), reported as
+    /// `recovered_within_b = None`.
+    pub ran: bool,
+    /// Actual steps spanned by the two anchors — the span the advance is
+    /// measured over. Equals the derived B, or B-1 when the recovery anchor
+    /// clamps to the run's last step (an exact-boundary drain window). Reported
+    /// in `PostHealLiveness` so the failure states the real window, not a
+    /// nominal one.
     pub window_steps: u32,
-    /// Minimum confirmed-frame advance required within B (G).
+    /// Minimum confirmed-frame advance required within the window (G).
     pub required_advance: i32,
     /// Confirmed frame per peer at the heal anchor (indexed by peer; empty if
-    /// `!healed`).
+    /// `!ran`).
     pub confirmed_at_heal: Vec<i32>,
     /// Confirmed frame per peer at the recovery anchor (indexed by peer; empty
-    /// if `!healed`).
+    /// if `!ran`).
     pub confirmed_after: Vec<i32>,
 }
 
@@ -417,11 +423,10 @@ impl Oracle {
         // peer can clear the absolute end bar (recovered late, ends ≥ 30) yet
         // fail this bounded bar (did not advance ≥ G within B), which is exactly
         // the metastable stall (c-lite) misses.
-        // (c) runs only when the schedule healed AND the drain window is at
-        // least B; otherwise it stays inert (no heal) or indeterminate
-        // (window < B) — `None`, never a pass or a fail.
-        let run_check = self.heal.healed && self.heal.post_heal_window >= self.heal.window_steps;
-        let recovered_within_b = run_check.then(|| {
+        // (c) runs only when the runner signalled it (a heal fired AND a full
+        // recovery window follows); otherwise it stays inert (no heal) or
+        // indeterminate (window < B) — `None`, never a pass or a fail.
+        let recovered_within_b = self.heal.ran.then(|| {
             let mut all_live_ok = true;
             for peer in 0..self.n_players {
                 if self.is_dead(peer) {

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -156,7 +156,9 @@ pub struct Verdict {
     /// (i) metastability: `Some(true)` iff the schedule healed, the post-heal
     /// window was ≥ B, and every live peer advanced ≥ G within B (the (c) check
     /// ran and passed); `Some(false)` when it ran and at least one live peer was
-    /// pinned; `None` when (c) was inert (no heal) or indeterminate (window < B).
+    /// pinned; `None` when (c) was inert (no heal), indeterminate (window < B),
+    /// or every peer was killed (no live peer to report recovery for — that is
+    /// caught separately by `NoLivePeers`, not reported here as "recovered").
     /// The explicit "recovered within B steps of heal: yes/no" signal.
     pub recovered_within_b: Option<bool>,
 }
@@ -426,12 +428,14 @@ impl Oracle {
         // (c) runs only when the runner signalled it (a heal fired AND a full
         // recovery window follows); otherwise it stays inert (no heal) or
         // indeterminate (window < B) — `None`, never a pass or a fail.
-        let recovered_within_b = self.heal.ran.then(|| {
+        let recovered_within_b = if self.heal.ran {
+            let mut checked_any = false;
             let mut all_live_ok = true;
             for peer in 0..self.n_players {
                 if self.is_dead(peer) {
                     continue;
                 }
+                checked_any = true;
                 // A missing per-peer entry would be a runner bug; read it as
                 // NULL (-1) so a plumbing bug fails the bar loudly rather than
                 // panicking on an index.
@@ -450,8 +454,15 @@ impl Oracle {
                     });
                 }
             }
-            all_live_ok
-        });
+            // An all-dead mesh has no live peer whose recovery to report: the
+            // metastability signal is indeterminate (`None`), not "recovered".
+            // (Without this guard the loop skips every peer and `all_live_ok`
+            // stays `true`, so a fully-crashed mesh would read `Some(true)`.)
+            // The verdict itself still fails independently via `NoLivePeers`.
+            checked_any.then_some(all_live_ok)
+        } else {
+            None
+        };
 
         Verdict {
             failures: self.failures,
@@ -648,6 +659,43 @@ mod tests {
                 .iter()
                 .any(|f| matches!(f, OracleFailure::NoLivePeers { n_players: 2 })),
             "an all-crashed mesh must fail, not vacuously pass: {:?}",
+            verdict.failures
+        );
+    }
+
+    /// The (i) metastability signal must not read "recovered" for a mesh with no
+    /// live peer left. Even when (c) is armed (`ran = true`), an all-dead mesh
+    /// has no peer whose recovery to report, so `recovered_within_b` is `None`
+    /// (indeterminate) rather than a vacuous `Some(true)` from an empty loop.
+    #[test]
+    fn recovered_within_b_is_none_when_every_peer_is_killed() {
+        let mut oracle = Oracle::new(2);
+        oracle.mark_peer_dead(0);
+        oracle.mark_peer_dead(1);
+        oracle.set_heal_liveness(HealLiveness {
+            ran: true,
+            window_steps: 250,
+            required_advance: POST_HEAL_MIN_ADVANCE,
+            confirmed_at_heal: vec![100, 100],
+            confirmed_after: vec![100, 100],
+        });
+        let verdict = oracle.finalize(
+            &[BTreeMap::new(), BTreeMap::new()],
+            &[Frame::new(500), Frame::new(500)],
+            &[SessionState::Running, SessionState::Running],
+        );
+        assert_eq!(
+            verdict.recovered_within_b, None,
+            "an all-dead mesh must be indeterminate, not vacuously recovered: {:?}",
+            verdict.recovered_within_b
+        );
+        // And no phantom per-peer liveness failure is charged to a dead peer.
+        assert!(
+            !verdict
+                .failures
+                .iter()
+                .any(|f| matches!(f, OracleFailure::PostHealLiveness { .. })),
+            "dead peers must not be charged a (c) failure: {:?}",
             verdict.failures
         );
     }

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -103,12 +103,13 @@ pub enum OracleFailure {
     NoLivePeers { n_players: usize },
     /// (c): a **live** peer failed the bounded post-heal liveness bar — after
     /// the last `HealAll`, its `confirmed_frame` did not advance by at least
-    /// `required` (G) frames within `window_steps` (B) steps. Catches a peer
-    /// pinned post-heal (or a mutual deadlock) that the coarse end-progress bar
-    /// (c-lite) can miss — a peer may recover late and still clear the absolute
-    /// end bar. Killed peers are excluded (dead, not pinned); the check is inert
-    /// when the schedule never heals and skipped when the post-heal window is
-    /// shorter than B. `advanced` is `after - at_heal` and may read negative
+    /// `required` (G) frames within the observed `window_steps` span (B, or B-1
+    /// at an exact-boundary drain). Catches a peer pinned post-heal (or a mutual
+    /// deadlock) that the coarse end-progress bar (c-lite) can miss — a peer may
+    /// recover late and still clear the absolute end bar. Killed peers are
+    /// excluded (dead, not pinned); the check is inert when the schedule never
+    /// heals and skipped when the post-heal drain is too short for both anchors
+    /// to be observable. `advanced` is `after - at_heal` and may read negative
     /// under the documented transient `confirmed_frame` dip — recorded raw so a
     /// dip is visible in the repro rather than hidden.
     PostHealLiveness {
@@ -127,17 +128,19 @@ pub enum OracleFailure {
 /// schedule that never heals — simply skips (c).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct HealLiveness {
-    /// The (c) check should run: an actual `HealAll` event fired AND the run
-    /// leaves a full recovery window (≥ B steps) after it to observe. The runner
-    /// owns this decision (heal detection + drain length); `false` ⇒ (c) is
-    /// inert (no heal) or indeterminate (window < B), reported as
+    /// The (c) check should run: an actual `HealAll` event fired AND enough
+    /// post-heal drain remains for both anchors to be observable (the recovery
+    /// anchor `heal + B` is at most the run's end). The runner owns this
+    /// decision (heal detection + drain length); `false` ⇒ (c) is inert (no
+    /// heal) or indeterminate (window too short), reported as
     /// `recovered_within_b = None`.
     pub ran: bool,
     /// Actual steps spanned by the two anchors — the span the advance is
-    /// measured over. Equals the derived B, or B-1 when the recovery anchor
-    /// clamps to the run's last step (an exact-boundary drain window). Reported
-    /// in `PostHealLiveness` so the failure states the real window, not a
-    /// nominal one.
+    /// measured over, and the source of truth for the window (not a nominal B).
+    /// Equals the derived B, or B-1 at the exact-boundary drain where the
+    /// recovery anchor `heal + B` lands on the run's end and clamps to the last
+    /// recorded step. Reported in `PostHealLiveness` so a failure states the
+    /// real window.
     pub window_steps: u32,
     /// Minimum confirmed-frame advance required within the window (G).
     pub required_advance: i32,
@@ -153,13 +156,14 @@ pub struct HealLiveness {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Verdict {
     pub failures: Vec<OracleFailure>,
-    /// (i) metastability: `Some(true)` iff the schedule healed, the post-heal
-    /// window was ≥ B, and every live peer advanced ≥ G within B (the (c) check
-    /// ran and passed); `Some(false)` when it ran and at least one live peer was
-    /// pinned; `None` when (c) was inert (no heal), indeterminate (window < B),
-    /// or every peer was killed (no live peer to report recovery for — that is
-    /// caught separately by `NoLivePeers`, not reported here as "recovered").
-    /// The explicit "recovered within B steps of heal: yes/no" signal.
+    /// (i) metastability: `Some(true)` iff the schedule healed, both post-heal
+    /// anchors were observable, and every live peer advanced ≥ G within the
+    /// window (the (c) check ran and passed); `Some(false)` when it ran and at
+    /// least one live peer was pinned; `None` when (c) was inert (no heal), the
+    /// window was too short to observe, or every peer was killed (no live peer
+    /// to report recovery for — that is caught separately by `NoLivePeers`, not
+    /// reported here as "recovered"). The explicit "recovered within B steps of
+    /// heal: yes/no" signal.
     pub recovered_within_b: Option<bool>,
 }
 
@@ -416,18 +420,19 @@ impl Oracle {
         }
 
         // (c) bounded post-heal liveness. Inert unless the schedule healed AND
-        // the post-heal drain window is at least B (else the anchors would
-        // sample an incomplete recovery — indeterminate, never a failure). Dead
-        // peers are excluded exactly like (c-lite): a crashed peer cannot
-        // advance and that is not its own fault. A *live* peer whose confirmed
-        // frame did not advance by G within B steps is pinned (or mutually
-        // deadlocked) — fail it, per peer. This is orthogonal to (c-lite): a
-        // peer can clear the absolute end bar (recovered late, ends ≥ 30) yet
-        // fail this bounded bar (did not advance ≥ G within B), which is exactly
-        // the metastable stall (c-lite) misses.
-        // (c) runs only when the runner signalled it (a heal fired AND a full
-        // recovery window follows); otherwise it stays inert (no heal) or
-        // indeterminate (window < B) — `None`, never a pass or a fail.
+        // the post-heal drain is long enough for both anchors to be observable
+        // (else the anchors would sample an incomplete recovery — indeterminate,
+        // never a failure). Dead peers are excluded exactly like (c-lite): a
+        // crashed peer cannot advance and that is not its own fault. A *live*
+        // peer whose confirmed frame did not advance by G within the observed
+        // window is pinned (or mutually deadlocked) — fail it, per peer. This is
+        // orthogonal to (c-lite): a peer can clear the absolute end bar
+        // (recovered late, ends ≥ 30) yet fail this bounded bar (did not advance
+        // ≥ G within the window), which is exactly the metastable stall (c-lite)
+        // misses.
+        // (c) runs only when the runner signalled it (a heal fired AND both
+        // anchors are observable); otherwise it stays inert (no heal) or
+        // indeterminate (window too short) — `None`, never a pass or a fail.
         let recovered_within_b = if self.heal.ran {
             let mut checked_any = false;
             let mut all_live_ok = true;
@@ -441,6 +446,11 @@ impl Oracle {
                 // panicking on an index.
                 let at_heal = self.heal.confirmed_at_heal.get(peer).copied().unwrap_or(-1);
                 let after = self.heal.confirmed_after.get(peer).copied().unwrap_or(-1);
+                // Signed `saturating_sub`: guards only the (impossible for frame
+                // numbers) i32 overflow, NOT the sign — a transient dip where
+                // `after < at_heal` is preserved as a negative `advanced` and
+                // reported raw (it then trips the `< required` bar and shows the
+                // dip in the failure), never clamped to 0.
                 let advanced = after.saturating_sub(at_heal);
                 if advanced < self.heal.required_advance {
                     all_live_ok = false;

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -175,6 +175,32 @@ impl SimConfig {
     pub fn step_dt(&self) -> Duration {
         Duration::from_millis(self.step_dt_ms)
     }
+
+    /// Virtual wall-clock budget for post-heal recovery, in milliseconds — the
+    /// bound `B` for the oracle's (c) bounded-liveness check. Folds the maximum
+    /// documented compound recovery path (a peer that dropped during a partition
+    /// must, after the network heals, still time its endpoints out, re-run the
+    /// sync handshake, then re-fold connect-status gossip before it resumes
+    /// confirming): `disconnect_timeout` (2000ms), plus a sync-retry burst
+    /// (`num_sync_packets` times `sync_retry_interval` = 5 times 200ms = 1000ms),
+    /// plus gossip settle (3 times `keepalive_interval` = 600ms), rounded up to
+    /// one further keepalive round of slack. Source of the constants:
+    /// `src/network/protocol/mod.rs` `poll()` Running arm (:1237-1258, the
+    /// disconnect and keepalive cadence) and `SyncConfig::default` (:6431-6435);
+    /// `DEFAULT_DISCONNECT_TIMEOUT` and `DEFAULT_DISCONNECT_NOTIFY_START`
+    /// (`src/sessions/builder.rs:43-44`). This is the same ~250-step budget the
+    /// schedule generator already reserves as its post-heal drain window.
+    pub const RECOVERY_WINDOW_MS: u64 = 4000;
+
+    /// The (c) bounded-recovery window `B` in **steps** at this schedule's
+    /// `step_dt` — a fixed [`RECOVERY_WINDOW_MS`](Self::RECOVERY_WINDOW_MS)
+    /// wall-clock budget converted to the step granularity, so the bound is the
+    /// same real duration regardless of `step_dt_ms` (250 steps at 16ms, 125 at
+    /// 32ms, 500 at 8ms).
+    #[must_use]
+    pub fn recovery_window_steps(&self) -> u32 {
+        u32::try_from(Self::RECOVERY_WINDOW_MS.div_ceil(self.step_dt_ms.max(1))).unwrap_or(u32::MAX)
+    }
 }
 
 /// A timed control-plane event. Link endpoints are peer *indices* (resolved


### PR DESCRIPTION
## Summary

Lands the **§6.2 (c) bounded post-heal liveness** oracle invariant and the **(i) metastability report** — the quantitative recovery check the DST harness was missing.

Until now the oracle's only liveness check was **(c-lite)**: at end-of-run every non-dead peer must be `Running` and confirmed ≥ 30. That is a coarse *absolute* bar — a peer can stall for most of the run, recover in the final stretch, and still clear it. **(c)** adds a *bounded* bar: after the last `HealAll`, every **live** peer's `confirmed_frame` must advance by at least **G = 10** frames within **B** steps of the heal. It catches a peer pinned post-heal (or a mutual deadlock) that (c-lite) misses.

**(i)** surfaces the metastability verdict explicitly: `recovered_within_b: Some(true)` = every live peer recovered, `Some(false)` = healed but at least one peer stayed pinned (the metastable case), `None` = inert (no heal) or indeterminate (post-heal window < B).

## The bound B (derived, not arbitrary)

`RECOVERY_WINDOW_MS = 4000ms` folds the documented compound worst-case recovery path — a peer that dropped during a partition must, after the heal, time its endpoints out, re-run sync, then re-fold gossip:

```
disconnect_timeout           2000 ms   (builder.rs:43, protocol/mod.rs:1254)
+ sync-retry burst (5 × 200)  1000 ms   (SyncConfig::default, protocol/mod.rs:6431-6435)
+ gossip settle  (3 × 200)     600 ms   (keepalive cadence, protocol/mod.rs:1237)
→ round up                    4000 ms   →  250 steps at 16ms
```

This is the same ~250-step budget the schedule generator already reserves as its post-heal drain window. B is computed from `step_dt` (`recovery_window_steps()`), so it is the same wall-clock bound at any step granularity. **G = 10** is a floor, not a rate target: `> max_prediction` (8) so a mere prediction-window refill does not clear it, `< MIN_END_CONFIRMED` (30) so (c) stays complementary to (c-lite).

## Both directions, with measured margins

Four tests (`fleet.rs`), sharing one builder that differs only by stall duration — a clean red-green premise:

- **passes when a hitched peer recovers** — peer 1 hitches 60 steps then catches up; every peer advances **~191** frames post-heal → `Some(true)`, (c) passes. Also asserts (c) actually *ran* (anchors sampled per peer, each clears the floor) — not silently inert.
- **inert without a heal** — no `HealAll` ⇒ `None`, empty anchors, no `PostHealLiveness`. Pins that `heal_at` alone (without a `HealAll` event) is not a heal.
- **fires on a pinned peer** — peer 1 frozen across the whole window advances **0**, the three ContinueWithout survivors advance **90** each → (c) fires on peer 1 *only*, `Some(false)`. The G=10 threshold sits unambiguously between 0 and 90.
- **reports non-recovery under Halt** — a partition healed under `Halt` never recovers (all peers halt) → `Some(false)`: the headline metastability case, a true non-recovery.

## Design: always-on, no schema bump

(c) runs on **every** healing schedule (no opt-in), so the existing smoke/tcp/hitch/split-brain fleets gain it for free — **verified: all 2411 tests stay green**. The change adds no `SimConfig`/`Schedule`/serde fields (only harness-internal anchors + `RunReport`/`Verdict` fields), and the anchors reuse the already-trace-folded per-`(step,peer)` `confirmed` read — no new session call, no RNG draw — so existing seeds replay **bit-identically**. Killed peers are excluded (dead, not pinned); a stalled peer is live and *is* checked. `heals` is decided by an actual `HealAll` event, not `heal_at < steps`.

## Changes (test-infra only — no `src/`, no public API, no changelog)

- **`schedule.rs`**: `RECOVERY_WINDOW_MS` + `recovery_window_steps()`.
- **`oracle.rs`**: `PostHealLiveness` failure, `HealLiveness` inputs (Default = inert), `set_heal_liveness`, the (c) check in `finalize`, `POST_HEAL_MIN_ADVANCE`, `Verdict::recovered_within_b`.
- **`mod.rs`**: heal-anchored confirmed snapshots + 3 `RunReport` fields; `expect_pass` repro now prints `recovered_within_b`.
- **`fleet.rs`**: the builder + four tests.

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json` — clean
- full test suite: **2411 passed**; the four new tests pass with the margins above
- `python3 scripts/ci/agent-preflight.py --auto-fix` — all checks pass

Reviewed by a Plan agent (design) + an adversarial sub-agent (always-on soundness, negative-control teeth, B/G derivation, anchor-vector alignment, non-monotonicity) + GitHub Copilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only simulation harness and oracle changes; production library code is untouched.
> 
> **Overview**
> Extends the **DST simulation harness** with **§6.2 (c) bounded post-heal liveness** and an **(i) metastability** signal, complementing existing end-of-run **(c-lite)** checks.
> 
> After the last real **`HealAll`** event (not `schedule.heal_at` alone), the runner samples each peer’s **`confirmed_frame`** at heal and at **B** steps later (**`RECOVERY_WINDOW_MS` / `step_dt`** via **`recovery_window_steps()`**). Live peers must advance by at least **G = 10** frames in that span or get **`PostHealLiveness`**; **`Verdict` / `RunReport`** expose **`recovered_within_b`** as **`Some(true/false)`** or **`None`** when the check is inert or indeterminate (no heal, window shorter than G, all peers dead).
> 
> **`fleet.rs`** adds red/green tests (recovering hitch, pinned peer, no-heal inert, coarse `step_dt`, Halt non-recovery) plus **`step_dt_ms >= 1`** validation. No **`src/`** or public API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adf545113d910128792595ad9f7b688fde220293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->