### PR TITLE
Advance M3 simulation census coverage

### DIFF
--- a/tests/common/sim_net.rs
+++ b/tests/common/sim_net.rs
@@ -59,6 +59,11 @@ pub const MAX_RECEIVE_MESSAGES_PER_POLL: usize = 256;
 ///
 /// All probabilities are in `0.0..=1.0` and are rolled per send, in a fixed
 /// order (burst, drop, duplicate, jitter), from the net-wide seeded RNG.
+/// When [`Self::retransmit_delay`] is nonzero, a burst/drop roll models a
+/// reliable transport retransmission instead of packet loss: the would-be
+/// dropped send is delayed, and subsequent sends on the same link are held
+/// behind that retransmission deadline (TCP/WebRTC-reliable head-of-line
+/// blocking).
 /// Serializable so simulation schedules (which embed link policies) can be
 /// stored as reproducible corpus artifacts.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -77,6 +82,10 @@ pub struct LinkPolicy {
     pub burst_rate: f64,
     /// Total sends dropped per burst, including the send that triggered it.
     pub burst_len: u32,
+    /// Reliable retransmission delay for would-be drops. `Duration::ZERO`
+    /// keeps UDP-like unreliable loss semantics.
+    #[serde(default)]
+    pub retransmit_delay: Duration,
 }
 
 impl LinkPolicy {
@@ -90,6 +99,7 @@ impl LinkPolicy {
             jitter: Duration::ZERO,
             burst_rate: 0.0,
             burst_len: 0,
+            retransmit_delay: Duration::ZERO,
         }
     }
 }
@@ -122,6 +132,8 @@ pub struct SimNetStats {
     pub delivered: u64,
     /// Copies dropped by drop-rate or burst rolls.
     pub dropped_by_policy: u64,
+    /// Would-be policy drops converted into reliable retransmission delays.
+    pub retransmit_delayed: u64,
     /// Copies dropped because the link was blocked.
     pub dropped_blocked: u64,
     /// Copies dropped on delivery because no socket was attached
@@ -139,6 +151,8 @@ struct LinkState {
     policy: LinkPolicy,
     /// Remaining sends to drop in the current loss burst.
     burst_remaining: u32,
+    /// Reliable transport head-of-line block deadline for this link.
+    retransmit_blocked_until: Option<Instant>,
     /// Black-hole: every send is dropped.
     blocked: bool,
     /// Capture-and-hold: sends bypass fault rolls and queue until release.
@@ -150,6 +164,7 @@ impl LinkState {
         Self {
             policy,
             burst_remaining: 0,
+            retransmit_blocked_until: None,
             blocked: false,
             holding: false,
         }
@@ -246,6 +261,29 @@ impl<M: Clone> SimNetState<M> {
         }));
     }
 
+    /// Returns `true` when a policy loss was converted into a reliable
+    /// retransmission and the payload should still be scheduled.
+    fn handle_policy_loss(
+        &mut self,
+        key: (SocketAddr, SocketAddr),
+        retransmit_delay: Duration,
+    ) -> bool {
+        if retransmit_delay.is_zero() {
+            self.stats.dropped_by_policy += 1;
+            return false;
+        }
+
+        self.stats.retransmit_delayed += 1;
+        let deadline = self.now() + retransmit_delay;
+        if let Some(link) = self.links.get_mut(&key) {
+            link.retransmit_blocked_until = Some(
+                link.retransmit_blocked_until
+                    .map_or(deadline, |existing| existing.max(deadline)),
+            );
+        }
+        true
+    }
+
     fn send(&mut self, from: SocketAddr, to: SocketAddr, payload: M) {
         self.stats.sent += 1;
         let key = (from, to);
@@ -270,6 +308,11 @@ impl<M: Clone> SimNetState<M> {
             return;
         }
 
+        let policy = self
+            .links
+            .get(&key)
+            .map_or_else(LinkPolicy::clean, |link| link.policy.clone());
+
         // Burst state machine (mirrors the ChaosSocket semantics: the
         // triggering send and the following `burst_len - 1` sends drop).
         let in_burst = self
@@ -280,35 +323,29 @@ impl<M: Clone> SimNetState<M> {
             if let Some(link) = self.links.get_mut(&key) {
                 link.burst_remaining -= 1;
             }
-            self.stats.dropped_by_policy += 1;
-            return;
-        }
-        let (burst_rate, burst_len, drop_rate, dup_rate, base_delay, jitter) =
-            match self.links.get(&key) {
-                Some(link) => (
-                    link.policy.burst_rate,
-                    link.policy.burst_len,
-                    link.policy.drop_rate,
-                    link.policy.dup_rate,
-                    link.policy.base_delay,
-                    link.policy.jitter,
-                ),
-                None => (0.0, 0, 0.0, 0.0, Duration::ZERO, Duration::ZERO),
-            };
-
-        if burst_rate > 0.0 && self.roll_unit() < burst_rate {
-            if let Some(link) = self.links.get_mut(&key) {
-                link.burst_remaining = burst_len.saturating_sub(1);
+            if !self.handle_policy_loss(key, policy.retransmit_delay) {
+                return;
             }
-            self.stats.dropped_by_policy += 1;
-            return;
-        }
-        if drop_rate > 0.0 && self.roll_unit() < drop_rate {
-            self.stats.dropped_by_policy += 1;
-            return;
         }
 
-        let copies = if dup_rate > 0.0 && self.roll_unit() < dup_rate {
+        let burst_roll_hit =
+            !in_burst && policy.burst_rate > 0.0 && self.roll_unit() < policy.burst_rate;
+        if burst_roll_hit {
+            if let Some(link) = self.links.get_mut(&key) {
+                link.burst_remaining = policy.burst_len.saturating_sub(1);
+            }
+            if !self.handle_policy_loss(key, policy.retransmit_delay) {
+                return;
+            }
+        } else {
+            let drop_roll_hit =
+                !in_burst && policy.drop_rate > 0.0 && self.roll_unit() < policy.drop_rate;
+            if drop_roll_hit && !self.handle_policy_loss(key, policy.retransmit_delay) {
+                return;
+            }
+        }
+
+        let copies = if policy.dup_rate > 0.0 && self.roll_unit() < policy.dup_rate {
             self.stats.duplicated += 1;
             2
         } else {
@@ -316,9 +353,17 @@ impl<M: Clone> SimNetState<M> {
         };
 
         let now = self.now();
+        let blocked_until = self
+            .links
+            .get(&key)
+            .and_then(|link| link.retransmit_blocked_until);
         for _ in 0..copies {
-            let delay = base_delay + self.roll_jitter(jitter);
-            self.schedule(from, to, payload.clone(), now + delay);
+            let delay = policy.base_delay + self.roll_jitter(policy.jitter);
+            let mut deliver_at = now + delay;
+            if let Some(deadline) = blocked_until {
+                deliver_at = deliver_at.max(deadline);
+            }
+            self.schedule(from, to, payload.clone(), deliver_at);
         }
     }
 
@@ -444,8 +489,8 @@ impl<M: Clone> SimNet<M> {
     }
 
     /// Sets (or replaces) the fault policy for the directed link `from → to`,
-    /// preserving its blocked/holding toggles and resetting any burst in
-    /// progress.
+    /// preserving its blocked/holding toggles and any current retransmission
+    /// head-of-line deadline, and resetting any burst in progress.
     pub fn set_link(&self, from: SocketAddr, to: SocketAddr, policy: LinkPolicy) {
         let mut state = self.lock();
         let link = state.links.entry((from, to)).or_default();
@@ -503,6 +548,7 @@ impl<M: Clone> SimNet<M> {
             if let Some(link) = state.links.get_mut(&key) {
                 link.policy = LinkPolicy::clean();
                 link.burst_remaining = 0;
+                link.retransmit_blocked_until = None;
                 link.blocked = false;
                 link.holding = false;
             }
@@ -620,6 +666,7 @@ mod tests {
             jitter: Duration::from_millis(25),
             burst_rate: 0.02,
             burst_len: 4,
+            retransmit_delay: Duration::ZERO,
         };
         let first = run_trace(42, policy.clone());
         let second = run_trace(42, policy.clone());
@@ -720,6 +767,55 @@ mod tests {
 
         offset.fetch_add(1, AtomicOrdering::Relaxed);
         assert_eq!(b.recv_payloads().len(), 1, "due exactly at base_delay");
+    }
+
+    #[test]
+    fn retransmit_delay_delivers_would_drop_and_holds_later_sends() {
+        let (clock, offset) = manual_clock();
+        let net: SimNet<u32> = SimNet::new(7, clock);
+        let a = net.attach(addr(1));
+        let b = net.attach(addr(2));
+
+        let reliable_loss = LinkPolicy {
+            drop_rate: 1.0,
+            retransmit_delay: Duration::from_millis(100),
+            ..LinkPolicy::clean()
+        };
+        let reliable_clean = LinkPolicy {
+            drop_rate: 0.0,
+            retransmit_delay: Duration::from_millis(100),
+            ..LinkPolicy::clean()
+        };
+
+        net.set_link(addr(1), addr(2), reliable_loss);
+        a.send_payload(addr(2), 1);
+        assert!(
+            b.recv_payloads().is_empty(),
+            "would-drop payload is retransmission-delayed, not delivered immediately"
+        );
+
+        net.set_link(addr(1), addr(2), reliable_clean);
+        offset.fetch_add(10, AtomicOrdering::Relaxed);
+        a.send_payload(addr(2), 2);
+        offset.fetch_add(89, AtomicOrdering::Relaxed);
+        assert!(
+            b.recv_payloads().is_empty(),
+            "later clean sends stay behind the retransmission deadline"
+        );
+
+        offset.fetch_add(1, AtomicOrdering::Relaxed);
+        let values: Vec<u32> = b.recv_payloads().into_iter().map(|(_, v)| v).collect();
+        assert_eq!(
+            values,
+            vec![1, 2],
+            "retransmitted and later clean sends deliver FIFO at the HOL deadline"
+        );
+
+        let stats = net.stats();
+        assert_eq!(stats.sent, 2);
+        assert_eq!(stats.retransmit_delayed, 1);
+        assert_eq!(stats.dropped_by_policy, 0);
+        assert_eq!(stats.delivered, 2);
     }
 
     #[test]

--- a/tests/simulation.rs
+++ b/tests/simulation.rs
@@ -25,6 +25,7 @@ mod common;
 // Simulation test modules
 mod simulation {
     pub mod baseline_sweep;
+    pub mod census;
     pub mod fleet;
     pub mod harness;
 }

--- a/tests/simulation/baseline_sweep.rs
+++ b/tests/simulation/baseline_sweep.rs
@@ -59,6 +59,7 @@ impl CellParams {
             jitter: Duration::from_millis(self.jitter_ms),
             burst_rate: 0.0,
             burst_len: 0,
+            retransmit_delay: Duration::ZERO,
         }
     }
 

--- a/tests/simulation/census.rs
+++ b/tests/simulation/census.rs
@@ -1,0 +1,61 @@
+//! Premise-asserted simulation census rows for specific distributed failure modes.
+
+use super::harness::schedule::{
+    BackgroundNoise, Schedule, ScheduleEvent, SimConfig, SCHEDULE_SCHEMA_VERSION,
+};
+use super::harness::{run, RunOptions};
+use crate::common::sim_net::LinkPolicy;
+use std::time::Duration;
+
+fn delayed_two_peer_schedule() -> Schedule {
+    let mut config = SimConfig::smoke(2);
+    config.steps = 520;
+    config.noise = BackgroundNoise::Clean;
+    config.input_delay = 0;
+    config.max_prediction = 2;
+
+    let delayed = LinkPolicy {
+        base_delay: Duration::from_millis(120),
+        ..LinkPolicy::clean()
+    };
+    let initial_links = vec![(0, 1, delayed.clone()), (1, 0, delayed)];
+    let heal_at = 260;
+
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0xCE45_0001,
+        link_seed: 0xCE45_0002,
+        config,
+        initial_links,
+        events: vec![(heal_at, ScheduleEvent::HealAll)],
+        heal_at,
+    }
+}
+
+/// M3 §6.4 census: when RTT is far larger than `max_prediction`, peers should
+/// throttle by returning `Ok(empty)` rather than diverging or surfacing advance
+/// errors. The permanent oracle checks liveness and byte-consistent state; this
+/// row also asserts the stall counter is non-zero so the high-RTT premise fired.
+#[test]
+fn high_rtt_beyond_prediction_window_throttles_without_divergence() {
+    let schedule = delayed_two_peer_schedule();
+
+    let report = run(&schedule, &RunOptions::default());
+    report.expect_pass(&schedule);
+
+    let stalls: u64 = report
+        .metrics
+        .iter()
+        .map(|metrics| metrics.stall_count)
+        .sum();
+    assert!(
+        stalls > 0,
+        "high-RTT census row must exercise prediction-window throttling"
+    );
+
+    let again = run(&schedule, &RunOptions::default());
+    assert_eq!(
+        report.trace_hash, again.trace_hash,
+        "high-RTT census row must reproduce its exact trace"
+    );
+}

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -453,12 +453,12 @@ fn probe_smoke_fleet_sixteen_player_mesh_holds_invariants() {
 }
 
 /// H-TCP-lite transport-model probe (PLAN.md §13 H-TCP): a reliable,
-/// in-order, loss-free link profile (TCP / WebRTC-reliable model) with
-/// head-of-line-blocking stalls approximated by capture-and-FIFO-release
-/// holds. Zero jitter keeps `SimNet`'s per-link FIFO exact, so delivery is
-/// in-order — the TCP contract. Each 25-step hold (≈400ms virtual) models a
-/// retransmit stall far exceeding the 8-frame prediction window, so the
-/// session must stall-and-catch-up, never diverge.
+/// in-order link profile (TCP / WebRTC-reliable model) with
+/// head-of-line-blocking stalls modeled by `LinkPolicy::retransmit_delay`.
+/// Zero jitter keeps `SimNet`'s per-link FIFO exact, so delivery is in-order —
+/// the TCP contract. Each retransmit window delays would-drop sends by 400 ms
+/// (> the 8-frame prediction window), so the session must stall-and-catch-up,
+/// never diverge.
 ///
 /// Expected green: the protocol's correctness must not depend on loss or
 /// reordering being present. A failure here is a real transport-model bug.
@@ -466,6 +466,7 @@ fn run_tcp_model_mesh(n: usize) {
     let config = SimConfig {
         n_players: n,
         steps: 900,
+        noise: BackgroundNoise::ReliableFifo,
         ..SimConfig::smoke(n)
     };
     let fifo = LinkPolicy {
@@ -475,6 +476,12 @@ fn run_tcp_model_mesh(n: usize) {
         jitter: Duration::ZERO,
         burst_rate: 0.0,
         burst_len: 0,
+        retransmit_delay: Duration::ZERO,
+    };
+    let hol = LinkPolicy {
+        drop_rate: 1.0,
+        retransmit_delay: Duration::from_millis(400),
+        ..fifo
     };
     let mut initial_links = Vec::new();
     for from in 0..n {
@@ -484,24 +491,24 @@ fn run_tcp_model_mesh(n: usize) {
             }
         }
     }
-    // Three HOL stalls on distinct directed links, well before heal.
+    // Three HOL retransmit windows on distinct directed links, well before heal.
     let hold_windows: [(usize, usize, u32); 3] = [(0, 1, 100), (1, 0, 250), (n - 1, 0, 400)];
     let mut events = Vec::new();
     for (from, to, start) in hold_windows {
         events.push((
             start,
-            ScheduleEvent::Hold {
+            ScheduleEvent::SetLink {
                 from,
                 to,
-                holding: true,
+                policy: hol.clone(),
             },
         ));
         events.push((
             start + 25,
-            ScheduleEvent::Hold {
+            ScheduleEvent::SetLink {
                 from,
                 to,
-                holding: false,
+                policy: fifo.clone(),
             },
         ));
     }
@@ -520,6 +527,17 @@ fn run_tcp_model_mesh(n: usize) {
     };
     let report = run(&schedule, &RunOptions::default());
     report.expect_pass(&schedule);
+    assert!(
+        report.net_stats.retransmit_delayed > 0,
+        "the TCP-model schedule must exercise reliable HOL retransmission: {:?}",
+        report.net_stats
+    );
+    assert_eq!(
+        report.net_stats.dropped_by_policy, 0,
+        "reliable retransmission mode must delay would-drop sends instead of \
+         dropping them: {:?}",
+        report.net_stats
+    );
 }
 
 #[test]
@@ -2205,6 +2223,7 @@ fn wait_rec_schedule(n: usize, app_model: AppModel) -> Schedule {
         jitter: Duration::ZERO,
         burst_rate: 0.0,
         burst_len: 0,
+        retransmit_delay: Duration::ZERO,
     };
     let mut initial_links = Vec::new();
     for from in 0..n {
@@ -2305,6 +2324,7 @@ fn clock_skew_schedule(n: usize, skew: Vec<i32>) -> Schedule {
         jitter: Duration::ZERO,
         burst_rate: 0.0,
         burst_len: 0,
+        retransmit_delay: Duration::ZERO,
     };
     let mut initial_links = Vec::new();
     for from in 0..n {
@@ -2382,6 +2402,7 @@ fn clock_skew_long_run_schedule(steps: u32, ppm: i32) -> Schedule {
         jitter: Duration::ZERO,
         burst_rate: 0.0,
         burst_len: 0,
+        retransmit_delay: Duration::ZERO,
     };
     let initial_links = vec![(0, 1, delayed.clone()), (1, 0, delayed)];
     Schedule {

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -82,13 +82,18 @@ pub enum AppModel {
 ///   crash/failover probe.
 /// - `8`: adds [`ScheduleEvent::HotJoin`], a returning-peer reactivation probe
 ///   driven through the public hot-join API.
-pub const SCHEDULE_SCHEMA_VERSION: u32 = 8;
+/// - `9`: adds [`BackgroundNoise::ReliableFifo`] and
+///   [`LinkPolicy::retransmit_delay`](crate::common::sim_net::LinkPolicy::retransmit_delay)
+///   for reliable-ordered transport probes.
+pub const SCHEDULE_SCHEMA_VERSION: u32 = 9;
 
 /// Background link-noise level applied to every directed link at start.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BackgroundNoise {
     /// Perfect links.
     Clean,
+    /// Reliable, ordered, loss-free links (TCP/WebRTC-reliable baseline).
+    ReliableFifo,
     /// LAN-to-good-WAN: ≤2% loss, 5–30ms delay, ≤10ms jitter, ≤1% dup.
     Mild,
     /// Bad WAN / mobile: 2–10% loss, 20–80ms delay, ≤30ms jitter, ≤3% dup,
@@ -389,6 +394,10 @@ impl Draw<'_> {
 fn roll_background_policy(draw: &mut Draw<'_>, noise: BackgroundNoise) -> LinkPolicy {
     match noise {
         BackgroundNoise::Clean => LinkPolicy::clean(),
+        BackgroundNoise::ReliableFifo => LinkPolicy {
+            base_delay: Duration::from_millis(30),
+            ..LinkPolicy::clean()
+        },
         BackgroundNoise::Mild => LinkPolicy {
             drop_rate: draw.range_f64(0.0, 0.02),
             dup_rate: draw.range_f64(0.0, 0.01),
@@ -396,6 +405,7 @@ fn roll_background_policy(draw: &mut Draw<'_>, noise: BackgroundNoise) -> LinkPo
             jitter: Duration::from_millis(draw.range_u64(0, 10)),
             burst_rate: 0.0,
             burst_len: 0,
+            retransmit_delay: Duration::ZERO,
         },
         BackgroundNoise::Rough => LinkPolicy {
             drop_rate: draw.range_f64(0.02, 0.10),
@@ -404,6 +414,7 @@ fn roll_background_policy(draw: &mut Draw<'_>, noise: BackgroundNoise) -> LinkPo
             jitter: Duration::from_millis(draw.range_u64(0, 30)),
             burst_rate: draw.range_f64(0.0, 0.005),
             burst_len: u32::try_from(draw.range_u64(2, 5)).unwrap_or(3),
+            retransmit_delay: Duration::ZERO,
         },
     }
 }
@@ -458,7 +469,9 @@ pub fn generate(seed: u64, config: SimConfig) -> Schedule {
     // introduced deliberately in the lifecycle vocabulary, not by accident.
     let mut events: Vec<(u32, ScheduleEvent)> = Vec::new();
     let storyline_budget = heal_at.saturating_sub(20);
-    let n_storylines = if storyline_budget > 100 {
+    let n_storylines = if matches!(config.noise, BackgroundNoise::ReliableFifo) {
+        0
+    } else if storyline_budget > 100 {
         draw.range_u64(0, 3)
     } else {
         0
@@ -578,6 +591,36 @@ mod tests {
     }
 
     #[test]
+    fn reliable_fifo_profile_is_lossless_ordered_and_storyline_free() {
+        let schedule = generate(
+            42,
+            SimConfig {
+                noise: BackgroundNoise::ReliableFifo,
+                ..SimConfig::smoke(4)
+            },
+        );
+        for (from, to, policy) in &schedule.initial_links {
+            assert_ne!(from, to);
+            assert!(policy.drop_rate.abs() < f64::EPSILON);
+            assert!(policy.dup_rate.abs() < f64::EPSILON);
+            assert_eq!(policy.base_delay, Duration::from_millis(30));
+            assert_eq!(policy.jitter, Duration::ZERO);
+            assert!(policy.burst_rate.abs() < f64::EPSILON);
+            assert_eq!(policy.burst_len, 0);
+            assert_eq!(policy.retransmit_delay, Duration::ZERO);
+        }
+        assert_eq!(
+            schedule
+                .events
+                .iter()
+                .filter(|(_, event)| !matches!(event, ScheduleEvent::HealAll))
+                .count(),
+            0,
+            "ReliableFifo must not add random loss, partition, or reorder storylines"
+        );
+    }
+
+    #[test]
     fn generate_covers_every_directed_link() {
         for n in 2..=16 {
             let schedule = generate(7, SimConfig::smoke(n));
@@ -665,6 +708,31 @@ mod tests {
         assert_eq!(
             schedule, back,
             "corpus artifacts must round-trip losslessly"
+        );
+    }
+
+    #[test]
+    fn link_policy_without_retransmit_delay_uses_zero_default() {
+        let schedule = generate(42, SimConfig::smoke(2));
+        let mut value = serde_json::to_value(&schedule).unwrap();
+        let first_policy = value
+            .get_mut("initial_links")
+            .and_then(|links| links.as_array_mut())
+            .and_then(|links| links.first_mut())
+            .and_then(|link| link.as_array_mut())
+            .and_then(|link| link.get_mut(2))
+            .and_then(|policy| policy.as_object_mut())
+            .expect("initial link policy must serialize as an object");
+        assert!(
+            first_policy.remove("retransmit_delay").is_some(),
+            "policy must serialize retransmit_delay for this test to remove"
+        );
+
+        let back: Schedule = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            back.initial_links[0].2.retransmit_delay,
+            Duration::ZERO,
+            "old corpus artifacts without retransmit_delay must keep UDP-like loss semantics"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add a ReliableFifo simulation noise profile plus `LinkPolicy::retransmit_delay` so M3 can model reliable ordered transports with head-of-line retransmission stalls instead of packet loss.
- Rework the TCP-model fleet probes to use retransmit-delay windows and assert the premise with `retransmit_delayed > 0` and `dropped_by_policy == 0`.
- Add the first `tests/simulation/census.rs` row for RTT far beyond `max_prediction`, asserting stall telemetry while the existing simulation oracle proves liveness and state agreement.

## Validation

- `cargo nextest run --no-capture -E 'test(retransmit_delay_delivers_would_drop_and_holds_later_sends) or test(reliable_fifo_profile_is_lossless_ordered_and_storyline_free) or test(link_policy_without_retransmit_delay_uses_zero_default) or test(tcp_model_reliable_fifo_two_player_mesh_holds_invariants) or test(tcp_model_reliable_fifo_four_player_mesh_holds_invariants) or test(high_rtt_beyond_prediction_window_throttles_without_divergence)'`
- `cargo fmt`
- `cargo clippy --workspace --all-targets --features tokio,json`
- `python3 scripts/ci/agent-preflight.py --auto-fix`
- `cargo nextest run --test simulation --no-capture`
- `cargo nextest run --no-capture` (2441 passed, 58 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test/simulation infrastructure (`SimNet`, schedules, fleet/census tests); production rollback protocol code is untouched.
> 
> **Overview**
> Extends the simulation test stack so M3 can exercise **reliable ordered transports** (TCP/WebRTC-style) instead of only UDP-like loss.
> 
> **`SimNet`** gains `LinkPolicy::retransmit_delay`: when nonzero, burst/drop rolls **delay** would-be drops and block later sends on that link until the retransmit deadline (head-of-line blocking), with a `retransmit_delayed` stat and `#[serde(default)]` so older schedule JSON still deserializes as zero (UDP semantics).
> 
> **Schedule harness** bumps schema to **9**, adds `BackgroundNoise::ReliableFifo` (lossless 30ms links, no random storylines), and wires `retransmit_delay` through generated policies.
> 
> **Fleet** TCP-model probes swap capture-and-hold `Hold` windows for **`SetLink`** policies with `drop_rate: 1.0` + 400ms retransmit delay, and assert `retransmit_delayed > 0` and `dropped_by_policy == 0`.
> 
> **New `tests/simulation/census.rs`** row: two peers with ~240ms RTT and `max_prediction = 2` must pass the oracle, show **stall_count > 0**, and reproduce trace hash (prediction-window throttling without divergence).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995beb63b3f3878cad424e1f87dfc2bcccfdc02f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->