### PR TITLE
[codex] Hardening M3 LegacyDisconnect lifecycle op

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -942,6 +942,46 @@ fn run_rejects_out_of_range_set_input_delay_peer() {
     let _ = run(&schedule, &RunOptions::default());
 }
 
+/// Builds the common clean 4-peer lifecycle schedule used by the planted drop
+/// operations. `event`, when present, fires at step 100; `None` yields the
+/// matched no-op control.
+fn clean_four_peer_lifecycle_schedule(
+    disconnect_behavior: DropPolicy,
+    event: Option<ScheduleEvent>,
+) -> Schedule {
+    let n = 4;
+    let config = SimConfig {
+        n_players: n,
+        steps: 900,
+        disconnect_behavior,
+        noise: BackgroundNoise::Clean,
+        ..SimConfig::smoke(n)
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, LinkPolicy::clean()));
+            }
+        }
+    }
+    let heal_at = 650;
+    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
+    if let Some(event) = event {
+        events.push((100, event));
+    }
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
 /// Builds a peer-kill schedule: a clean 4-mesh (`ContinueWithout`) in which peer
 /// 1 crashes at step 100 — the harness stops driving it and detaches it from the
 /// fabric, so it never returns (not even after `HealAll`). Under `ContinueWithout`
@@ -950,118 +990,39 @@ fn run_rejects_out_of_range_set_input_delay_peer() {
 /// liveness checks. `None` yields the identical schedule without the kill, the
 /// control the premise compares to.
 fn peer_kill_schedule(kill: Option<usize>) -> Schedule {
-    let n = 4;
-    let config = SimConfig {
-        n_players: n,
-        steps: 900,
-        disconnect_behavior: DropPolicy::ContinueWithout,
-        noise: BackgroundNoise::Clean,
-        ..SimConfig::smoke(n)
-    };
-    let mut initial_links = Vec::new();
-    for from in 0..n {
-        for to in 0..n {
-            if from != to {
-                initial_links.push((from, to, LinkPolicy::clean()));
-            }
-        }
-    }
-    let heal_at = 650;
-    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
-    if let Some(peer) = kill {
-        events.push((100, ScheduleEvent::PeerKill { peer }));
-    }
-    events.sort_by_key(|(step, _)| *step);
-    Schedule {
-        schema_version: SCHEDULE_SCHEMA_VERSION,
-        seed: 0,
-        link_seed: 0,
-        config,
-        initial_links,
-        events,
-        heal_at,
-    }
+    clean_four_peer_lifecycle_schedule(
+        DropPolicy::ContinueWithout,
+        kill.map(|peer| ScheduleEvent::PeerKill { peer }),
+    )
 }
 
 /// Builds a graceful-remove schedule: a clean 4-mesh (`ContinueWithout`) in
-/// which peer `by` calls `remove_player(target)` at step 100, then `target`
-/// leaves the harness. Only one survivor applies the user API; the other
-/// survivors must learn the drop through protocol gossip and converge on the
-/// same frozen slot value. `None` yields the identical schedule without the
-/// removal, the control the premise compares to.
+/// which peer `by` calls `remove_player(target)` at step 100. On success the
+/// target leaves the harness; on error it stays live and the oracle records the
+/// failed API call. Only one survivor applies the user API; the other survivors
+/// must learn the drop through protocol gossip and converge on the same frozen
+/// slot value. `None` yields the identical schedule without the removal, the
+/// control the premise compares to.
 fn graceful_remove_schedule(remove: Option<(usize, usize)>) -> Schedule {
-    let n = 4;
-    let config = SimConfig {
-        n_players: n,
-        steps: 900,
-        disconnect_behavior: DropPolicy::ContinueWithout,
-        noise: BackgroundNoise::Clean,
-        ..SimConfig::smoke(n)
-    };
-    let mut initial_links = Vec::new();
-    for from in 0..n {
-        for to in 0..n {
-            if from != to {
-                initial_links.push((from, to, LinkPolicy::clean()));
-            }
-        }
-    }
-    let heal_at = 650;
-    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
-    if let Some((by, target)) = remove {
-        events.push((100, ScheduleEvent::GracefulRemove { by, target }));
-    }
-    events.sort_by_key(|(step, _)| *step);
-    Schedule {
-        schema_version: SCHEDULE_SCHEMA_VERSION,
-        seed: 0,
-        link_seed: 0,
-        config,
-        initial_links,
-        events,
-        heal_at,
-    }
+    clean_four_peer_lifecycle_schedule(
+        DropPolicy::ContinueWithout,
+        remove.map(|(by, target)| ScheduleEvent::GracefulRemove { by, target }),
+    )
 }
 
 /// Builds a legacy-disconnect schedule: a clean 4-mesh in which peer `by`
-/// calls the older `disconnect_player(target)` API at step 100, then `target`
-/// leaves the harness. This is intentionally not a graceful-convergence
-/// contract: today's `disconnect_player` path is Halt-oriented and intersects
-/// D13, so the useful property is that the op is executable, deterministic, and
-/// reported as the expected post-heal non-recovery. `None` yields the identical
-/// schedule without the disconnect, the control the premise compares to.
+/// calls the older `disconnect_player(target)` API at step 100. On success the
+/// target leaves the harness; on error it stays live and the oracle records the
+/// failed API call. This is intentionally not a graceful-convergence contract:
+/// today's `disconnect_player` path is Halt-oriented and intersects D13, so the
+/// useful property is that the op is executable, deterministic, and reported as
+/// the expected post-heal non-recovery. `None` yields the identical schedule
+/// without the disconnect, the control the premise compares to.
 fn legacy_disconnect_schedule(disconnect: Option<(usize, usize)>) -> Schedule {
-    let n = 4;
-    let config = SimConfig {
-        n_players: n,
-        steps: 900,
-        disconnect_behavior: DropPolicy::Halt,
-        noise: BackgroundNoise::Clean,
-        ..SimConfig::smoke(n)
-    };
-    let mut initial_links = Vec::new();
-    for from in 0..n {
-        for to in 0..n {
-            if from != to {
-                initial_links.push((from, to, LinkPolicy::clean()));
-            }
-        }
-    }
-    let heal_at = 650;
-    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
-    if let Some((by, target)) = disconnect {
-        events.push((100, ScheduleEvent::LegacyDisconnect { by, target }));
-    }
-    events.sort_by_key(|(step, _)| *step);
-    Schedule {
-        schema_version: SCHEDULE_SCHEMA_VERSION,
-        seed: 0,
-        link_seed: 0,
-        config,
-        initial_links,
-        events,
-        heal_at,
-    }
+    clean_four_peer_lifecycle_schedule(
+        DropPolicy::Halt,
+        disconnect.map(|(by, target)| ScheduleEvent::LegacyDisconnect { by, target }),
+    )
 }
 
 /// M3 §6.1 lifecycle vocabulary — the peer crash (`ScheduleEvent::PeerKill`).

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -14,7 +14,8 @@ use super::harness::{
     run, RunOptions,
 };
 use crate::common::sim_net::LinkPolicy;
-use std::time::Duration;
+use fortress_rollback::SessionState;
+use std::{collections::BTreeSet, time::Duration};
 
 /// Fixed PR-smoke seed set. Nightly fleets (later milestone) randomize seeds
 /// from the CI run id; the PR set is fixed so PR failures are reproducible
@@ -1022,6 +1023,47 @@ fn graceful_remove_schedule(remove: Option<(usize, usize)>) -> Schedule {
     }
 }
 
+/// Builds a legacy-disconnect schedule: a clean 4-mesh in which peer `by`
+/// calls the older `disconnect_player(target)` API at step 100, then `target`
+/// leaves the harness. This is intentionally not a graceful-convergence
+/// contract: today's `disconnect_player` path is Halt-oriented and intersects
+/// D13, so the useful property is that the op is executable, deterministic, and
+/// reported as the expected post-heal non-recovery. `None` yields the identical
+/// schedule without the disconnect, the control the premise compares to.
+fn legacy_disconnect_schedule(disconnect: Option<(usize, usize)>) -> Schedule {
+    let n = 4;
+    let config = SimConfig {
+        n_players: n,
+        steps: 900,
+        disconnect_behavior: DropPolicy::Halt,
+        noise: BackgroundNoise::Clean,
+        ..SimConfig::smoke(n)
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, LinkPolicy::clean()));
+            }
+        }
+    }
+    let heal_at = 650;
+    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
+    if let Some((by, target)) = disconnect {
+        events.push((100, ScheduleEvent::LegacyDisconnect { by, target }));
+    }
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
 /// M3 §6.1 lifecycle vocabulary — the peer crash (`ScheduleEvent::PeerKill`).
 /// Under `ContinueWithout`, crashing one peer must degrade gracefully: the three
 /// survivors converge on dropping it (freeze its slot to an agreed value) and
@@ -1208,6 +1250,201 @@ fn oracle_catches_seeded_divergence_under_graceful_remove() {
         "the state comparison must keep its teeth after graceful remove: {:?}",
         report.verdict.failures
     );
+}
+
+/// M3 §6.1 lifecycle vocabulary — the legacy user disconnect
+/// (`ScheduleEvent::LegacyDisconnect`). Unlike `GracefulRemove`,
+/// `disconnect_player` takes the Halt-oriented path, so this test does NOT
+/// assert survivor convergence. It pins the executable harness vocabulary and
+/// the current D13-adjacent observation: after a clean network heal, the live
+/// peers do not recover within B and the oracle reports that non-recovery.
+#[test]
+fn legacy_disconnect_reports_halt_non_recovery() {
+    let base = legacy_disconnect_schedule(None);
+    let disconnected = legacy_disconnect_schedule(Some((0, 1)));
+
+    let base_report = run(&base, &RunOptions::default());
+    base_report.expect_pass(&base);
+    let report = run(&disconnected, &RunOptions::default());
+
+    assert!(
+        !report.verdict.passed(),
+        "legacy disconnect is expected to report Halt non-recovery today, not \
+         pass as a graceful drop"
+    );
+    assert_eq!(
+        report.recovered_within_b,
+        Some(false),
+        "a legacy-disconnected Halt mesh healed but did not recover"
+    );
+
+    let expected_live: BTreeSet<usize> = [0usize, 2, 3].into_iter().collect();
+    let expected_advance_errors: BTreeSet<usize> = [2usize, 3].into_iter().collect();
+    let mut advance_error_peers = BTreeSet::new();
+    let mut end_progress_peers = BTreeSet::new();
+    let mut post_heal_peers = BTreeSet::new();
+    for failure in &report.verdict.failures {
+        match failure {
+            OracleFailure::SessionError {
+                operation: "advance_frame",
+                peer,
+                error,
+                ..
+            } => {
+                assert!(
+                    expected_advance_errors.contains(peer),
+                    "only peers that learn the propagated Halt through \
+                     advance_frame should report NotSynchronized: {:?}",
+                    report.verdict.failures
+                );
+                assert!(
+                    error.contains("NotSynchronized"),
+                    "legacy disconnect should surface only NotSynchronized \
+                     advance errors, got {error:?}: {:?}",
+                    report.verdict.failures
+                );
+                advance_error_peers.insert(*peer);
+            },
+            OracleFailure::EndProgress { peer, state, .. } => {
+                assert!(
+                    expected_live.contains(peer),
+                    "target peer 1 is retired; only live peers should fail \
+                     end-progress: {:?}",
+                    report.verdict.failures
+                );
+                assert_eq!(
+                    *state,
+                    SessionState::Synchronizing,
+                    "legacy disconnect should leave live peers Halt-stalled in \
+                     Synchronizing today: {:?}",
+                    report.verdict.failures
+                );
+                end_progress_peers.insert(*peer);
+            },
+            OracleFailure::PostHealLiveness { peer, .. } => {
+                assert!(
+                    expected_live.contains(peer),
+                    "target peer 1 is retired; only live peers should fail \
+                     post-heal liveness: {:?}",
+                    report.verdict.failures
+                );
+                post_heal_peers.insert(*peer);
+            },
+            _ => panic!(
+                "unexpected failure class for a clean legacy-disconnect Halt \
+                 probe: {failure:?}\nall failures: {:?}",
+                report.verdict.failures
+            ),
+        }
+    }
+    assert_eq!(
+        advance_error_peers, expected_advance_errors,
+        "peers 2 and 3 should learn the propagated Halt during advance_frame; \
+         this keeps the expected-failure shape precise: {:?}",
+        report.verdict.failures
+    );
+    assert_eq!(
+        end_progress_peers, expected_live,
+        "all and only live peers must fail end-progress after the legacy \
+         disconnect; this catches regressions where only the caller halts: {:?}",
+        report.verdict.failures
+    );
+    assert_eq!(
+        post_heal_peers, expected_live,
+        "all and only live peers must fail bounded post-heal liveness after \
+         the legacy disconnect: {:?}",
+        report.verdict.failures
+    );
+    assert!(
+        !report.verdict.failures.iter().any(|f| matches!(
+            f,
+            OracleFailure::SessionError {
+                operation: "disconnect_player",
+                ..
+            }
+        )),
+        "the harness must call disconnect_player successfully; failures are the \
+         protocol outcome, not an API error: {:?}",
+        report.verdict.failures
+    );
+
+    let again = run(&disconnected, &RunOptions::default());
+    assert_eq!(
+        report.trace_hash, again.trace_hash,
+        "a LegacyDisconnect schedule must reproduce its exact trace"
+    );
+    assert_ne!(
+        base_report.trace_hash, report.trace_hash,
+        "LegacyDisconnect must change execution — a silent no-op would leave \
+         the trace identical"
+    );
+}
+
+/// A peer that diverges *before* a legacy disconnect must not escape detection
+/// by being retired. This is the `LegacyDisconnect` analogue of the peer-kill
+/// and graceful-remove alive-mask negative controls: retirement excludes the
+/// target from liveness only, not from pre-retirement state agreement.
+#[test]
+fn oracle_catches_pre_disconnect_divergence_on_the_legacy_target() {
+    let schedule = legacy_disconnect_schedule(Some((0, 1)));
+    let options = RunOptions {
+        corrupt_state_from: Some((1, 40)),
+        ..RunOptions::default()
+    };
+    let report = run(&schedule, &options);
+    assert!(
+        !report.verdict.passed(),
+        "a pre-disconnect divergence on the retired target must fail the run"
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|f| matches!(f, OracleFailure::StateDivergence { .. })),
+        "the legacy-disconnected peer's pre-retirement states must still be \
+         compared: {:?}",
+        report.verdict.failures
+    );
+}
+
+/// Malformed `LegacyDisconnect` events share the lifecycle-drop validation
+/// contract with `GracefulRemove`: bad caller, bad target, and self-target are
+/// rejected before the runner can raw-index or accidentally call the API on a
+/// local handle.
+#[test]
+fn run_rejects_malformed_legacy_disconnect_events() {
+    let cases = [
+        (
+            ScheduleEvent::LegacyDisconnect { by: 9, target: 1 },
+            "out of range",
+        ),
+        (
+            ScheduleEvent::LegacyDisconnect { by: 0, target: 9 },
+            "out of range",
+        ),
+        (
+            ScheduleEvent::LegacyDisconnect { by: 1, target: 1 },
+            "target must be remote",
+        ),
+    ];
+
+    for (event, expected) in cases {
+        let mut schedule = legacy_disconnect_schedule(None);
+        schedule.events.push((100, event));
+        schedule.events.sort_by_key(|(step, _)| *step);
+        let result = std::panic::catch_unwind(|| {
+            let _ = run(&schedule, &RunOptions::default());
+        });
+        let Err(payload) = result else {
+            panic!("malformed LegacyDisconnect event unexpectedly ran: {schedule:?}");
+        };
+        let message = panic_payload_to_string(payload.as_ref());
+        assert!(
+            message.contains(expected),
+            "panic should mention {expected:?}, got {message:?}"
+        );
+    }
 }
 
 /// A checksum-only desync must fail even when the app model starves every

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -699,10 +699,11 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 },
                 ScheduleEvent::LegacyDisconnect { by, target } => {
                     // User-driven legacy disconnect: one survivor explicitly
-                    // kicks the target through the older Halt-oriented API, and
-                    // the target stops participating. This deliberately does
-                    // not assert graceful convergence; D13 tracks the current
-                    // fabricated-frame Halt behavior.
+                    // kicks the target through the older Halt-oriented API. On
+                    // success the target stops participating; on error it
+                    // stays live and the oracle records the failed API call.
+                    // This deliberately does not assert graceful convergence;
+                    // D13 tracks the current fabricated-frame Halt behavior.
                     if !dead[*by] && !dead[*target] {
                         let handle = PlayerHandle::new(*target);
                         if let Err(error) = peers[*by].session.disconnect_player(handle) {

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -443,7 +443,8 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                 *peer < n,
                 "SetInputDelay peer {peer} out of range for a {n}-peer mesh"
             ),
-            ScheduleEvent::GracefulRemove { by, target } => {
+            ScheduleEvent::GracefulRemove { by, target }
+            | ScheduleEvent::LegacyDisconnect { by, target } => {
                 assert!(
                     *by < n && *target < n,
                     "lifecycle drop ({by} -> {target}) out of range for a {n}-peer mesh"
@@ -583,8 +584,9 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
     // `step < stalled_until[i]`. `0` means never stalled; a `PeerStall` event
     // sets it to `step + steps`.
     let mut stalled_until: Vec<u32> = vec![0; n];
-    // Peers killed by a `PeerKill` event: no longer driven, detached from the
-    // fabric, and excluded from the oracle's liveness checks (their pre-death
+    // Peers retired by lifecycle events (`PeerKill`, `GracefulRemove`, or
+    // `LegacyDisconnect`): no longer driven, detached from the fabric, and
+    // excluded from the oracle's liveness checks (their pre-retirement
     // observations still count for agreement).
     let mut dead: Vec<bool> = vec![false; n];
     // Per-peer count of advances still owed to an obeyed `WaitRecommendation`
@@ -688,6 +690,23 @@ fn run_inner(schedule: &Schedule, options: &RunOptions, diagnose: bool) -> RunRe
                         let handle = PlayerHandle::new(*target);
                         if let Err(error) = peers[*by].session.remove_player(handle) {
                             oracle.observe_session_error("remove_player", *by, step, &error);
+                        } else {
+                            dead[*target] = true;
+                            net.detach(addrs[*target]);
+                            oracle.mark_peer_dead(*target);
+                        }
+                    }
+                },
+                ScheduleEvent::LegacyDisconnect { by, target } => {
+                    // User-driven legacy disconnect: one survivor explicitly
+                    // kicks the target through the older Halt-oriented API, and
+                    // the target stops participating. This deliberately does
+                    // not assert graceful convergence; D13 tracks the current
+                    // fabricated-frame Halt behavior.
+                    if !dead[*by] && !dead[*target] {
+                        let handle = PlayerHandle::new(*target);
+                        if let Err(error) = peers[*by].session.disconnect_player(handle) {
+                            oracle.observe_session_error("disconnect_player", *by, step, &error);
                         } else {
                             dead[*target] = true;
                             net.detach(addrs[*target]);

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -199,11 +199,11 @@ pub struct Oracle {
     /// anti-pattern inside the oracle itself). Every class is now
     /// guaranteed representation.
     per_class_cap: usize,
-    /// Peers that were retired mid-run (`PeerKill` or `GracefulRemove`). A
-    /// retired peer is excluded from the *liveness* checks only: it cannot
-    /// satisfy the `Running`/end-progress bar (c-lite), and its frozen confirmed
-    /// frame must not drag the globally-confirmed prefix below where the
-    /// survivors agree.
+    /// Peers that were retired mid-run (`PeerKill`, `GracefulRemove`, or
+    /// `LegacyDisconnect`). A retired peer is excluded from the *liveness*
+    /// checks only: it cannot satisfy the `Running`/end-progress bar (c-lite),
+    /// and its frozen confirmed frame must not drag the globally-confirmed
+    /// prefix below where the survivors agree.
     /// Its **pre-retirement** observations still count — recorded states it
     /// produced before leaving are compared in (b), and its confirmed-input
     /// samples stand in (a) — so a peer that diverged before it left cannot

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -260,8 +260,10 @@ pub enum ScheduleEvent {
     /// Planted by lifecycle tests, not yet emitted by the random generator.
     GracefulRemove { by: usize, target: usize },
     /// A live peer `by` explicitly disconnects remote player `target` via
-    /// `P2PSession::disconnect_player`, then the target leaves the harness.
-    /// This is the legacy GGRS-style user path: unlike
+    /// `P2PSession::disconnect_player`. If the API call succeeds, the target
+    /// then leaves the harness; if it errors, the runner records a
+    /// `SessionError` and keeps the target live. This is the legacy GGRS-style
+    /// user path: unlike
     /// [`ScheduleEvent::GracefulRemove`], it does not freeze the dropped slot or
     /// emit `PeerDropped`; with today's `Halt` path it reports non-recovery
     /// and remains part of the D13 "not fully fail-closed" defect surface. That

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -76,7 +76,9 @@ pub enum AppModel {
 ///   a network black-hole).
 /// - `5`: adds [`ScheduleEvent::GracefulRemove`], the explicit
 ///   user-driven graceful-drop entry point (`P2PSession::remove_player`).
-pub const SCHEDULE_SCHEMA_VERSION: u32 = 5;
+/// - `6`: adds [`ScheduleEvent::LegacyDisconnect`], the older
+///   user-driven disconnect entry point (`P2PSession::disconnect_player`).
+pub const SCHEDULE_SCHEMA_VERSION: u32 = 6;
 
 /// Background link-noise level applied to every directed link at start.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -257,6 +259,16 @@ pub enum ScheduleEvent {
     ///
     /// Planted by lifecycle tests, not yet emitted by the random generator.
     GracefulRemove { by: usize, target: usize },
+    /// A live peer `by` explicitly disconnects remote player `target` via
+    /// `P2PSession::disconnect_player`, then the target leaves the harness.
+    /// This is the legacy GGRS-style user path: unlike
+    /// [`ScheduleEvent::GracefulRemove`], it does not freeze the dropped slot or
+    /// emit `PeerDropped`; with today's `Halt` path it reports non-recovery
+    /// and remains part of the D13 "not fully fail-closed" defect surface. That
+    /// makes it a Halt/D13 probe rather than a graceful-convergence contract.
+    ///
+    /// Planted by lifecycle tests, not yet emitted by the random generator.
+    LegacyDisconnect { by: usize, target: usize },
     /// Permanently kill peer `peer`: the harness stops driving its session and
     /// detaches it from the fabric (its inbox is discarded; further traffic to
     /// it is dropped). Models a **crash** — the peer is gone for good and, being
@@ -639,6 +651,9 @@ mod tests {
             .push((275, ScheduleEvent::GracefulRemove { by: 0, target: 1 }));
         schedule
             .events
+            .push((285, ScheduleEvent::LegacyDisconnect { by: 0, target: 2 }));
+        schedule
+            .events
             .push((300, ScheduleEvent::PeerKill { peer: 2 }));
         schedule.events.sort_by_key(|(step, _)| *step);
         let json = serde_json::to_string(&schedule).unwrap();
@@ -659,6 +674,10 @@ mod tests {
             .events
             .iter()
             .any(|(_, ev)| matches!(ev, ScheduleEvent::GracefulRemove { by: 0, target: 1 })));
+        assert!(back
+            .events
+            .iter()
+            .any(|(_, ev)| matches!(ev, ScheduleEvent::LegacyDisconnect { by: 0, target: 2 })));
         assert!(back
             .events
             .iter()


### PR DESCRIPTION
## Summary

Adds the M3 `LegacyDisconnect` lifecycle operation to the deterministic simulation harness.

- bumps simulation schedule schema to v6 and serializes `ScheduleEvent::LegacyDisconnect { by, target }`
- wires the runner to call the real `P2PSession::disconnect_player` API, retiring/detaching the target only on success
- adds planted coverage for serialization, malformed event validation, deterministic execution, and the current Halt/D13 non-recovery shape
- adds a pre-retirement divergence control so a legacy-disconnected target cannot hide a determinism bug behind the alive mask

This is intentionally not modeled as graceful convergence: the legacy path remains Halt/D13-facing and the test pins non-recovery precisely.

## Validation

- `cargo fmt`
- `cargo nextest run --no-capture --no-fail-fast legacy_disconnect pre_disconnect lifecycle_events_round_trip_through_json`
- `cargo nextest run --no-capture --test simulation` (126 passed, 10 skipped)
- `cargo clippy --workspace --all-targets --features tokio,json`
- `python3 scripts/ci/agent-preflight.py --auto-fix`
- `cargo nextest run --no-capture` (2395 passed, 57 skipped)
- `cargo nextest run --features hot-join --no-capture` (2634 passed, 57 skipped)

## Review Notes

A local adversarial review found and fixed an overly loose expected-failure assertion: the test now pins the exact live-peer non-recovery set and only the expected failure classes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulation harness, schedule schema, and tests; production session code is only invoked, not modified.
> 
> **Overview**
> Introduces **`ScheduleEvent::LegacyDisconnect`** and bumps the simulation schedule schema to **v6**, so corpus schedules can plant the legacy **`P2PSession::disconnect_player`** path alongside existing lifecycle ops.
> 
> The harness runner now executes that event like **`GracefulRemove`**: one peer calls the real API, retires and detaches the target on success, and records **`SessionError`** on failure. **`LegacyDisconnect`** shares the same up-front validation as graceful remove (range checks, remote-only target). The oracle treats legacy-disconnected peers like other retired peers for the alive mask (liveness excluded, pre-retirement state still compared).
> 
> **`clean_four_peer_lifecycle_schedule`** deduplicates the 4-peer mesh setup used by peer-kill, graceful-remove, and legacy-disconnect builders; legacy schedules use **`DropPolicy::Halt`** to match today’s halt-oriented behavior.
> 
> New fleet coverage documents that this is **not** a graceful-convergence contract: **`legacy_disconnect_reports_halt_non_recovery`** expects a failing run with precise oracle failure classes, **`recovered_within_b == false`**, and deterministic trace hashes; plus pre-disconnect divergence and malformed-event rejection tests. JSON round-trip tests include the new event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb312a0acec2f1d1b443384e419c04e7c2f44ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->