### PR TITLE
[codex] Hardening M3 GracefulRemove lifecycle op

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -982,6 +982,46 @@ fn peer_kill_schedule(kill: Option<usize>) -> Schedule {
     }
 }
 
+/// Builds a graceful-remove schedule: a clean 4-mesh (`ContinueWithout`) in
+/// which peer `by` calls `remove_player(target)` at step 100, then `target`
+/// leaves the harness. Only one survivor applies the user API; the other
+/// survivors must learn the drop through protocol gossip and converge on the
+/// same frozen slot value. `None` yields the identical schedule without the
+/// removal, the control the premise compares to.
+fn graceful_remove_schedule(remove: Option<(usize, usize)>) -> Schedule {
+    let n = 4;
+    let config = SimConfig {
+        n_players: n,
+        steps: 900,
+        disconnect_behavior: DropPolicy::ContinueWithout,
+        noise: BackgroundNoise::Clean,
+        ..SimConfig::smoke(n)
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, LinkPolicy::clean()));
+            }
+        }
+    }
+    let heal_at = 650;
+    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
+    if let Some((by, target)) = remove {
+        events.push((100, ScheduleEvent::GracefulRemove { by, target }));
+    }
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
 /// M3 §6.1 lifecycle vocabulary — the peer crash (`ScheduleEvent::PeerKill`).
 /// Under `ContinueWithout`, crashing one peer must degrade gracefully: the three
 /// survivors converge on dropping it (freeze its slot to an agreed value) and
@@ -1101,6 +1141,111 @@ fn oracle_catches_pre_kill_divergence_on_the_killed_peer() {
     );
 }
 
+/// M3 §6.1 lifecycle vocabulary — the user-driven graceful drop
+/// (`ScheduleEvent::GracefulRemove`). Under `ContinueWithout`, one survivor's
+/// `remove_player(target)` call must be enough for the live mesh to converge on
+/// the target's frozen slot and keep confirming together. This covers the real
+/// public API path, not just organic timeout/crash detection.
+#[test]
+fn graceful_remove_survivors_converge_under_continue_without() {
+    let base = graceful_remove_schedule(None);
+    let removed = graceful_remove_schedule(Some((0, 1)));
+
+    let base_report = run(&base, &RunOptions::default());
+    base_report.expect_pass(&base);
+    let removed_report = run(&removed, &RunOptions::default());
+    removed_report.expect_pass(&removed);
+
+    let removed_again = run(&removed, &RunOptions::default());
+    assert_eq!(
+        removed_report.trace_hash, removed_again.trace_hash,
+        "a GracefulRemove schedule must reproduce its exact trace"
+    );
+    assert_ne!(
+        base_report.trace_hash, removed_report.trace_hash,
+        "GracefulRemove must change execution — a silent no-op would leave the \
+         trace identical"
+    );
+
+    let confirmed = &removed_report.final_confirmed;
+    for (peer, &c) in confirmed.iter().enumerate() {
+        if peer == 1 {
+            continue;
+        }
+        assert!(
+            c > 200,
+            "survivor {peer} must keep confirming after graceful remove: {confirmed:?}"
+        );
+    }
+    assert!(
+        confirmed[1] < confirmed[0],
+        "the removed peer 1 must stay frozen behind the survivors: {confirmed:?}"
+    );
+}
+
+/// Negative control for graceful remove: the alive mask must exclude only the
+/// removed peer. A real divergence seeded into a survivor after the removal must
+/// still reach the state-agreement oracle, not be hidden by the retired target's
+/// frozen confirmed frame.
+#[test]
+fn oracle_catches_seeded_divergence_under_graceful_remove() {
+    let schedule = graceful_remove_schedule(Some((0, 1)));
+    let options = RunOptions {
+        corrupt_state_from: Some((2, 300)),
+        ..RunOptions::default()
+    };
+    let report = run(&schedule, &options);
+    assert!(
+        !report.verdict.passed(),
+        "a seeded divergence in a survivor must fail under graceful remove"
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::StateDivergence { .. })),
+        "the state comparison must keep its teeth after graceful remove: {:?}",
+        report.verdict.failures
+    );
+}
+
+/// A checksum-only desync must fail even when the app model starves every
+/// session event queue. Without the metrics-backed oracle path, `DesyncDetected`
+/// can sit undrained (or be discarded by D9 trimming), states still agree, and
+/// the run can report a false green.
+#[test]
+fn checksum_mismatch_metric_catches_starved_desync_event() {
+    let config = SimConfig {
+        n_players: 2,
+        noise: BackgroundNoise::Clean,
+        starve_events: vec![0, 1],
+        event_queue_size: Some(10),
+        ..SimConfig::smoke(2)
+    };
+    let mut schedule = generate(13, config);
+    schedule.events.clear();
+    schedule.heal_at = schedule.config.steps;
+    let options = RunOptions {
+        corrupt_checksum_from: Some((0, 40)),
+        ..RunOptions::default()
+    };
+    let report = run(&schedule, &options);
+    assert!(
+        !report.verdict.passed(),
+        "a checksum mismatch must fail even when DesyncDetected events are starved"
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::ChecksumMismatchMetric { .. })),
+        "metrics-backed checksum mismatch must be visible to the oracle: {:?}",
+        report.verdict.failures
+    );
+}
+
 /// A `PeerKill` naming a peer outside the mesh must fail loudly with the same
 /// clear message as the other events (per-event fail-loud contract of the
 /// up-front validation).
@@ -1113,6 +1258,141 @@ fn run_rejects_out_of_range_peer_kill() {
         .push((100, ScheduleEvent::PeerKill { peer: 9 }));
     schedule.events.sort_by_key(|(step, _)| *step);
     let _ = run(&schedule, &RunOptions::default());
+}
+
+fn panic_payload_to_string(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        (*message).to_owned()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "<non-string panic payload>".to_owned()
+    }
+}
+
+/// Malformed `GracefulRemove` events must fail during up-front schedule
+/// validation with clear corpus-replay diagnostics, not as raw indexing panics
+/// in the runner body. The cases cover the whole class: bad caller, bad target,
+/// and a self-target that would make the target local rather than remote.
+#[test]
+fn run_rejects_malformed_graceful_remove_events() {
+    let cases = [
+        (
+            ScheduleEvent::GracefulRemove { by: 9, target: 1 },
+            "out of range",
+        ),
+        (
+            ScheduleEvent::GracefulRemove { by: 0, target: 9 },
+            "out of range",
+        ),
+        (
+            ScheduleEvent::GracefulRemove { by: 1, target: 1 },
+            "target must be remote",
+        ),
+    ];
+
+    for (event, expected) in cases {
+        let mut schedule = graceful_remove_schedule(None);
+        schedule.events.push((100, event));
+        schedule.events.sort_by_key(|(step, _)| *step);
+        let result = std::panic::catch_unwind(|| {
+            let _ = run(&schedule, &RunOptions::default());
+        });
+        let Err(payload) = result else {
+            panic!("malformed GracefulRemove event unexpectedly ran: {schedule:?}");
+        };
+        let message = panic_payload_to_string(payload.as_ref());
+        assert!(
+            message.contains(expected),
+            "panic should mention {expected:?}, got {message:?}"
+        );
+    }
+}
+
+fn assert_run_panics_with(schedule: &Schedule, expected: &str) {
+    let result = std::panic::catch_unwind(|| {
+        let _ = run(schedule, &RunOptions::default());
+    });
+    let Err(payload) = result else {
+        panic!("invalid schedule unexpectedly ran: {schedule:?}");
+    };
+    let message = panic_payload_to_string(payload.as_ref());
+    assert!(
+        message.contains(expected),
+        "panic should mention {expected:?}, got {message:?}"
+    );
+}
+
+/// Hand-authored/corpus schedules must satisfy the same invariants as generated
+/// schedules. Otherwise the runner can silently run an empty mesh, skip a late
+/// event, reorder lifecycle faults, or default a missing directed link to clean.
+#[test]
+fn run_rejects_invalid_materialized_schedule_invariants() {
+    let valid = graceful_remove_schedule(None);
+
+    let mut zero_players = valid.clone();
+    zero_players.config.n_players = 0;
+    zero_players.initial_links.clear();
+    zero_players.events.clear();
+    zero_players.heal_at = zero_players.config.steps;
+
+    let mut unsorted_events = valid.clone();
+    unsorted_events.events.push((10, ScheduleEvent::HealAll));
+
+    let mut event_outside_run = valid.clone();
+    event_outside_run
+        .events
+        .push((event_outside_run.config.steps, ScheduleEvent::HealAll));
+
+    let mut missing_link = valid.clone();
+    let _ = missing_link.initial_links.pop();
+
+    let mut self_link = valid.clone();
+    if let Some(first) = self_link.initial_links.first_mut() {
+        first.1 = first.0;
+    }
+
+    let mut self_link_event = valid.clone();
+    self_link_event.events.push((
+        10,
+        ScheduleEvent::Block {
+            from: 0,
+            to: 0,
+            blocked: true,
+        },
+    ));
+    self_link_event.events.sort_by_key(|(step, _)| *step);
+
+    let mut duplicate_link = valid.clone();
+    if let Some(first) = duplicate_link.initial_links.first().cloned() {
+        let _ = duplicate_link.initial_links.pop();
+        duplicate_link.initial_links.push(first);
+    }
+
+    let mut post_heal_fault = valid;
+    post_heal_fault.events.push((
+        post_heal_fault.heal_at + 1,
+        ScheduleEvent::Block {
+            from: 0,
+            to: 1,
+            blocked: true,
+        },
+    ));
+
+    let cases = [
+        (zero_players, "2..=16 players"),
+        (unsorted_events, "sorted"),
+        (event_outside_run, "outside the run"),
+        (missing_link, "exactly one directed policy"),
+        (self_link, "must not target itself"),
+        (self_link_event, "must not target itself"),
+        (duplicate_link, "duplicate initial link"),
+        (post_heal_fault, "after the last HealAll"),
+    ];
+
+    for (schedule, expected) in cases {
+        assert_run_panics_with(&schedule, expected);
+    }
 }
 
 /// Builds a schedule that reliably drives `WaitRecommendation`s: an `n`-mesh
@@ -1761,6 +2041,44 @@ fn post_heal_liveness_fires_on_a_pinned_peer() {
             OracleFailure::PostHealLiveness { peer, .. } if *peer != 1)),
         "only the pinned peer may fail (c): {:?}",
         report.verdict.failures
+    );
+}
+
+/// Overlapping `PeerStall` events are cumulative in effect: a later short stall
+/// during a long stall must not shorten the first stall's deadline. This pins the
+/// runner to `max(existing_deadline, new_deadline)` semantics; otherwise the
+/// second event below lets peer 1 resume immediately and falsely clears (c).
+#[test]
+fn overlapping_peer_stalls_keep_the_later_deadline() {
+    let b = SimConfig::smoke(4).recovery_window_steps();
+    let mut schedule = heal_liveness_schedule(None, true);
+    schedule.events.push((
+        HEAL_LIVENESS_HEAL_AT - 1,
+        ScheduleEvent::PeerStall {
+            peer: 1,
+            steps: b + 11,
+        },
+    ));
+    schedule.events.push((
+        HEAL_LIVENESS_HEAL_AT,
+        ScheduleEvent::PeerStall { peer: 1, steps: 1 },
+    ));
+    schedule.events.sort_by_key(|(step, _)| *step);
+
+    let report = run(&schedule, &RunOptions::default());
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::PostHealLiveness { peer: 1, .. })),
+        "overlapping short stall must not shorten the long pinned stall: {:?}",
+        report.verdict.failures
+    );
+    assert_eq!(
+        report.recovered_within_b,
+        Some(false),
+        "the long stall must remain pinned across the recovery window"
     );
 }
 

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -29,7 +29,7 @@ use fortress_rollback::{
 };
 use oracle::{HealLiveness, Oracle, Verdict, POST_HEAL_MIN_ADVANCE};
 use schedule::{AppModel, Schedule, ScheduleEvent};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -347,11 +347,56 @@ pub fn run(schedule: &Schedule, options: &RunOptions) -> RunReport {
 
 fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunReport {
     let n = schedule.config.n_players;
+    assert!(
+        (2..=16).contains(&n),
+        "materialized simulation schedules must use 2..=16 players (got {n})"
+    );
+    assert!(
+        schedule.config.steps >= 2,
+        "materialized simulation schedules need at least 2 steps (got {})",
+        schedule.config.steps
+    );
+
     let clock = TestClock::new();
     let net: SimNet<Message> = SimNet::new(schedule.link_seed, clock.as_protocol_clock());
 
     let addrs: Vec<SocketAddr> = (0..n).map(peer_addr).collect();
 
+    assert!(
+        schedule
+            .events
+            .windows(2)
+            .all(|pair| pair[0].0 <= pair[1].0),
+        "schedule events must be sorted by nondecreasing step"
+    );
+    for (step, _) in &schedule.events {
+        assert!(
+            *step < schedule.config.steps,
+            "schedule event at step {step} is outside the run (0..{})",
+            schedule.config.steps
+        );
+    }
+    if let Some(last_heal) = schedule
+        .events
+        .iter()
+        .filter(|(_, event)| matches!(event, ScheduleEvent::HealAll))
+        .map(|(step, _)| *step)
+        .max()
+    {
+        for (step, event) in &schedule.events {
+            assert!(
+                *step <= last_heal || matches!(event, ScheduleEvent::HealAll),
+                "non-HealAll event at step {step} occurs after the last HealAll at {last_heal}"
+            );
+        }
+    }
+    let expected_links = n * (n - 1);
+    assert_eq!(
+        schedule.initial_links.len(),
+        expected_links,
+        "initial_links must contain exactly one directed policy for every non-self pair"
+    );
+    let mut seen_links = BTreeSet::new();
     // Validate every peer index up front so a malformed or hand-edited corpus
     // schedule fails loudly with a clear message instead of panicking on a raw
     // slice index deep in the run (or, for `PeerStall` steps, silently in a
@@ -361,15 +406,29 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
             *from < n && *to < n,
             "initial link ({from} -> {to}) out of range for a {n}-peer mesh"
         );
+        assert!(
+            *from != *to,
+            "initial link ({from} -> {to}) must not target itself"
+        );
+        assert!(
+            seen_links.insert((*from, *to)),
+            "duplicate initial link ({from} -> {to})"
+        );
     }
     for (_, event) in &schedule.events {
         match event {
             ScheduleEvent::SetLink { from, to, .. }
             | ScheduleEvent::Block { from, to, .. }
-            | ScheduleEvent::Hold { from, to, .. } => assert!(
-                *from < n && *to < n,
-                "schedule event link ({from} -> {to}) out of range for a {n}-peer mesh"
-            ),
+            | ScheduleEvent::Hold { from, to, .. } => {
+                assert!(
+                    *from < n && *to < n,
+                    "schedule event link ({from} -> {to}) out of range for a {n}-peer mesh"
+                );
+                assert!(
+                    *from != *to,
+                    "schedule event link ({from} -> {to}) must not target itself"
+                );
+            },
             ScheduleEvent::PeerStall { peer, steps } => {
                 assert!(
                     *peer < n,
@@ -384,6 +443,16 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 *peer < n,
                 "SetInputDelay peer {peer} out of range for a {n}-peer mesh"
             ),
+            ScheduleEvent::GracefulRemove { by, target } => {
+                assert!(
+                    *by < n && *target < n,
+                    "lifecycle drop ({by} -> {target}) out of range for a {n}-peer mesh"
+                );
+                assert!(
+                    by != target,
+                    "lifecycle drop target must be remote (by={by}, target={target})"
+                );
+            },
             ScheduleEvent::PeerKill { peer } => assert!(
                 *peer < n,
                 "PeerKill peer {peer} out of range for a {n}-peer mesh"
@@ -598,7 +667,7 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 },
                 ScheduleEvent::PeerStall { peer, steps } => {
                     // `peer` in range and `steps > 0` are validated up front.
-                    stalled_until[*peer] = step.saturating_add(*steps);
+                    stalled_until[*peer] = stalled_until[*peer].max(step.saturating_add(*steps));
                 },
                 ScheduleEvent::SetInputDelay { peer, delay } => {
                     // Reconfigure the peer's own local input delay mid-run. A
@@ -608,6 +677,22 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                     let handle = PlayerHandle::new(*peer);
                     if let Err(error) = peers[*peer].session.set_input_delay(handle, *delay) {
                         oracle.observe_advance_error(*peer, step, &error);
+                    }
+                },
+                ScheduleEvent::GracefulRemove { by, target } => {
+                    // User-driven graceful departure: one survivor explicitly
+                    // removes the target and the target stops participating. The
+                    // remaining live peers must learn the drop through gossip and
+                    // keep a byte-consistent confirmed prefix.
+                    if !dead[*by] && !dead[*target] {
+                        let handle = PlayerHandle::new(*target);
+                        if let Err(error) = peers[*by].session.remove_player(handle) {
+                            oracle.observe_advance_error(*by, step, &error);
+                        } else {
+                            dead[*target] = true;
+                            net.detach(addrs[*target]);
+                            oracle.mark_peer_dead(*target);
+                        }
                     }
                 },
                 ScheduleEvent::PeerKill { peer } => {
@@ -746,12 +831,16 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
         clock.advance(schedule.config.step_dt());
     }
 
+    let metrics: Vec<fortress_rollback::SessionMetrics> =
+        peers.iter().map(|slot| slot.session.metrics()).collect();
+
     // Final observations.
-    for (i, slot) in peers.iter().enumerate() {
+    for ((i, slot), metric) in peers.iter().enumerate().zip(metrics.iter()) {
         let severe = slot
             .observer
             .violations_at_severity(ViolationSeverity::Error);
         oracle.observe_violations(i, &severe);
+        oracle.observe_checksum_mismatches(i, metric.checksums_mismatched);
     }
     let recorded: Vec<BTreeMap<i32, StateStub>> = peers
         .iter()
@@ -769,9 +858,6 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     for confirmed in &final_confirmed {
         fold_trace(&mut trace_hash, confirmed);
     }
-
-    let metrics: Vec<fortress_rollback::SessionMetrics> =
-        peers.iter().map(|slot| slot.session.metrics()).collect();
 
     // Aggregate each peer's per-remote wire metrics into one per-player total.
     // Peer `i` holds a remote handle `PlayerHandle::new(j)` for every `j != i`

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -676,7 +676,7 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                     // oracle must surface, not swallow.
                     let handle = PlayerHandle::new(*peer);
                     if let Err(error) = peers[*peer].session.set_input_delay(handle, *delay) {
-                        oracle.observe_advance_error(*peer, step, &error);
+                        oracle.observe_session_error("set_input_delay", *peer, step, &error);
                     }
                 },
                 ScheduleEvent::GracefulRemove { by, target } => {
@@ -687,7 +687,7 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                     if !dead[*by] && !dead[*target] {
                         let handle = PlayerHandle::new(*target);
                         if let Err(error) = peers[*by].session.remove_player(handle) {
-                            oracle.observe_advance_error(*by, step, &error);
+                            oracle.observe_session_error("remove_player", *by, step, &error);
                         } else {
                             dead[*target] = true;
                             net.detach(addrs[*target]);
@@ -763,7 +763,7 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                             if let Err(error) =
                                 slot.session.add_local_input(handle, input_for(step, i))
                             {
-                                oracle.observe_advance_error(i, step, &error);
+                                oracle.observe_session_error("add_local_input", i, step, &error);
                             }
                         }
                         match slot.session.advance_frame() {

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -18,9 +18,9 @@
 //!   silent desync. Checksum-mismatch metrics are also consumed directly so a
 //!   starved event queue cannot hide a detector finding. Either way the run
 //!   fails with the full picture recorded.
-//! - **(g) Session-error allowlist**: `advance_frame` while `Running` must
-//!   not error (the prediction throttle is `Ok` with no requests, not an
-//!   error). Any error fails the run with the step and peer recorded.
+//! - **(g) Session-error allowlist**: session APIs the harness expects to
+//!   succeed must not error. Any error fails the run with the operation, step,
+//!   and peer recorded.
 //! - **Violations**: telemetry violations at `Error`+ severity fail the run
 //!   (Critical is never acceptable; the Error allowlist arrives with the
 //!   lifecycle vocabulary in a later milestone, seeded by a fleet census).
@@ -88,8 +88,10 @@ pub enum OracleFailure {
         frame: i32,
         error: String,
     },
-    /// (g): `advance_frame` returned an error while `Running`.
+    /// (g): a session API returned an error while the harness expected it to
+    /// succeed.
     SessionError {
+        operation: &'static str,
         peer: usize,
         step: u32,
         error: String,
@@ -250,7 +252,7 @@ impl Oracle {
         self.dead[peer] = true;
     }
 
-    /// Whether `peer` was killed mid-run.
+    /// Whether `peer` was retired mid-run.
     fn is_dead(&self, peer: usize) -> bool {
         self.dead.get(peer).copied().unwrap_or(false)
     }
@@ -319,6 +321,22 @@ impl Oracle {
         }
     }
 
+    /// (g): a session API errored while the harness expected it to succeed.
+    pub fn observe_session_error(
+        &mut self,
+        operation: &'static str,
+        peer: usize,
+        step: u32,
+        error: &fortress_rollback::FortressError,
+    ) {
+        self.push_failure(OracleFailure::SessionError {
+            operation,
+            peer,
+            step,
+            error: format!("{error:?}"),
+        });
+    }
+
     /// (g): `advance_frame` errored while `Running`.
     pub fn observe_advance_error(
         &mut self,
@@ -326,11 +344,7 @@ impl Oracle {
         step: u32,
         error: &fortress_rollback::FortressError,
     ) {
-        self.push_failure(OracleFailure::SessionError {
-            peer,
-            step,
-            error: format!("{error:?}"),
-        });
+        self.observe_session_error("advance_frame", peer, step, error);
     }
 
     /// Telemetry violations collected for one peer over the whole run.
@@ -777,6 +791,35 @@ mod tests {
             1,
             "only the Error-severity violation should fail the run"
         );
+    }
+
+    /// Session errors carry the failing operation so non-advance harness calls
+    /// are diagnosable from the oracle verdict.
+    #[test]
+    fn oracle_records_session_error_operation() {
+        let mut oracle = Oracle::new(2);
+        oracle.observe_session_error(
+            "remove_player",
+            1,
+            7,
+            &fortress_rollback::FortressError::NotSynchronized,
+        );
+
+        let verdict = oracle.finalize(
+            &[BTreeMap::new(), BTreeMap::new()],
+            &[Frame::new(500), Frame::new(500)],
+            &[SessionState::Running, SessionState::Running],
+        );
+        assert_eq!(verdict.failures.len(), 1, "{:?}", verdict.failures);
+        assert!(matches!(
+            &verdict.failures[0],
+            OracleFailure::SessionError {
+                operation: "remove_player",
+                peer: 1,
+                step: 7,
+                error
+            } if error.contains("NotSynchronized")
+        ));
     }
 
     /// The failure cap keeps a systemically broken run readable.

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -15,7 +15,9 @@
 //! - **(b-cross) In-band cross-check**: `DesyncDetected` events must be
 //!   consistent with (b): an event while recorded states agree exposes a
 //!   false-positive detector; states diverging without an event exposes a
-//!   silent desync. Either way the run fails with the full picture recorded.
+//!   silent desync. Checksum-mismatch metrics are also consumed directly so a
+//!   starved event queue cannot hide a detector finding. Either way the run
+//!   fails with the full picture recorded.
 //! - **(g) Session-error allowlist**: `advance_frame` while `Running` must
 //!   not error (the prediction throttle is `Ok` with no requests, not an
 //!   error). Any error fails the run with the step and peer recorded.
@@ -75,6 +77,10 @@ pub enum OracleFailure {
     },
     /// (b-cross): the in-band desync detector fired.
     InbandDesyncDetected { peer: usize, frame: i32 },
+    /// (b-cross): the session recorded checksum mismatches in metrics. This is
+    /// the event-queue-independent detector signal, so a peer whose app never
+    /// drains `DesyncDetected` events still fails the run.
+    ChecksumMismatchMetric { peer: usize, mismatches: u64 },
     /// (a)-sampling: confirmed inputs for a frame the session reported as
     /// confirmed could not be fetched (eviction outran sampling, or a bug).
     ConfirmedInputUnavailable {
@@ -191,14 +197,15 @@ pub struct Oracle {
     /// anti-pattern inside the oracle itself). Every class is now
     /// guaranteed representation.
     per_class_cap: usize,
-    /// Peers that were killed mid-run (`ScheduleEvent::PeerKill`). A crashed
-    /// peer is excluded from the *liveness* checks only: it cannot satisfy the
-    /// `Running`/end-progress bar (c-lite), and its frozen confirmed frame must
-    /// not drag the globally-confirmed prefix below where the survivors agree.
-    /// Its **pre-death** observations still count — recorded states it produced
-    /// before crashing are compared in (b), and its confirmed-input samples
-    /// stand in (a) — so a peer that diverged before it died cannot escape
-    /// detection by being killed.
+    /// Peers that were retired mid-run (`PeerKill` or `GracefulRemove`). A
+    /// retired peer is excluded from the *liveness* checks only: it cannot
+    /// satisfy the `Running`/end-progress bar (c-lite), and its frozen confirmed
+    /// frame must not drag the globally-confirmed prefix below where the
+    /// survivors agree.
+    /// Its **pre-retirement** observations still count — recorded states it
+    /// produced before leaving are compared in (b), and its confirmed-input
+    /// samples stand in (a) — so a peer that diverged before it left cannot
+    /// escape detection by being retired.
     dead: Vec<bool>,
     /// (c) bounded post-heal liveness inputs. Inert by default; the runner sets
     /// it via [`Self::set_heal_liveness`] once it has the heal-anchored
@@ -228,8 +235,9 @@ impl Oracle {
         self.heal = heal;
     }
 
-    /// Marks `peer` as killed (crashed): it is excluded from the liveness
-    /// checks in [`Self::finalize`]. Idempotent for in-range peers. An
+    /// Marks `peer` as retired (crashed or gracefully removed): it is excluded
+    /// from the liveness checks in [`Self::finalize`]. Idempotent for in-range
+    /// peers. An
     /// out-of-range peer is a programming error — the runner validates every
     /// event's peer index up front — so it panics loudly rather than silently
     /// leaving the mask unset.
@@ -302,6 +310,15 @@ impl Oracle {
         });
     }
 
+    /// (b-cross): a session recorded checksum mismatches, even if its event
+    /// queue was not drained and the corresponding `DesyncDetected` event was
+    /// discarded or left buffered.
+    pub fn observe_checksum_mismatches(&mut self, peer: usize, mismatches: u64) {
+        if mismatches > 0 {
+            self.push_failure(OracleFailure::ChecksumMismatchMetric { peer, mismatches });
+        }
+    }
+
     /// (g): `advance_frame` errored while `Running`.
     pub fn observe_advance_error(
         &mut self,
@@ -344,8 +361,9 @@ impl Oracle {
         assert_eq!(end_confirmed.len(), self.n_players);
         assert_eq!(end_state.len(), self.n_players);
 
-        // (c-lite) end progress per peer. Killed peers are excluded — a crashed
-        // peer cannot be `Running` and its frozen frame is not its own fault.
+        // (c-lite) end progress per peer. Retired peers are excluded — a peer
+        // that left the harness cannot be `Running` and its frozen frame is not
+        // its own fault.
         for peer in 0..self.n_players {
             if self.is_dead(peer) {
                 continue;
@@ -369,9 +387,9 @@ impl Oracle {
             }
         }
 
-        // Guard against a vacuous pass: if every peer was killed, the excluded
+        // Guard against a vacuous pass: if every peer was retired, the excluded
         // end-checks below all skip and the run would report success with
-        // nothing verified. A whole-mesh crash proves no property.
+        // nothing verified. A whole-mesh crash/removal proves no property.
         if self.n_players > 0 && (0..self.n_players).all(|peer| self.is_dead(peer)) {
             self.push_failure(OracleFailure::NoLivePeers {
                 n_players: self.n_players,
@@ -379,7 +397,7 @@ impl Oracle {
         }
 
         // (b) state agreement over the globally confirmed prefix. The prefix is
-        // the minimum over *live* peers only — a killed peer's frozen confirmed
+        // the minimum over *live* peers only — a retired peer's frozen confirmed
         // frame must not shrink the window the survivors are checked across.
         let global_confirmed = end_confirmed
             .iter()
@@ -392,11 +410,11 @@ impl Oracle {
         // the result of simulating frame N with confirmed inputs ≤ N), so a
         // frame's state is final once the *previous* frame is confirmed;
         // comparing up to `global_confirmed` stays strictly inside the final
-        // region. Killed peers are NOT skipped here: their *pre-death* recorded
-        // states are real observations for the frames they produced, so a peer
-        // that diverged before it crashed is still caught (it cannot escape the
-        // check merely by being killed). They only lack states past their death,
-        // so they never contribute past the survivor prefix.
+        // region. Retired peers are NOT skipped here: their *pre-retirement*
+        // recorded states are real observations for the frames they produced, so
+        // a peer that diverged before leaving is still caught. They only lack
+        // states past retirement, so they never contribute past the survivor
+        // prefix.
         let mut canonical_states: BTreeMap<i32, (usize, StateStub)> = BTreeMap::new();
         for (peer, states) in recorded.iter().enumerate() {
             for (&frame, &state) in states.range(..=global_confirmed) {
@@ -422,8 +440,8 @@ impl Oracle {
         // (c) bounded post-heal liveness. Inert unless the schedule healed AND
         // the post-heal drain is long enough for both anchors to be observable
         // (else the anchors would sample an incomplete recovery — indeterminate,
-        // never a failure). Dead peers are excluded exactly like (c-lite): a
-        // crashed peer cannot advance and that is not its own fault. A *live*
+        // never a failure). Retired peers are excluded exactly like (c-lite): a
+        // retired peer cannot advance and that is not its own fault. A *live*
         // peer whose confirmed frame did not advance by G within the observed
         // window is pinned (or mutually deadlocked) — fail it, per peer. This is
         // orthogonal to (c-lite): a peer can clear the absolute end bar

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -74,7 +74,9 @@ pub enum AppModel {
 /// - `4`: adds [`ScheduleEvent::PeerKill`] (a peer crash — the harness stops
 ///   driving the peer and detaches it from the fabric — modeled distinctly from
 ///   a network black-hole).
-pub const SCHEDULE_SCHEMA_VERSION: u32 = 4;
+/// - `5`: adds [`ScheduleEvent::GracefulRemove`], the explicit
+///   user-driven graceful-drop entry point (`P2PSession::remove_player`).
+pub const SCHEDULE_SCHEMA_VERSION: u32 = 5;
 
 /// Background link-noise level applied to every directed link at start.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -247,6 +249,14 @@ pub enum ScheduleEvent {
     /// Like `PeerStall`, this is planted by lifecycle tests, not yet emitted by
     /// the random generator (that lands with the §6.1 storyline overhaul).
     SetInputDelay { peer: usize, delay: usize },
+    /// A live peer `by` explicitly removes remote player `target` via
+    /// `P2PSession::remove_player`, then the target leaves the harness. This is
+    /// the clean user-driven graceful-drop path: one survivor applies the API
+    /// call and the remaining live mesh must learn the drop through protocol
+    /// gossip, freeze the target slot to an agreed value, and keep confirming.
+    ///
+    /// Planted by lifecycle tests, not yet emitted by the random generator.
+    GracefulRemove { by: usize, target: usize },
     /// Permanently kill peer `peer`: the harness stops driving its session and
     /// detaches it from the fabric (its inbox is discarded; further traffic to
     /// it is dropped). Models a **crash** — the peer is gone for good and, being
@@ -626,6 +636,9 @@ mod tests {
             .push((250, ScheduleEvent::SetInputDelay { peer: 2, delay: 3 }));
         schedule
             .events
+            .push((275, ScheduleEvent::GracefulRemove { by: 0, target: 1 }));
+        schedule
+            .events
             .push((300, ScheduleEvent::PeerKill { peer: 2 }));
         schedule.events.sort_by_key(|(step, _)| *step);
         let json = serde_json::to_string(&schedule).unwrap();
@@ -642,6 +655,10 @@ mod tests {
             .events
             .iter()
             .any(|(_, ev)| matches!(ev, ScheduleEvent::SetInputDelay { peer: 2, delay: 3 })));
+        assert!(back
+            .events
+            .iter()
+            .any(|(_, ev)| matches!(ev, ScheduleEvent::GracefulRemove { by: 0, target: 1 })));
         assert!(back
             .events
             .iter()


### PR DESCRIPTION
## Summary

Adds the M3 simulation lifecycle operation `ScheduleEvent::GracefulRemove { by, target }`, backed by the real `P2PSession::remove_player` API path. The deterministic simulation runner now applies the removal on one live survivor, detaches/retires the target, and lets the remaining mesh learn the drop through protocol gossip.

This also folds in adversarial harness hardening found during review:

- checksum mismatch metrics now feed the oracle directly, so a starved event queue cannot hide a checksum-only desync
- materialized/corpus schedules are validated at `run()` time for player bounds, sorted/in-run events, post-heal faults, exact directed-link coverage, self links, and duplicates
- overlapping `PeerStall` events keep the later deadline instead of shortening an existing stall

## Validation

- `cargo fmt`
- `cargo clippy --workspace --all-targets --features tokio,json`
- `cargo nextest run --no-capture graceful_remove`
- `cargo nextest run --no-capture checksum_mismatch_metric_catches_starved_desync_event run_rejects_invalid_materialized_schedule_invariants overlapping_peer_stalls_keep_the_later_deadline`
- `cargo nextest run --no-capture simulation::` — 60 passed, 2388 skipped
- `cargo nextest run --no-capture` — 2391 passed, 57 skipped
- `cargo nextest run --features hot-join --no-capture` — 2630 passed, 57 skipped
- `npx markdownlint 'PLAN.md' 'progress/session-76-m3-graceful-remove-harness-hardening.md' --config .markdownlint.json --fix`
- `python3 scripts/ci/agent-preflight.py --auto-fix`

No production `src/` changes and no public API changes; no changelog entry needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulation tests and harness/oracle code; no production src/ or public API changes, so rollout risk is low aside from stricter schedule validation for hand-authored corpora.
> 
> **Overview**
> Introduces **`ScheduleEvent::GracefulRemove`** (schedule schema v5): the runner calls **`P2PSession::remove_player`** on one survivor, detaches the target, and marks it retired like **`PeerKill`** so survivors stay byte-consistent under **`ContinueWithout`**. Fleet tests cover convergence, determinism, oracle negative controls, and malformed-event validation.
> 
> **Harness/oracle hardening:** **`run()`** now rejects invalid materialized schedules (player bounds, sorted in-run events, full directed link mesh, no self/duplicate links, no faults after last **`HealAll`**). Overlapping **`PeerStall`** deadlines use **`max`**, not overwrite. The oracle fails on **`checksums_mismatched`** metrics when event queues are starved, and **`SessionError`** records the failing operation (e.g. **`remove_player`**, **`set_input_delay`**). Retired-peer wording generalizes the alive mask beyond kills only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6521e5a39380db1e413e3fb7b036507aab7b0210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->