### PR TITLE
[codex] Wire nightly baseline sweep

### DIFF
--- a/.github/workflows/ci-network-nightly.yml
+++ b/.github/workflows/ci-network-nightly.yml
@@ -1,6 +1,7 @@
 name: CI - Network Tests (Nightly)
 
-# Nightly "does it survive real sockets" lane.
+# Nightly "does it survive real sockets and keep producing measured cost
+# baselines" lane.
 #
 # The extreme / flaky real-UDP chaos scenarios in tests/network/multi_process.rs
 # are marked `#[ignore]` so they do NOT gate every PR (they are slow and
@@ -8,7 +9,9 @@ name: CI - Network Tests (Nightly)
 # covered deterministically and in-process by tests/network/in_process_chaos.rs.
 #
 # This workflow runs the ignored real-UDP extreme tests on a daily schedule (and
-# on demand) to confirm they still survive real sockets + real wall-clock.
+# on demand) to confirm they still survive real sockets + real wall-clock. It
+# also captures the deterministic full baseline sweep artifact on Linux so M5's
+# wire-format cost deltas have a nightly ledger.
 
 on:
   # Daily at 3 AM UTC
@@ -119,6 +122,30 @@ jobs:
           restore-keys: |
             network-nightly-${{ runner.os }}-cargo-
             network-${{ runner.os }}-cargo-
+
+      - name: Run deterministic baseline full matrix (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          rm -rf "$RUNNER_TEMP/fortress-sweep"
+          mkdir -p "$RUNNER_TEMP/fortress-sweep"
+          cargo nextest run --profile ci-network-nightly --release --run-ignored ignored-only -E 'test(full_matrix_sweep)' --test simulation --no-capture
+        env:
+          FORTRESS_SWEEP_OUT: ${{ runner.temp }}/fortress-sweep/full-matrix.jsonl
+          FORTRESS_SWEEP_GIT_SHA: ${{ github.sha }}
+          RUSTC_WRAPPER: ${{ steps.sccache-check.outputs.working == 'true' && 'sccache' || '' }}
+          SCCACHE_GHA_ENABLED: ${{ steps.sccache-check.outputs.working == 'true' && 'true' || 'false' }}
+          SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
+          SCCACHE_STARTUP_NOTIFY_TIMEOUT: "60"
+          SCCACHE_IDLE_TIMEOUT: "0"
+
+      - name: Upload deterministic baseline sweep artifact
+        if: always() && runner.os == 'Linux'
+        uses: actions/upload-artifact@v7
+        with:
+          name: baseline-sweep-nightly-results
+          path: ${{ runner.temp }}/fortress-sweep/full-matrix.jsonl
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Build network test peer
         uses: nick-fields/retry@v4

--- a/.github/workflows/ci-network-nightly.yml
+++ b/.github/workflows/ci-network-nightly.yml
@@ -124,7 +124,9 @@ jobs:
             network-${{ runner.os }}-cargo-
 
       - name: Run deterministic baseline full matrix (Linux)
+        id: baseline-sweep
         if: runner.os == 'Linux'
+        continue-on-error: true
         run: |
           rm -rf "$RUNNER_TEMP/fortress-sweep"
           mkdir -p "$RUNNER_TEMP/fortress-sweep"
@@ -144,7 +146,7 @@ jobs:
         with:
           name: baseline-sweep-nightly-results
           path: ${{ runner.temp }}/fortress-sweep/full-matrix.jsonl
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 30
 
       - name: Build network test peer
@@ -174,6 +176,10 @@ jobs:
           SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
           SCCACHE_STARTUP_NOTIFY_TIMEOUT: "60"
           SCCACHE_IDLE_TIMEOUT: "0"
+
+      - name: Fail if deterministic baseline full matrix failed
+        if: always() && runner.os == 'Linux' && steps.baseline-sweep.outcome != 'success'
+        run: exit 1
 
   # Docker tc/netem chaos lane (with packet loss).
   #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -936,9 +936,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/tests/simulation/baseline_sweep.rs
+++ b/tests/simulation/baseline_sweep.rs
@@ -15,8 +15,7 @@
 //! reports as JSON Lines for offline analysis.
 //!
 //! Deferred to a follow-up (see PLAN.md §5.3): the input-width axis (the harness
-//! `StubConfig` fixes a 4-byte input), a checked-in exact-value baseline as M5's
-//! cost ledger, and the nightly full-matrix CI job.
+//! `StubConfig` fixes a 4-byte input).
 
 use super::harness::schedule::{Schedule, SimConfig, SCHEDULE_SCHEMA_VERSION};
 use super::harness::{run, PeerWireTotals, RunOptions, RunReport};
@@ -298,9 +297,7 @@ pub fn run_cell(params: CellParams) -> CellReport {
         schema: 1,
         label: params.label.to_owned(),
         version: env!("CARGO_PKG_VERSION").to_owned(),
-        git_sha: option_env!("FORTRESS_SWEEP_GIT_SHA")
-            .unwrap_or("unknown")
-            .to_owned(),
+        git_sha: std::env::var("FORTRESS_SWEEP_GIT_SHA").unwrap_or_else(|_| "unknown".to_owned()),
         n_players: n,
         loss_pct: params.loss_pct,
         rtt_ms: params.rtt_ms,
@@ -579,41 +576,7 @@ fn sweep_pr_gate() {
     let reports: Vec<CellReport> = cells.iter().copied().map(run_cell).collect();
 
     for r in &reports {
-        let ctx = || format!("cell {}: {r:?}", r.label);
-        // The load-bearing invariant: constant-conditions meshes never desync.
-        assert_eq!(r.desync_incidents, 0, "desync in a clean cell — {}", ctx());
-        // Liveness: every cell confirms real frames (a stalled mesh would pin
-        // near frame 0). 1000 steps ≈ 16 virtual seconds even at loss15/rtt200.
-        assert!(
-            r.min_final_confirmed >= 50,
-            "cell made too little progress — {}",
-            ctx()
-        );
-        // Real wire traffic flowed, and the per-kind map covers every kind.
-        assert!(
-            r.bytes_sent_per_player_per_sec > 0.0,
-            "no bandwidth recorded — {}",
-            ctx()
-        );
-        assert_eq!(
-            r.messages_sent_by_kind.len(),
-            MessageKind::COUNT,
-            "by-kind map missing categories — {}",
-            ctx()
-        );
-        // Rollback-depth percentiles are ordered and bounded by the observed
-        // max — a real cross-check between the histogram (percentile source)
-        // and the independently-tracked `max_rollback_depth`.
-        assert!(
-            r.rollback_depth_p50 <= r.rollback_depth_p99,
-            "p50 > p99 — {}",
-            ctx()
-        );
-        assert!(
-            r.rollback_depth_p99 <= r.rollback_depth_max,
-            "p99 exceeds max — {}",
-            ctx()
-        );
+        assert_cell_health(r);
     }
 
     // Determinism: virtual time ⇒ a cell is bit-for-bit reproducible.
@@ -628,23 +591,20 @@ fn sweep_pr_gate() {
 }
 
 /// The full baseline matrix. `#[ignore]`d: it runs 5000-frame cells across the
-/// loss × RTT × jitter grid and is intended for offline capture via
-/// `FORTRESS_SWEEP_OUT`, not PR CI. (Nightly CI wiring is a follow-up; see
-/// PLAN.md §5.3.)
-#[test]
-#[ignore = "full matrix; run offline with FORTRESS_SWEEP_OUT set"]
-fn full_matrix_sweep() {
+/// loss × RTT × jitter grid plus scale spot rows and is intended for nightly or
+/// offline capture via `FORTRESS_SWEEP_OUT`, not PR CI.
+fn full_matrix_cells() -> Vec<CellParams> {
     const STEPS: u32 = 5000;
     const SEED: u64 = 1;
     let losses = [0.0, 1.0, 5.0, 15.0];
     let rtts = [10u64, 50, 100, 200];
     let jitters = [0u64, 20];
-    let mut reports = Vec::new();
+    let mut cells = Vec::new();
     for &n_players in &[2usize, 4] {
         for &loss_pct in &losses {
             for &rtt_ms in &rtts {
                 for &jitter_ms in &jitters {
-                    reports.push(run_cell(CellParams {
+                    cells.push(CellParams {
                         label: "matrix",
                         n_players,
                         loss_pct,
@@ -652,13 +612,103 @@ fn full_matrix_sweep() {
                         jitter_ms,
                         steps: STEPS,
                         seed: SEED,
-                    }));
+                    });
                 }
             }
         }
     }
+    for (label, n_players, loss_pct, rtt_ms, jitter_ms) in [
+        ("3p-regional", 3usize, 1.0, 100u64, 20u64),
+        ("8p-regional", 8, 1.0, 100, 20),
+        ("12p-regional", 12, 1.0, 100, 20),
+        ("16p-regional", 16, 1.0, 100, 20),
+    ] {
+        cells.push(CellParams {
+            label,
+            n_players,
+            loss_pct,
+            rtt_ms,
+            jitter_ms,
+            steps: STEPS,
+            seed: SEED,
+        });
+    }
+    cells
+}
+
+#[test]
+fn full_matrix_includes_scale_spot_rows() {
+    let cells = full_matrix_cells();
+    let expected_spots: [(&str, usize, f64, u64, u64); 4] = [
+        ("3p-regional", 3usize, 1.0, 100u64, 20u64),
+        ("8p-regional", 8, 1.0, 100, 20),
+        ("12p-regional", 12, 1.0, 100, 20),
+        ("16p-regional", 16, 1.0, 100, 20),
+    ];
+    assert_eq!(
+        cells.len(),
+        68,
+        "full matrix should be the 64-cell grid plus 4 scale spot rows"
+    );
+    for (label, n_players, loss_pct, rtt_ms, jitter_ms) in expected_spots {
+        assert!(
+            cells.iter().any(|cell| {
+                cell.label == label
+                    && cell.n_players == n_players
+                    && cell.loss_pct.to_bits() == loss_pct.to_bits()
+                    && cell.rtt_ms == rtt_ms
+                    && cell.jitter_ms == jitter_ms
+            }),
+            "full matrix must include exact scale spot row {label}"
+        );
+    }
+}
+
+fn assert_cell_health(r: &CellReport) {
+    let ctx = || format!("cell {}: {r:?}", r.label);
+    // The load-bearing invariant: constant-conditions meshes never desync.
+    assert_eq!(r.desync_incidents, 0, "desync in a clean cell — {}", ctx());
+    // Liveness: every cell confirms real frames (a stalled mesh would pin near
+    // frame 0). 1000 steps ≈ 16 virtual seconds even at loss15/rtt200; the full
+    // matrix runs 5000 steps, so this floor is intentionally conservative there.
+    assert!(
+        r.min_final_confirmed >= 50,
+        "cell made too little progress — {}",
+        ctx()
+    );
+    // Real wire traffic flowed, and the per-kind map covers every kind.
+    assert!(
+        r.bytes_sent_per_player_per_sec > 0.0,
+        "no bandwidth recorded — {}",
+        ctx()
+    );
+    assert_eq!(
+        r.messages_sent_by_kind.len(),
+        MessageKind::COUNT,
+        "by-kind map missing categories — {}",
+        ctx()
+    );
+    // Rollback-depth percentiles are ordered and bounded by the observed max —
+    // a real cross-check between the histogram (percentile source) and the
+    // independently-tracked `max_rollback_depth`.
+    assert!(
+        r.rollback_depth_p50 <= r.rollback_depth_p99,
+        "p50 > p99 — {}",
+        ctx()
+    );
+    assert!(
+        r.rollback_depth_p99 <= r.rollback_depth_max,
+        "p99 exceeds max — {}",
+        ctx()
+    );
+}
+
+#[test]
+#[ignore = "full matrix; run offline with FORTRESS_SWEEP_OUT set"]
+fn full_matrix_sweep() {
+    let reports: Vec<CellReport> = full_matrix_cells().into_iter().map(run_cell).collect();
     for r in &reports {
-        assert_eq!(r.desync_incidents, 0, "desync in matrix cell: {r:?}");
+        assert_cell_health(r);
     }
     write_jsonl(&reports);
 }

--- a/tests/simulation/baseline_sweep.rs
+++ b/tests/simulation/baseline_sweep.rs
@@ -708,8 +708,8 @@ fn assert_cell_health(r: &CellReport) {
 #[ignore = "full matrix; run offline with FORTRESS_SWEEP_OUT set"]
 fn full_matrix_sweep() {
     let reports: Vec<CellReport> = full_matrix_cells().into_iter().map(run_cell).collect();
+    write_jsonl(&reports);
     for r in &reports {
         assert_cell_health(r);
     }
-    write_jsonl(&reports);
 }

--- a/tests/simulation/baseline_sweep.rs
+++ b/tests/simulation/baseline_sweep.rs
@@ -590,9 +590,10 @@ fn sweep_pr_gate() {
     check_or_bless_baseline(&reports);
 }
 
-/// The full baseline matrix. `#[ignore]`d: it runs 5000-frame cells across the
-/// loss × RTT × jitter grid plus scale spot rows and is intended for nightly or
-/// offline capture via `FORTRESS_SWEEP_OUT`, not PR CI.
+/// Returns the full baseline matrix used by the ignored
+/// [`full_matrix_sweep`] test: 5000-frame cells across the loss × RTT ×
+/// jitter grid plus scale spot rows, intended for nightly or offline capture
+/// via `FORTRESS_SWEEP_OUT`, not PR CI.
 fn full_matrix_cells() -> Vec<CellParams> {
     const STEPS: u32 = 5000;
     const SEED: u64 = 1;


### PR DESCRIPTION
## Summary

- Wire the deterministic full baseline sweep into the nightly network workflow on Linux.
- Add N=3/8/12/16 scale rows to the ignored full matrix and pin the exact row set with a cheap PR test.
- Strengthen the full-matrix sweep to assert the same health invariants as the PR gate, and write sweep artifacts under `$RUNNER_TEMP` so uploads cannot publish stale cached `target` data.
- Update locked dev dependencies (`crossbeam-epoch`, `rand`) to patched versions after the security advisory gate failed on newly published advisories.

## Validation

- `cargo nextest run --no-capture --test simulation -E 'test(full_matrix_includes_scale_spot_rows) | test(sweep_pr_gate)'`
- `FORTRESS_SWEEP_OUT=/tmp/fortress-full-matrix.jsonl FORTRESS_SWEEP_GIT_SHA=local-test-sha cargo nextest run --profile ci-network-nightly --release --run-ignored ignored-only -E 'test(full_matrix_sweep)' --test simulation --no-capture`
- `actionlint .github/workflows/ci-network-nightly.yml`
- `cargo clippy --workspace --all-targets --features tokio,json`
- `cargo deny check advisories`
- `cargo deny check`
- `python3 scripts/ci/agent-preflight.py --auto-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI orchestration, simulation test/baseline capture, and non-runtime dependency lockfile updates—no production networking or auth paths.
> 
> **Overview**
> The **nightly network workflow** on Linux now runs the ignored `full_matrix_sweep` simulation test, writes `full-matrix.jsonl` under `$RUNNER_TEMP/fortress-sweep` (avoiding stale cached `target` artifacts), uploads it for 30 days, and **fails the job** if that step did not succeed—even though the sweep step itself uses `continue-on-error` so the artifact can still upload.
> 
> **Baseline sweep harness** changes: `FORTRESS_SWEEP_GIT_SHA` is read at runtime via `std::env::var` instead of compile-time `option_env!`. PR-gate and full-matrix sweeps share **`assert_cell_health`**. The full matrix gains four **scale spot rows** (3/8/12/16 players, regional profile); a cheap PR test **`full_matrix_includes_scale_spot_rows`** pins 68 cells total. Docs no longer defer nightly CI for the full matrix.
> 
> **`Cargo.lock`**: bumps `crossbeam-epoch` and `rand` to address advisory gate failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2148017f4997d7f8fac2e22974b7d78e83a0bbde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->