### PR TITLE
Add hot-join lifecycle simulation op

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -1049,6 +1049,55 @@ fn graceful_remove_schedule(remove: Option<(usize, usize)>) -> Schedule {
     )
 }
 
+#[cfg(feature = "hot-join")]
+fn hot_join_schedule(slot: Option<usize>) -> Schedule {
+    let n = 2;
+    let config = SimConfig {
+        n_players: n,
+        steps: 900,
+        input_delay: 0,
+        disconnect_behavior: DropPolicy::ContinueWithout,
+        noise: BackgroundNoise::Clean,
+        ..SimConfig::smoke(n)
+    };
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, LinkPolicy::clean()));
+            }
+        }
+    }
+    let heal_at = 650;
+    let mut events = vec![(heal_at, ScheduleEvent::HealAll)];
+    if let Some(slot) = slot {
+        events.push((100, ScheduleEvent::HotJoin { slot }));
+    }
+    events.sort_by_key(|(step, _)| *step);
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0,
+        link_seed: 0,
+        config,
+        initial_links,
+        events,
+        heal_at,
+    }
+}
+
+#[cfg(feature = "hot-join")]
+fn hot_join_after_runtime_remove_schedule() -> Schedule {
+    let mut schedule = hot_join_schedule(None);
+    schedule
+        .events
+        .push((100, ScheduleEvent::GracefulRemove { by: 0, target: 1 }));
+    schedule
+        .events
+        .push((120, ScheduleEvent::HotJoin { slot: 1 }));
+    schedule.events.sort_by_key(|(step, _)| *step);
+    schedule
+}
+
 /// Builds a legacy-disconnect schedule: a clean 4-mesh in which peer `by`
 /// calls the older `disconnect_player(target)` API at step 100. On success the
 /// target leaves the harness; on error it stays live and the oracle records the
@@ -1282,6 +1331,119 @@ fn preplanned_spectator_matches_graceful_remove_mesh_canon() {
     assert_eq!(
         report.trace_hash, again.trace_hash,
         "a preplanned spectator schedule must reproduce its exact trace"
+    );
+}
+
+/// M3 §6.1 lifecycle vocabulary — hot-join reactivation
+/// (`ScheduleEvent::HotJoin`). A cleanly dropped slot must be refillable by a
+/// fresh peer at the same address, and that rejoined slot must return to the
+/// live mesh rather than staying behind the oracle's dead-peer mask.
+#[cfg(feature = "hot-join")]
+#[test]
+fn hot_join_reactivates_cleanly_dropped_slot() {
+    use fortress_rollback::MessageKind;
+
+    let base = hot_join_schedule(None);
+    let base_report = run(&base, &RunOptions::default());
+    base_report.expect_pass(&base);
+
+    let slot = 1;
+    let joined = hot_join_schedule(Some(slot));
+    let report = run(&joined, &RunOptions::default());
+    report.expect_pass(&joined);
+
+    let again = run(&joined, &RunOptions::default());
+    assert_eq!(
+        report.trace_hash, again.trace_hash,
+        "a HotJoin schedule for slot {slot} must reproduce its exact trace"
+    );
+    assert_ne!(
+        base_report.trace_hash, report.trace_hash,
+        "HotJoin slot {slot} must change execution — a silent no-op would \
+         leave the trace identical"
+    );
+
+    for (peer, &confirmed) in report.final_confirmed.iter().enumerate() {
+        assert!(
+            confirmed > 200,
+            "peer {peer} must be live and confirming after hot-join slot {slot}: {:?}",
+            report.final_confirmed
+        );
+    }
+
+    let join_requests: u64 = report
+        .peer_wire
+        .iter()
+        .map(|wire| wire.sent_by_kind(MessageKind::JoinRequest))
+        .sum();
+    let snapshots: u64 = report
+        .peer_wire
+        .iter()
+        .map(|wire| wire.sent_by_kind(MessageKind::StateSnapshot))
+        .sum();
+    assert!(
+        join_requests > 0 && snapshots > 0,
+        "hot-join slot {slot} wire traffic must be present \
+         (join_requests={join_requests}, snapshots={snapshots})"
+    );
+}
+
+/// A `HotJoin` event must never silently no-op against a slot already retired by
+/// an earlier runtime lifecycle API. `GracefulRemove` is runtime-contingent, so
+/// static validation cannot reject it; the runner must report it through the
+/// oracle when the hot-join event fires.
+#[cfg(feature = "hot-join")]
+#[test]
+fn hot_join_after_runtime_remove_fails_loudly() {
+    let schedule = hot_join_after_runtime_remove_schedule();
+
+    let report = run(&schedule, &RunOptions::default());
+    assert!(
+        !report.verdict.passed(),
+        "hot-joining an already-retired slot must fail loudly"
+    );
+    assert!(
+        report.verdict.failures.iter().any(|failure| {
+            matches!(
+                failure,
+                OracleFailure::SessionError {
+                    operation: "hot_join_slot_unavailable",
+                    peer: 1,
+                    ..
+                }
+            )
+        }),
+        "expected explicit hot_join_slot_unavailable failure, got {:?}",
+        report.verdict.failures
+    );
+}
+
+/// The hot-join generation boundary intentionally discards the departing
+/// slot's trailing handoff-window confirmed-input authorship, because the
+/// coordinator freezes that window when it cleanly removes the slot. It must
+/// not hide settled pre-handoff determinism bugs.
+#[cfg(feature = "hot-join")]
+#[test]
+fn oracle_catches_settled_pre_handoff_divergence_under_hot_join() {
+    let schedule = hot_join_schedule(Some(1));
+    let options = RunOptions {
+        corrupt_state_from: Some((1, 80)),
+        ..RunOptions::default()
+    };
+
+    let report = run(&schedule, &options);
+    assert!(
+        !report.verdict.passed(),
+        "a pre-handoff divergence on the departing slot must still fail"
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .any(|failure| matches!(failure, OracleFailure::StateDivergence { .. })),
+        "expected StateDivergence before the hot-join handoff, got {:?}",
+        report.verdict.failures
     );
 }
 

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -585,22 +585,6 @@ fn start_hot_join_for_slot<I: SimInput>(slot: usize, step: u32, ctx: &mut HotJoi
         return;
     }
 
-    let handle = PlayerHandle::new(slot);
-    if let Err(error) = ctx.peers[host].session.remove_player(handle) {
-        ctx.oracle
-            .observe_session_error("hot_join_remove_player", host, step, &error);
-        return;
-    }
-
-    let handoff_floor = ctx.peers[host]
-        .session
-        .confirmed_frame()
-        .as_i32()
-        .saturating_sub(i32::try_from(ctx.schedule.config.max_prediction).unwrap_or(i32::MAX));
-    let input_handoff_floor = handoff_floor.saturating_sub(1);
-    ctx.oracle
-        .begin_replacement_generation(slot, input_handoff_floor);
-    ctx.net.detach(ctx.addrs[slot]);
     let socket: SimSocket<Message> = ctx.net.attach(ctx.addrs[slot]);
     let observer = Arc::clone(&ctx.peers[slot].observer);
     let protocol_config = peer_protocol_config(ctx.schedule, slot, ctx.clock);
@@ -635,16 +619,36 @@ fn start_hot_join_for_slot<I: SimInput>(slot: usize, step: u32, ctx: &mut HotJoi
             .expect("valid hot-join player registration");
     }
 
-    match builder.start_hot_join_session(socket, ctx.addrs[host]) {
-        Ok(session) => {
-            ctx.peers[slot].session = session;
-            ctx.peers[slot].pending_replacement_handoff_floor = Some(handoff_floor);
-        },
+    let replacement = match builder.start_hot_join_session(socket, ctx.addrs[host]) {
+        Ok(session) => session,
         Err(error) => {
             ctx.oracle
                 .observe_session_error("start_hot_join_session", slot, step, &error);
+            return;
         },
+    };
+
+    let handle = PlayerHandle::new(slot);
+    if let Err(error) = ctx.peers[host].session.remove_player(handle) {
+        ctx.oracle
+            .observe_session_error("hot_join_remove_player", host, step, &error);
+        return;
     }
+
+    let handoff_floor = ctx.peers[host]
+        .session
+        .confirmed_frame()
+        .as_i32()
+        .saturating_sub(i32::try_from(ctx.schedule.config.max_prediction).unwrap_or(i32::MAX));
+    let input_handoff_floor = handoff_floor.saturating_sub(1);
+    ctx.oracle
+        .begin_replacement_generation(slot, input_handoff_floor);
+    // The replacement owns an address-backed `SimSocket`; reset the old peer's
+    // inbox, then recreate an empty inbox at the same address for that socket.
+    ctx.net.detach(ctx.addrs[slot]);
+    let _replacement_inbox = ctx.net.attach(ctx.addrs[slot]);
+    ctx.peers[slot].session = replacement;
+    ctx.peers[slot].pending_replacement_handoff_floor = Some(handoff_floor);
 }
 
 /// Pure per-peer input function: any deterministic mapping works; this one
@@ -1641,6 +1645,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::simulation::harness::oracle::OracleFailure;
     use fortress_rollback::network::codec;
 
     fn assert_input_width<I: SimInput>(input: I) {
@@ -1723,6 +1728,126 @@ mod tests {
                 InputStatus::Confirmed
             )]),
             "same-tick replacement inputs must replace old-generation data"
+        );
+    }
+
+    #[cfg(feature = "hot-join")]
+    fn test_peer_slot(
+        peer: usize,
+        schedule: &Schedule,
+        clock: &TestClock,
+        net: &SimNet<Message>,
+        addrs: &[SocketAddr],
+    ) -> PeerSlot<StubInput> {
+        let socket: SimSocket<Message> = net.attach(addrs[peer]);
+        let observer = Arc::new(CollectingObserver::new());
+        let protocol_config = peer_protocol_config(schedule, peer, clock);
+        let mut builder = SessionBuilder::<StubConfig>::new()
+            .with_num_players(addrs.len())
+            .expect("valid player count")
+            .with_max_prediction_window(1)
+            .with_input_delay(0)
+            .expect("valid input delay")
+            .with_desync_detection_mode(DesyncDetection::On {
+                interval: schedule.config.desync_interval,
+            })
+            .with_disconnect_behavior(schedule.config.disconnect_behavior.into())
+            .with_protocol_config(protocol_config)
+            .with_violation_observer(Arc::clone(&observer) as Arc<_>);
+        for (slot, addr) in addrs.iter().enumerate() {
+            let player_type = if slot == peer {
+                PlayerType::Local
+            } else {
+                PlayerType::Remote(*addr)
+            };
+            builder = builder
+                .add_player(player_type, PlayerHandle::new(slot))
+                .expect("valid player registration");
+        }
+        PeerSlot {
+            session: builder.start_p2p_session(socket).expect("session starts"),
+            game: SimGameStub::<StubInput>::new(),
+            observer,
+            sampled_confirmed: -1,
+            pending_replacement_handoff_floor: None,
+        }
+    }
+
+    #[cfg(feature = "hot-join")]
+    #[test]
+    fn failed_hot_join_session_build_leaves_existing_slot_intact() {
+        let n = 2;
+        let clock = TestClock::new();
+        let net: SimNet<Message> = SimNet::new(0, clock.as_protocol_clock());
+        let addrs: Vec<SocketAddr> = (0..n).map(peer_addr).collect();
+        let schedule = Schedule {
+            schema_version: schedule::SCHEDULE_SCHEMA_VERSION,
+            seed: 0,
+            link_seed: 0,
+            config: schedule::SimConfig {
+                n_players: n,
+                steps: 10,
+                input_delay: 0,
+                max_prediction: 0,
+                disconnect_behavior: schedule::DropPolicy::ContinueWithout,
+                noise: schedule::BackgroundNoise::Clean,
+                ..schedule::SimConfig::smoke(n)
+            },
+            initial_links: Vec::new(),
+            events: Vec::new(),
+            heal_at: 0,
+        };
+        let mut peers: Vec<PeerSlot<StubInput>> = (0..n)
+            .map(|peer| test_peer_slot(peer, &schedule, &clock, &net, &addrs))
+            .collect();
+        let dead = vec![false; n];
+        let mut oracle = Oracle::new(n);
+
+        {
+            let mut ctx = HotJoinRuntime {
+                schedule: &schedule,
+                clock: &clock,
+                net: &net,
+                addrs: &addrs,
+                peers: &mut peers,
+                dead: &dead,
+                oracle: &mut oracle,
+            };
+            start_hot_join_for_slot::<StubInput>(1, 3, &mut ctx);
+        }
+
+        assert!(
+            !dead[1],
+            "failed replacement construction must not retire the old slot"
+        );
+        assert!(
+            peers[1].pending_replacement_handoff_floor.is_none(),
+            "failed replacement construction must not arm handoff pruning"
+        );
+        peers[0]
+            .session
+            .remove_player(PlayerHandle::new(1))
+            .expect("host must not have removed slot before replacement construction failed");
+
+        let verdict = oracle.finalize(
+            &[BTreeMap::new(), BTreeMap::new()],
+            &[Frame::NULL, Frame::NULL],
+            &[SessionState::Running, SessionState::Running],
+        );
+        assert!(
+            verdict.failures.iter().any(|failure| {
+                matches!(
+                    failure,
+                    OracleFailure::SessionError {
+                        operation: "start_hot_join_session",
+                        peer: 1,
+                        step: 3,
+                        ..
+                    }
+                )
+            }),
+            "expected start_hot_join_session failure, got {:?}",
+            verdict.failures
         );
     }
 

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -380,19 +380,36 @@ impl<I: SimInput> SimGameStub<I> {
         self.applied_inputs.retain(|frame, _| *frame < from_frame);
     }
 
-    fn handle_requests(&mut self, requests: RequestVec<I::SessionConfig>) -> Option<Frame> {
-        let mut loaded_frame = None;
+    fn loaded_frame(requests: &RequestVec<I::SessionConfig>) -> Option<Frame> {
+        requests.iter().find_map(|request| match request {
+            FortressRequest::LoadGameState { frame, .. } => Some(*frame),
+            FortressRequest::SaveGameState { .. } | FortressRequest::AdvanceFrame { .. } => None,
+        })
+    }
+
+    fn handle_replacement_handoff_requests(
+        &mut self,
+        requests: RequestVec<I::SessionConfig>,
+        handoff_floor: i32,
+    ) -> Option<Frame> {
+        let loaded = Self::loaded_frame(&requests);
+        if let Some(frame) = loaded {
+            self.prune_replacement_generation(handoff_floor.min(frame.as_i32()));
+        }
+        self.handle_requests(requests);
+        loaded
+    }
+
+    fn handle_requests(&mut self, requests: RequestVec<I::SessionConfig>) {
         for request in requests {
             match request {
-                FortressRequest::LoadGameState { cell, frame } => {
+                FortressRequest::LoadGameState { cell, .. } => {
                     self.load(&cell);
-                    loaded_frame = Some(frame);
                 },
                 FortressRequest::SaveGameState { cell, frame } => self.save(&cell, frame),
                 FortressRequest::AdvanceFrame { inputs } => self.advance(&inputs),
             }
         }
-        loaded_frame
     }
 
     fn save(&self, cell: &GameStateCell<StateStub>, frame: Frame) {
@@ -1415,16 +1432,20 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                         }
                         match slot.session.advance_frame() {
                             Ok(requests) => {
-                                let loaded = slot.game.handle_requests(requests);
                                 if let Some(handoff_floor) = slot.pending_replacement_handoff_floor
                                 {
-                                    if let Some(frame) = loaded {
+                                    if let Some(frame) =
+                                        slot.game.handle_replacement_handoff_requests(
+                                            requests,
+                                            handoff_floor,
+                                        )
+                                    {
                                         let snapshot_frame = frame.as_i32();
-                                        let state_boundary = handoff_floor.min(snapshot_frame);
-                                        slot.game.prune_replacement_generation(state_boundary);
                                         slot.sampled_confirmed = snapshot_frame;
                                         slot.pending_replacement_handoff_floor = None;
                                     }
+                                } else {
+                                    slot.game.handle_requests(requests);
                                 }
                             },
                             Err(error) => oracle.observe_advance_error(i, step, &error),
@@ -1640,6 +1661,69 @@ mod tests {
     fn sim_input_widths_match_codec() {
         assert_input_width(input_for::<StubInput>(7, 1));
         assert_input_width(input_for::<WideStubInput>(7, 1));
+    }
+
+    #[test]
+    fn replacement_generation_prunes_before_loading_snapshot_requests() {
+        let mut game = SimGameStub::<StubInput>::new();
+        game.recorded.insert(
+            4,
+            StateStub {
+                frame: 4,
+                state: 40,
+            },
+        );
+        game.recorded.insert(
+            6,
+            StateStub {
+                frame: 6,
+                state: 60,
+            },
+        );
+        game.applied_inputs.insert(5, Vec::new());
+
+        let cell = GameStateCell::<StateStub>::default();
+        cell.save(
+            Frame::new(5),
+            Some(StateStub {
+                frame: 5,
+                state: 10,
+            }),
+            Some(0),
+        );
+        let mut inputs = InputVec::<StubInput>::new();
+        inputs.push((StubInput { inp: 1 }, InputStatus::Confirmed));
+        let mut requests = RequestVec::<StubConfig>::new();
+        requests.push(FortressRequest::LoadGameState {
+            cell,
+            frame: Frame::new(5),
+        });
+        requests.push(FortressRequest::AdvanceFrame { inputs });
+
+        let loaded = game.handle_replacement_handoff_requests(requests, 5);
+
+        assert_eq!(loaded, Some(Frame::new(5)));
+        assert_eq!(
+            game.recorded.get(&4),
+            Some(&StateStub {
+                frame: 4,
+                state: 40
+            }),
+            "pre-handoff state must remain available for oracle comparison"
+        );
+        assert_eq!(
+            game.recorded.get(&6),
+            Some(&StateStub { frame: 6, state: 9 }),
+            "same-tick replacement advance must survive handoff pruning"
+        );
+        assert_eq!(
+            game.applied_inputs.get(&5),
+            Some(&vec![(
+                StubInput { inp: 1 }.fingerprint(),
+                InputStatus::Confirmed
+            )]),
+            "same-tick replacement inputs must replace old-generation data"
+        );
     }
 
     #[test]

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -573,6 +573,15 @@ fn start_hot_join_for_slot<I: SimInput>(slot: usize, step: u32, ctx: &mut HotJoi
     }
 
     let Some(host) = hot_join_host_for_slot(ctx.schedule.config.n_players, slot) else {
+        ctx.oracle.observe_runner_error(
+            "hot_join_host_unavailable",
+            slot,
+            step,
+            format!(
+                "no deterministic coordinator exists for slot {slot} in a {}-peer mesh",
+                ctx.schedule.config.n_players
+            ),
+        );
         return;
     };
     if ctx.dead[host] {
@@ -1355,11 +1364,13 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                 },
                 #[cfg(feature = "hot-join")]
                 ScheduleEvent::HotJoin { slot } => {
-                    // Returning clean-drop path: one survivor gracefully removes
-                    // the slot, then a fresh session re-attaches at the same
-                    // address and runs the public hot-join protocol. The slot is
-                    // not marked dead: it remains part of the live oracle set
-                    // and must end Running/confirming after reactivation.
+                    // Returning clean-drop path: build the replacement first so
+                    // constructor failures leave the old slot intact; then one
+                    // survivor removes the old slot, the runner resets the old
+                    // inbox, and the replacement runs the public hot-join
+                    // protocol. The slot is not marked dead: it remains part
+                    // of the live oracle set and must end Running/confirming
+                    // after reactivation.
                     let mut ctx = HotJoinRuntime {
                         schedule,
                         clock: &clock,
@@ -1649,6 +1660,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "hot-join")]
     use crate::simulation::harness::oracle::OracleFailure;
     use fortress_rollback::network::codec;
 

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -640,6 +640,10 @@ fn start_hot_join_for_slot<I: SimInput>(slot: usize, step: u32, ctx: &mut HotJoi
         .confirmed_frame()
         .as_i32()
         .saturating_sub(i32::try_from(ctx.schedule.config.max_prediction).unwrap_or(i32::MAX));
+    // `handoff_floor` is a post-advance state-frame boundary. Canonical
+    // confirmed-input samples are keyed by the input frame that produces the
+    // next state frame, so input frame `handoff_floor - 1` is the first sample
+    // that can affect replacement-generation state at `handoff_floor`.
     let input_handoff_floor = handoff_floor.saturating_sub(1);
     ctx.oracle
         .begin_replacement_generation(slot, input_handoff_floor);
@@ -1015,7 +1019,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                     "HotJoin slot {slot} is already retired by an earlier kill event"
                 );
                 let Some(host) = hot_join_host_for_slot(n, *slot) else {
-                    unreachable!("n >= 2 and slot in range guarantee a hot-join host")
+                    panic!("HotJoin requires at least two players; got n_players={n}, slot={slot}");
                 };
                 assert!(
                     !retired_by_guaranteed_kill[host],

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -375,14 +375,24 @@ impl<I: SimInput> SimGameStub<I> {
         }
     }
 
-    fn handle_requests(&mut self, requests: RequestVec<I::SessionConfig>) {
+    fn prune_replacement_generation(&mut self, from_frame: i32) {
+        self.recorded.retain(|frame, _| *frame < from_frame);
+        self.applied_inputs.retain(|frame, _| *frame < from_frame);
+    }
+
+    fn handle_requests(&mut self, requests: RequestVec<I::SessionConfig>) -> Option<Frame> {
+        let mut loaded_frame = None;
         for request in requests {
             match request {
-                FortressRequest::LoadGameState { cell, .. } => self.load(&cell),
+                FortressRequest::LoadGameState { cell, frame } => {
+                    self.load(&cell);
+                    loaded_frame = Some(frame);
+                },
                 FortressRequest::SaveGameState { cell, frame } => self.save(&cell, frame),
                 FortressRequest::AdvanceFrame { inputs } => self.advance(&inputs),
             }
         }
+        loaded_frame
     }
 
     fn save(&self, cell: &GameStateCell<StateStub>, frame: Frame) {
@@ -435,12 +445,51 @@ struct PeerSlot<I: SimInput> {
     observer: Arc<CollectingObserver>,
     /// Highest frame whose confirmed inputs were sampled into the oracle.
     sampled_confirmed: i32,
+    /// A hot-joined replacement starts from a mid-game snapshot and cannot
+    /// answer historical `confirmed_inputs_for_frame` queries below that
+    /// snapshot. While armed, this stores the earliest frame the coordinator's
+    /// clean-drop handoff may rewrite; the drive loop waits for the
+    /// replacement's first `LoadGameState { frame }`, prunes the replacement
+    /// generation from the earlier of those two boundaries, then resumes
+    /// confirmed-input sampling above the loaded snapshot frame.
+    pending_replacement_handoff_floor: Option<i32>,
 }
 
 struct SpectatorSlot<I: SimInput> {
     session: SpectatorSession<I::SessionConfig>,
     observer: Arc<CollectingObserver>,
     applied_inputs: BTreeMap<i32, Vec<(InputFingerprint, InputStatus)>>,
+}
+
+fn peer_protocol_config(schedule: &Schedule, peer: usize, clock: &TestClock) -> ProtocolConfig {
+    // Per-peer clock: the exact base clock at 0 ppm (byte-identical to
+    // before), or a rate-skewed clock modeling an unsynchronized local clock
+    // (H-SKEW). A missing/short skew vector means "no skew".
+    let ppm = schedule
+        .config
+        .clock_skew_ppm
+        .get(peer)
+        .copied()
+        .unwrap_or(0);
+    let peer_clock = if ppm == 0 {
+        clock.as_protocol_clock()
+    } else {
+        // ratio (1e6 + ppm) / 1e6. `ppm == -1_000_000` (-100%) is a
+        // frozen clock (num = 0); anything below that would run time
+        // backwards and is rejected up front, so the fallback is unused.
+        let num = u64::try_from(1_000_000_i64 + i64::from(ppm)).unwrap_or(0);
+        clock.as_skewed_protocol_clock(num, 1_000_000)
+    };
+
+    ProtocolConfig {
+        clock: Some(peer_clock),
+        protocol_rng_seed: Some(fnv1a_hash(&(schedule.seed, peer))),
+        ..ProtocolConfig::default()
+    }
+}
+
+fn hot_join_host_for_slot(n_players: usize, slot: usize) -> Option<usize> {
+    (0..n_players).find(|&peer| peer != slot)
 }
 
 fn update_spectator_required_min_frame<I: SimInput>(
@@ -480,6 +529,104 @@ fn retire_peer_for_lifecycle<I: SimInput>(
     oracle.mark_peer_dead(peer);
     if let Some(required_min_frame) = spectator_required_min_frame {
         update_spectator_required_min_frame(peers, dead, required_min_frame);
+    }
+}
+
+#[cfg(feature = "hot-join")]
+struct HotJoinRuntime<'a, I: SimInput> {
+    schedule: &'a Schedule,
+    clock: &'a TestClock,
+    net: &'a SimNet<Message>,
+    addrs: &'a [SocketAddr],
+    peers: &'a mut [PeerSlot<I>],
+    dead: &'a [bool],
+    oracle: &'a mut Oracle,
+}
+
+#[cfg(feature = "hot-join")]
+fn start_hot_join_for_slot<I: SimInput>(slot: usize, step: u32, ctx: &mut HotJoinRuntime<'_, I>) {
+    if ctx.dead[slot] {
+        ctx.oracle.observe_runner_error(
+            "hot_join_slot_unavailable",
+            slot,
+            step,
+            "slot is already retired",
+        );
+        return;
+    }
+
+    let Some(host) = hot_join_host_for_slot(ctx.schedule.config.n_players, slot) else {
+        return;
+    };
+    if ctx.dead[host] {
+        ctx.oracle.observe_runner_error(
+            "hot_join_host_unavailable",
+            host,
+            step,
+            "deterministic coordinator is already retired",
+        );
+        return;
+    }
+
+    let handle = PlayerHandle::new(slot);
+    if let Err(error) = ctx.peers[host].session.remove_player(handle) {
+        ctx.oracle
+            .observe_session_error("hot_join_remove_player", host, step, &error);
+        return;
+    }
+
+    let handoff_floor = ctx.peers[host]
+        .session
+        .confirmed_frame()
+        .as_i32()
+        .saturating_sub(i32::try_from(ctx.schedule.config.max_prediction).unwrap_or(i32::MAX));
+    let input_handoff_floor = handoff_floor.saturating_sub(1);
+    ctx.oracle
+        .begin_replacement_generation(slot, input_handoff_floor);
+    ctx.net.detach(ctx.addrs[slot]);
+    let socket: SimSocket<Message> = ctx.net.attach(ctx.addrs[slot]);
+    let observer = Arc::clone(&ctx.peers[slot].observer);
+    let protocol_config = peer_protocol_config(ctx.schedule, slot, ctx.clock);
+    let mut builder = SessionBuilder::<I::SessionConfig>::new()
+        .with_num_players(ctx.schedule.config.n_players)
+        .expect("valid player count")
+        .with_max_prediction_window(ctx.schedule.config.max_prediction)
+        .with_input_delay(0)
+        .expect("hot-join input delay is fixed at zero")
+        .with_desync_detection_mode(DesyncDetection::On {
+            interval: ctx.schedule.config.desync_interval,
+        })
+        .with_disconnect_behavior(ctx.schedule.config.disconnect_behavior.into())
+        .with_protocol_config(protocol_config)
+        .with_violation_observer(observer as Arc<_>);
+    if let Some(size) = ctx.schedule.config.event_queue_size {
+        builder = builder.with_event_queue_size(size).unwrap_or_else(|error| {
+            panic!(
+                "hot-join with_event_queue_size({size}) rejected a pre-validated \
+                 size: {error:?}"
+            )
+        });
+    }
+    for (peer, addr) in ctx.addrs.iter().enumerate() {
+        let player_type = if peer == slot {
+            PlayerType::Local
+        } else {
+            PlayerType::Remote(*addr)
+        };
+        builder = builder
+            .add_player(player_type, PlayerHandle::new(peer))
+            .expect("valid hot-join player registration");
+    }
+
+    match builder.start_hot_join_session(socket, ctx.addrs[host]) {
+        Ok(session) => {
+            ctx.peers[slot].session = session;
+            ctx.peers[slot].pending_replacement_handoff_floor = Some(handoff_floor);
+        },
+        Err(error) => {
+            ctx.oracle
+                .observe_session_error("start_hot_join_session", slot, step, &error);
+        },
     }
 }
 
@@ -679,6 +826,27 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
             );
         }
     }
+    let has_hot_join = schedule
+        .events
+        .iter()
+        .any(|(_, event)| matches!(event, ScheduleEvent::HotJoin { .. }));
+    #[cfg(not(feature = "hot-join"))]
+    assert!(
+        !has_hot_join,
+        "ScheduleEvent::HotJoin requires the crate's `hot-join` feature"
+    );
+    if has_hot_join {
+        assert!(
+            schedule.config.input_delay == 0,
+            "HotJoin schedules must use input_delay 0 (got {})",
+            schedule.config.input_delay
+        );
+        assert!(
+            schedule.config.max_prediction >= 1,
+            "HotJoin schedules must use max_prediction >= 1 (got {})",
+            schedule.config.max_prediction
+        );
+    }
     let expected_links = n * (n - 1);
     assert_eq!(
         schedule.initial_links.len(),
@@ -751,6 +919,10 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                 *host < n,
                 "SpectatorHostKill host {host} out of range for a {n}-peer mesh"
             ),
+            ScheduleEvent::HotJoin { slot } => assert!(
+                *slot < n,
+                "HotJoin slot {slot} out of range for a {n}-peer mesh"
+            ),
             ScheduleEvent::HealAll => {},
         }
     }
@@ -786,6 +958,16 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
         );
         spectator_host_enabled[peer] = true;
     }
+    let mut hot_join_host_enabled = vec![false; n];
+    for (_, event) in &schedule.events {
+        if let ScheduleEvent::HotJoin { slot } = event {
+            if let Some(host) = hot_join_host_for_slot(n, *slot) {
+                hot_join_host_enabled[host] = true;
+            }
+        }
+    }
+    #[cfg(not(feature = "hot-join"))]
+    let _ = &hot_join_host_enabled;
     // Only guaranteed harness kills can make a SpectatorHostKill malformed up
     // front. User API drops retire only after the runtime call returns `Ok`.
     let mut retired_by_guaranteed_kill = vec![false; n];
@@ -805,6 +987,20 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                     "SpectatorHostKill host {host} is already retired by an earlier kill event"
                 );
                 retired_by_guaranteed_kill[*host] = true;
+            },
+            ScheduleEvent::HotJoin { slot } => {
+                assert!(
+                    !retired_by_guaranteed_kill[*slot],
+                    "HotJoin slot {slot} is already retired by an earlier kill event"
+                );
+                let Some(host) = hot_join_host_for_slot(n, *slot) else {
+                    unreachable!("n >= 2 and slot in range guarantee a hot-join host")
+                };
+                assert!(
+                    !retired_by_guaranteed_kill[host],
+                    "HotJoin slot {slot}'s coordinator peer {host} is already retired by an \
+                     earlier kill event"
+                );
             },
             ScheduleEvent::SetLink { .. }
             | ScheduleEvent::Block { .. }
@@ -842,24 +1038,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
         .map(|i| {
             let socket: SimSocket<Message> = net.attach(addrs[i]);
             let observer = Arc::new(CollectingObserver::new());
-            // Per-peer clock: the exact base clock at 0 ppm (byte-identical to
-            // before), or a rate-skewed clock modeling an unsynchronized local
-            // clock (H-SKEW). A missing/short skew vector means "no skew".
-            let ppm = schedule.config.clock_skew_ppm.get(i).copied().unwrap_or(0);
-            let peer_clock = if ppm == 0 {
-                clock.as_protocol_clock()
-            } else {
-                // ratio (1e6 + ppm) / 1e6. `ppm == -1_000_000` (-100%) is a
-                // frozen clock (num = 0); anything below that would run time
-                // backwards and is rejected up front, so the fallback is unused.
-                let num = u64::try_from(1_000_000_i64 + i64::from(ppm)).unwrap_or(0);
-                clock.as_skewed_protocol_clock(num, 1_000_000)
-            };
-            let protocol_config = ProtocolConfig {
-                clock: Some(peer_clock),
-                protocol_rng_seed: Some(fnv1a_hash(&(schedule.seed, i))),
-                ..ProtocolConfig::default()
-            };
+            let protocol_config = peer_protocol_config(schedule, i, &clock);
             let mut builder = SessionBuilder::<I::SessionConfig>::new()
                 .with_num_players(n)
                 .expect("valid player count")
@@ -872,6 +1051,10 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                 .with_disconnect_behavior(schedule.config.disconnect_behavior.into())
                 .with_protocol_config(protocol_config)
                 .with_violation_observer(Arc::clone(&observer) as Arc<_>);
+            #[cfg(feature = "hot-join")]
+            if hot_join_host_enabled[i] {
+                builder = builder.with_hot_join(true);
+            }
             if let Some(size) = schedule.config.event_queue_size {
                 // Validated `>= 10` up front, so the current min-cap check
                 // cannot reject it; surface the real error (not a fixed string)
@@ -913,6 +1096,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                 game,
                 observer,
                 sampled_confirmed: -1,
+                pending_replacement_handoff_floor: None,
             }
         })
         .collect();
@@ -1144,6 +1328,28 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                         spectator_enabled.then_some(&mut spectator_required_min_frame),
                     );
                 },
+                #[cfg(feature = "hot-join")]
+                ScheduleEvent::HotJoin { slot } => {
+                    // Returning clean-drop path: one survivor gracefully removes
+                    // the slot, then a fresh session re-attaches at the same
+                    // address and runs the public hot-join protocol. The slot is
+                    // not marked dead: it remains part of the live oracle set
+                    // and must end Running/confirming after reactivation.
+                    let mut ctx = HotJoinRuntime {
+                        schedule,
+                        clock: &clock,
+                        net: &net,
+                        addrs: &addrs,
+                        peers: &mut peers,
+                        dead: &dead,
+                        oracle: &mut oracle,
+                    };
+                    start_hot_join_for_slot(*slot, step, &mut ctx);
+                },
+                #[cfg(not(feature = "hot-join"))]
+                ScheduleEvent::HotJoin { .. } => {
+                    unreachable!("HotJoin schedules are rejected before sessions are built")
+                },
                 ScheduleEvent::HealAll => net.heal_all(),
             }
             next_event += 1;
@@ -1208,7 +1414,19 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                             }
                         }
                         match slot.session.advance_frame() {
-                            Ok(requests) => slot.game.handle_requests(requests),
+                            Ok(requests) => {
+                                let loaded = slot.game.handle_requests(requests);
+                                if let Some(handoff_floor) = slot.pending_replacement_handoff_floor
+                                {
+                                    if let Some(frame) = loaded {
+                                        let snapshot_frame = frame.as_i32();
+                                        let state_boundary = handoff_floor.min(snapshot_frame);
+                                        slot.game.prune_replacement_generation(state_boundary);
+                                        slot.sampled_confirmed = snapshot_frame;
+                                        slot.pending_replacement_handoff_floor = None;
+                                    }
+                                }
+                            },
                             Err(error) => oracle.observe_advance_error(i, step, &error),
                         }
                     }
@@ -1216,7 +1434,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
 
                 // Incrementally sample newly confirmed inputs (they evict).
                 let confirmed = slot.session.confirmed_frame();
-                if confirmed.is_valid() {
+                if confirmed.is_valid() && slot.pending_replacement_handoff_floor.is_none() {
                     for frame in (slot.sampled_confirmed + 1)..=confirmed.as_i32() {
                         match slot.session.confirmed_inputs_for_frame(Frame::new(frame)) {
                             Ok(inputs) => {

--- a/tests/simulation/harness/oracle.rs
+++ b/tests/simulation/harness/oracle.rs
@@ -519,6 +519,23 @@ impl Oracle {
         self.dead[peer] = true;
     }
 
+    /// Starts a new live generation for `peer` without marking it dead. A
+    /// hot-join replacement is a different session at the same player slot; the
+    /// old session may have been the first author for trailing confirmed-input
+    /// samples that the serving host intentionally freezes differently when it
+    /// removes the slot. Those trailing old input-frame samples must not become
+    /// canonical for the replacement generation, while older settled samples
+    /// keep their oracle coverage.
+    pub fn begin_replacement_generation(&mut self, peer: usize, input_from_frame: i32) {
+        assert!(
+            peer < self.dead.len(),
+            "begin_replacement_generation: peer {peer} out of range (dead-mask len {})",
+            self.dead.len()
+        );
+        self.canonical_inputs
+            .retain(|frame, (first_author, _)| *first_author != peer || *frame < input_from_frame);
+    }
+
     /// Whether `peer` was retired mid-run.
     fn is_dead(&self, peer: usize) -> bool {
         self.dead.get(peer).copied().unwrap_or(false)
@@ -600,11 +617,23 @@ impl Oracle {
         step: u32,
         error: &fortress_rollback::FortressError,
     ) {
+        self.observe_runner_error(operation, peer, step, format!("{error:?}"));
+    }
+
+    /// (g): the harness detected an invalid lifecycle transition that is not a
+    /// direct library API error.
+    pub fn observe_runner_error(
+        &mut self,
+        operation: &'static str,
+        peer: usize,
+        step: u32,
+        error: impl Into<String>,
+    ) {
         self.push_failure(OracleFailure::SessionError {
             operation,
             peer,
             step,
-            error: format!("{error:?}"),
+            error: error.into(),
         });
     }
 

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -311,10 +311,11 @@ pub enum ScheduleEvent {
     /// Planted by lifecycle tests, not yet emitted by the random generator.
     SpectatorHostKill { host: usize },
     /// Reactivate player slot `slot` through the public hot-join path. The
-    /// runner first has a live survivor gracefully remove the slot, detaches the
-    /// old peer from the fabric, and then starts a fresh hot-joiner at that same
-    /// address with `slot` as its local player. That exercises the returning
-    /// clean-drop path without permanently retiring the slot from the oracle.
+    /// runner first constructs a fresh hot-joiner for that slot; once that
+    /// succeeds, a live survivor gracefully removes the old slot, the fabric
+    /// inbox at the old address is reset, and the fresh session takes over that
+    /// address. That exercises the returning clean-drop path without permanently
+    /// retiring the slot from the oracle.
     ///
     /// Requires the crate's `hot-join` feature at runtime. Hot-join schedules
     /// must use input delay 0 and `max_prediction >= 1`, matching

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -80,7 +80,9 @@ pub enum AppModel {
 ///   user-driven disconnect entry point (`P2PSession::disconnect_player`).
 /// - `7`: adds [`ScheduleEvent::SpectatorHostKill`], a spectator-focused host
 ///   crash/failover probe.
-pub const SCHEDULE_SCHEMA_VERSION: u32 = 7;
+/// - `8`: adds [`ScheduleEvent::HotJoin`], a returning-peer reactivation probe
+///   driven through the public hot-join API.
+pub const SCHEDULE_SCHEMA_VERSION: u32 = 8;
 
 /// Background link-noise level applied to every directed link at start.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -308,6 +310,17 @@ pub enum ScheduleEvent {
     ///
     /// Planted by lifecycle tests, not yet emitted by the random generator.
     SpectatorHostKill { host: usize },
+    /// Reactivate player slot `slot` through the public hot-join path. The
+    /// runner first has a live survivor gracefully remove the slot, detaches the
+    /// old peer from the fabric, and then starts a fresh hot-joiner at that same
+    /// address with `slot` as its local player. That exercises the returning
+    /// clean-drop path without permanently retiring the slot from the oracle.
+    ///
+    /// Requires the crate's `hot-join` feature at runtime. Hot-join schedules
+    /// must use input delay 0 and `max_prediction >= 1`, matching
+    /// `SessionBuilder::start_hot_join_session`'s public contract. Planted by
+    /// lifecycle tests, not yet emitted by the random generator.
+    HotJoin { slot: usize },
     /// Reset every link to clean and release all held traffic.
     HealAll,
 }
@@ -679,6 +692,9 @@ mod tests {
         schedule
             .events
             .push((325, ScheduleEvent::SpectatorHostKill { host: 0 }));
+        schedule
+            .events
+            .push((350, ScheduleEvent::HotJoin { slot: 1 }));
         schedule.events.sort_by_key(|(step, _)| *step);
         let json = serde_json::to_string(&schedule).unwrap();
         let back: Schedule = serde_json::from_str(&json).unwrap();
@@ -710,6 +726,10 @@ mod tests {
             .events
             .iter()
             .any(|(_, ev)| matches!(ev, ScheduleEvent::SpectatorHostKill { host: 0 })));
+        assert!(back
+            .events
+            .iter()
+            .any(|(_, ev)| matches!(ev, ScheduleEvent::HotJoin { slot: 1 })));
     }
 
     /// A corpus artifact predating the `#[serde(default)]` config axes (its


### PR DESCRIPTION
## Summary

Adds the M3 `ScheduleEvent::HotJoin { slot }` lifecycle operation to the deterministic simulation harness.

- Bumps the simulation schedule schema to v8 and round-trips `HotJoin` events.
- Wires hot-join schedules through the public `start_hot_join_session` path with a deterministic coordinator, fresh `SimSocket`, and explicit feature/config validation.
- Models hot-joined slots as replacement generations instead of permanent dead-mask entries.
- Adds regressions proving the clean-drop returning-slot path, fail-loud behavior after prior runtime retirement, and settled pre-handoff oracle coverage.

## Validation

- `cargo fmt`
- `cargo nextest run --features hot-join --no-capture hot_join_reactivates_cleanly_dropped_slot > /tmp/hotjoin-sim.txt 2>&1`
- `cargo nextest run --features hot-join --no-capture simulation::fleet > /tmp/hotjoin-fleet.txt 2>&1` (54 passed)
- `cargo test --test simulation --no-run > /tmp/simulation-no-run.txt 2>&1`
- `cargo clippy --workspace --all-targets --features tokio,json,hot-join > /tmp/clippy-hotjoin.txt 2>&1`
- `python3 scripts/ci/agent-preflight.py --auto-fix > /tmp/agent-preflight.txt 2>&1`

## Notes

`PLAN.md` and `progress/session-83-m3-hotjoin-lifecycle-op.md` are updated locally, but both paths are ignored by this repository's `.gitignore`, so they are not included in the PR diff.

Residuals recorded locally: slot-0 fixed-order and N-peer hot-join DST coverage remain future census/random-generator work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle orchestration and oracle canonical-input semantics for hot-join; impact is mostly confined to simulation tests behind the `hot-join` feature, but mistakes could mask real determinism or handoff bugs.
> 
> **Overview**
> Introduces **`ScheduleEvent::HotJoin`** (schedule schema **v8**) and runs it through the simulation harness via **`start_hot_join_session`**, with **`with_hot_join(true)`** on coordinator peers and static validation (feature flag, `input_delay == 0`, `max_prediction >= 1`).
> 
> Hot-join is modeled as a **replacement generation** at the same slot—not a permanent dead-peer mask: the oracle gains **`begin_replacement_generation`** to drop trailing handoff-window confirmed-input authorship, the game stub prunes state on snapshot load, and the drive loop defers confirmed-input sampling until the replacement **`LoadGameState`** completes. Runtime errors surface as **`hot_join_slot_unavailable`** (e.g. after **`GracefulRemove`**).
> 
> Fleet tests cover clean-slot reactivation, fail-loud behavior on an already-retired slot, and that pre-handoff **`StateDivergence`** is still detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d92c93d43164648341a058d5445c63f18e183d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->