### PR TITLE
Add frozen-queue network blip census row

### DIFF
--- a/tests/simulation/census.rs
+++ b/tests/simulation/census.rs
@@ -3,9 +3,9 @@
 use super::harness::schedule::{
     BackgroundNoise, DropPolicy, Schedule, ScheduleEvent, SimConfig, SCHEDULE_SCHEMA_VERSION,
 };
-use super::harness::{run, RunOptions, RunReport};
+use super::harness::{peer_addr, run, PeerEventKey, PeerEventPayload, RunOptions, RunReport};
 use crate::common::sim_net::LinkPolicy;
-use fortress_rollback::EventKind;
+use fortress_rollback::{EventKind, PlayerHandle};
 use std::time::Duration;
 
 fn clean_initial_links(n: usize) -> Vec<(usize, usize, LinkPolicy)> {
@@ -20,13 +20,30 @@ fn clean_initial_links(n: usize) -> Vec<(usize, usize, LinkPolicy)> {
     initial_links
 }
 
-fn peer_event_count(report: &RunReport, peer: usize, kind: EventKind) -> u64 {
+fn peer_event_payload_count(report: &RunReport, peer: usize, key: PeerEventKey) -> u64 {
     report
-        .peer_event_counts_by_peer
+        .peer_event_payload_counts_by_peer
         .get(peer)
-        .and_then(|counts| counts.get(&kind))
+        .and_then(|counts| counts.get(&key))
         .copied()
         .unwrap_or(0)
+}
+
+fn addr_event_key(kind: EventKind, peer: usize) -> PeerEventKey {
+    PeerEventKey {
+        kind,
+        payload: PeerEventPayload::Addr(peer_addr(peer)),
+    }
+}
+
+fn peer_dropped_key(peer: usize) -> PeerEventKey {
+    PeerEventKey {
+        kind: EventKind::PeerDropped,
+        payload: PeerEventPayload::PlayerAddr {
+            handle: PlayerHandle::new(peer),
+            addr: peer_addr(peer),
+        },
+    }
 }
 
 fn delayed_two_peer_schedule() -> Schedule {
@@ -64,7 +81,7 @@ fn frozen_queue_network_blip_schedule() -> Schedule {
     let drop_at = 140;
     let blip_start = 260;
     let blip_end = 335;
-    let heal_at = 520;
+    let heal_at = blip_end;
     let mut events = vec![
         (drop_at, ScheduleEvent::GracefulRemove { by: 0, target: 2 }),
         (
@@ -163,41 +180,30 @@ fn frozen_queue_survivors_resume_after_network_blip() {
         "network-blip census row must drop traffic on the blocked survivor link: {:?}",
         report.net_stats
     );
-    assert!(
-        report
-            .peer_event_counts
-            .get(&EventKind::PeerDropped)
-            .copied()
-            .unwrap_or(0)
-            > 0,
-        "frozen-queue census row must surface at least one PeerDropped event: {:?}",
-        report.peer_event_counts
-    );
     assert_eq!(
         report.recovered_within_b,
         Some(true),
         "network-blip census row must run and pass the bounded post-heal liveness oracle"
     );
-    assert!(
-        peer_event_count(&report, SURVIVOR_A, EventKind::NetworkInterrupted) > 0,
-        "survivor {SURVIVOR_A} must observe NetworkInterrupted on the blocked live link: {:?}",
-        report.peer_event_counts_by_peer
-    );
-    assert!(
-        peer_event_count(&report, SURVIVOR_B, EventKind::NetworkInterrupted) > 0,
-        "survivor {SURVIVOR_B} must observe NetworkInterrupted on the blocked live link: {:?}",
-        report.peer_event_counts_by_peer
-    );
-    assert!(
-        peer_event_count(&report, SURVIVOR_A, EventKind::NetworkResumed) > 0,
-        "survivor {SURVIVOR_A} must observe NetworkResumed after the live-link blip: {:?}",
-        report.peer_event_counts_by_peer
-    );
-    assert!(
-        peer_event_count(&report, SURVIVOR_B, EventKind::NetworkResumed) > 0,
-        "survivor {SURVIVOR_B} must observe NetworkResumed after the live-link blip: {:?}",
-        report.peer_event_counts_by_peer
-    );
+    for (observer, kind, remote) in [
+        (SURVIVOR_A, EventKind::NetworkInterrupted, SURVIVOR_B),
+        (SURVIVOR_B, EventKind::NetworkInterrupted, SURVIVOR_A),
+        (SURVIVOR_A, EventKind::NetworkResumed, SURVIVOR_B),
+        (SURVIVOR_B, EventKind::NetworkResumed, SURVIVOR_A),
+    ] {
+        assert!(
+            peer_event_payload_count(&report, observer, addr_event_key(kind, remote)) > 0,
+            "survivor {observer} must observe {kind:?} for survivor {remote}: {:?}",
+            report.peer_event_payload_counts_by_peer
+        );
+    }
+    for observer in [SURVIVOR_A, SURVIVOR_B] {
+        assert!(
+            peer_event_payload_count(&report, observer, peer_dropped_key(2)) > 0,
+            "survivor {observer} must observe PeerDropped for removed peer 2: {:?}",
+            report.peer_event_payload_counts_by_peer
+        );
+    }
     let survivor_0_confirmed = report.final_confirmed.first().copied().unwrap_or(i32::MIN);
     let survivor_1_confirmed = report.final_confirmed.get(1).copied().unwrap_or(i32::MIN);
     assert!(

--- a/tests/simulation/census.rs
+++ b/tests/simulation/census.rs
@@ -1,11 +1,33 @@
 //! Premise-asserted simulation census rows for specific distributed failure modes.
 
 use super::harness::schedule::{
-    BackgroundNoise, Schedule, ScheduleEvent, SimConfig, SCHEDULE_SCHEMA_VERSION,
+    BackgroundNoise, DropPolicy, Schedule, ScheduleEvent, SimConfig, SCHEDULE_SCHEMA_VERSION,
 };
-use super::harness::{run, RunOptions};
+use super::harness::{run, RunOptions, RunReport};
 use crate::common::sim_net::LinkPolicy;
+use fortress_rollback::EventKind;
 use std::time::Duration;
+
+fn clean_initial_links(n: usize) -> Vec<(usize, usize, LinkPolicy)> {
+    let mut initial_links = Vec::new();
+    for from in 0..n {
+        for to in 0..n {
+            if from != to {
+                initial_links.push((from, to, LinkPolicy::clean()));
+            }
+        }
+    }
+    initial_links
+}
+
+fn peer_event_count(report: &RunReport, peer: usize, kind: EventKind) -> u64 {
+    report
+        .peer_event_counts_by_peer
+        .get(peer)
+        .and_then(|counts| counts.get(&kind))
+        .copied()
+        .unwrap_or(0)
+}
 
 fn delayed_two_peer_schedule() -> Schedule {
     let mut config = SimConfig::smoke(2);
@@ -28,6 +50,66 @@ fn delayed_two_peer_schedule() -> Schedule {
         config,
         initial_links,
         events: vec![(heal_at, ScheduleEvent::HealAll)],
+        heal_at,
+    }
+}
+
+fn frozen_queue_network_blip_schedule() -> Schedule {
+    let n = 3;
+    let mut config = SimConfig::smoke(n);
+    config.steps = 780;
+    config.noise = BackgroundNoise::Clean;
+    config.disconnect_behavior = DropPolicy::ContinueWithout;
+
+    let drop_at = 140;
+    let blip_start = 260;
+    let blip_end = 335;
+    let heal_at = 520;
+    let mut events = vec![
+        (drop_at, ScheduleEvent::GracefulRemove { by: 0, target: 2 }),
+        (
+            blip_start,
+            ScheduleEvent::Block {
+                from: 0,
+                to: 1,
+                blocked: true,
+            },
+        ),
+        (
+            blip_start,
+            ScheduleEvent::Block {
+                from: 1,
+                to: 0,
+                blocked: true,
+            },
+        ),
+        (
+            blip_end,
+            ScheduleEvent::Block {
+                from: 0,
+                to: 1,
+                blocked: false,
+            },
+        ),
+        (
+            blip_end,
+            ScheduleEvent::Block {
+                from: 1,
+                to: 0,
+                blocked: false,
+            },
+        ),
+        (heal_at, ScheduleEvent::HealAll),
+    ];
+    events.sort_by_key(|(step, _)| *step);
+
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0xCE45_0010,
+        link_seed: 0xCE45_0011,
+        config,
+        initial_links: clean_initial_links(n),
+        events,
         heal_at,
     }
 }
@@ -57,5 +139,76 @@ fn high_rtt_beyond_prediction_window_throttles_without_divergence() {
     assert_eq!(
         report.trace_hash, again.trace_hash,
         "high-RTT census row must reproduce its exact trace"
+    );
+}
+
+/// M3 §6.4 census: after a graceful drop freezes a departed slot, a survivor
+/// link can still suffer a sub-timeout interruption and resume without wedging
+/// the remaining mesh. This pins the combined frozen-queue +
+/// `NetworkInterrupted`/`NetworkResumed` row with direct premise assertions:
+/// traffic is actually blocked, the user-facing interruption surfaces fire, and
+/// the oracle proves post-blip liveness plus byte-consistent survivor state.
+#[test]
+fn frozen_queue_survivors_resume_after_network_blip() {
+    const SURVIVOR_A: usize = 0;
+    const SURVIVOR_B: usize = 1;
+
+    let schedule = frozen_queue_network_blip_schedule();
+
+    let report = run(&schedule, &RunOptions::default());
+    report.expect_pass(&schedule);
+
+    assert!(
+        report.net_stats.dropped_blocked > 0,
+        "network-blip census row must drop traffic on the blocked survivor link: {:?}",
+        report.net_stats
+    );
+    assert!(
+        report
+            .peer_event_counts
+            .get(&EventKind::PeerDropped)
+            .copied()
+            .unwrap_or(0)
+            > 0,
+        "frozen-queue census row must surface at least one PeerDropped event: {:?}",
+        report.peer_event_counts
+    );
+    assert_eq!(
+        report.recovered_within_b,
+        Some(true),
+        "network-blip census row must run and pass the bounded post-heal liveness oracle"
+    );
+    assert!(
+        peer_event_count(&report, SURVIVOR_A, EventKind::NetworkInterrupted) > 0,
+        "survivor {SURVIVOR_A} must observe NetworkInterrupted on the blocked live link: {:?}",
+        report.peer_event_counts_by_peer
+    );
+    assert!(
+        peer_event_count(&report, SURVIVOR_B, EventKind::NetworkInterrupted) > 0,
+        "survivor {SURVIVOR_B} must observe NetworkInterrupted on the blocked live link: {:?}",
+        report.peer_event_counts_by_peer
+    );
+    assert!(
+        peer_event_count(&report, SURVIVOR_A, EventKind::NetworkResumed) > 0,
+        "survivor {SURVIVOR_A} must observe NetworkResumed after the live-link blip: {:?}",
+        report.peer_event_counts_by_peer
+    );
+    assert!(
+        peer_event_count(&report, SURVIVOR_B, EventKind::NetworkResumed) > 0,
+        "survivor {SURVIVOR_B} must observe NetworkResumed after the live-link blip: {:?}",
+        report.peer_event_counts_by_peer
+    );
+    let survivor_0_confirmed = report.final_confirmed.first().copied().unwrap_or(i32::MIN);
+    let survivor_1_confirmed = report.final_confirmed.get(1).copied().unwrap_or(i32::MIN);
+    assert!(
+        survivor_0_confirmed > 400 && survivor_1_confirmed > 400,
+        "survivors must keep confirming after the frozen-slot blip: {:?}",
+        report.final_confirmed
+    );
+
+    let again = run(&schedule, &RunOptions::default());
+    assert_eq!(
+        report.trace_hash, again.trace_hash,
+        "network-blip census row must reproduce its exact trace"
     );
 }

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -173,7 +173,7 @@ pub struct RunOptions {
     pub corrupt_spectator_status_from: Option<i32>,
 }
 
-/// Payload identity for user-facing peer events that name a remote endpoint.
+/// Payload identity for the endpoint-bearing peer events the harness records.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PeerEventPayload {
     Addr(SocketAddr),
@@ -183,7 +183,7 @@ pub enum PeerEventPayload {
     },
 }
 
-/// Key used by census rows that need to prove which endpoint an event named.
+/// Key used by census rows that need to prove which recorded endpoint an event named.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PeerEventKey {
     pub kind: EventKind,
@@ -1477,13 +1477,9 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                     for event in &events {
                         let kind = event.kind();
                         *peer_event_counts.entry(kind).or_default() += 1;
-                        if let Some(counts) = peer_event_counts_by_peer.get_mut(i) {
-                            *counts.entry(kind).or_default() += 1;
-                        }
+                        *peer_event_counts_by_peer[i].entry(kind).or_default() += 1;
                         if let Some(key) = peer_event_key::<I>(event) {
-                            if let Some(counts) = peer_event_payload_counts_by_peer.get_mut(i) {
-                                *counts.entry(key).or_default() += 1;
-                            }
+                            *peer_event_payload_counts_by_peer[i].entry(key).or_default() += 1;
                         }
                         if let FortressEvent::DesyncDetected { frame, .. } = event {
                             oracle.observe_desync_event(i, *frame);

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -23,9 +23,10 @@ use crate::common::test_clock::TestClock;
 use fortress_rollback::hash::fnv1a_hash;
 use fortress_rollback::telemetry::CollectingObserver;
 use fortress_rollback::{
-    Config, DesyncDetection, FortressError, FortressEvent, FortressRequest, Frame, GameStateCell,
-    InputStatus, InputVec, Message, MessageKind, P2PSession, PeerMetrics, PlayerHandle, PlayerType,
-    ProtocolConfig, RequestVec, SessionBuilder, SessionState, SpectatorSession,
+    Config, DesyncDetection, EventKind, FortressError, FortressEvent, FortressRequest, Frame,
+    GameStateCell, InputStatus, InputVec, Message, MessageKind, P2PSession, PeerMetrics,
+    PlayerHandle, PlayerType, ProtocolConfig, RequestVec, SessionBuilder, SessionState,
+    SpectatorSession,
 };
 use oracle::{
     validate_violation_allowlist, HealLiveness, InputFingerprint, Oracle, Verdict,
@@ -213,6 +214,13 @@ pub struct RunReport {
     /// census so warning-only signatures stay visible even though they do not
     /// fail the run.
     pub violation_census: BTreeMap<ViolationSignature, u64>,
+    /// User-facing peer events drained by the harness, counted by category.
+    /// Census rows use this to assert that a schedule exercised ordinary event
+    /// surfaces (for example `NetworkInterrupted`/`NetworkResumed`) instead of
+    /// only relying on end-state convergence.
+    pub peer_event_counts: BTreeMap<EventKind, u64>,
+    /// Same event counts split by observing peer. Indexed by peer.
+    pub peer_event_counts_by_peer: Vec<BTreeMap<EventKind, u64>>,
     /// Number of frames the configured spectator displayed and handed to the
     /// oracle. Zero when `SimConfig::spectator_hosts` is empty.
     pub spectator_applied_frames: usize,
@@ -1177,6 +1185,8 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
     validate_violation_allowlist(DEFAULT_VIOLATION_ALLOWLIST)
         .expect("reviewed default violation allowlist must stay valid");
     let mut trace_hash: u64 = 0xcbf2_9ce4_8422_2325; // FNV offset basis
+    let mut peer_event_counts: BTreeMap<EventKind, u64> = BTreeMap::new();
+    let mut peer_event_counts_by_peer = vec![BTreeMap::new(); n];
     let mut next_event = 0usize;
     // Per-peer stall deadline (exclusive step): peer `i` is frozen while
     // `step < stalled_until[i]`. `0` means never stalled; a `PeerStall` event
@@ -1416,6 +1426,11 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                     let events: Vec<FortressEvent<I::SessionConfig>> =
                         slot.session.events().collect();
                     for event in &events {
+                        let kind = event.kind();
+                        *peer_event_counts.entry(kind).or_default() += 1;
+                        if let Some(counts) = peer_event_counts_by_peer.get_mut(i) {
+                            *counts.entry(kind).or_default() += 1;
+                        }
                         if let FortressEvent::DesyncDetected { frame, .. } = event {
                             oracle.observe_desync_event(i, *frame);
                         }
@@ -1651,6 +1666,8 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
         confirmed_after_recovery,
         recovered_within_b,
         violation_census,
+        peer_event_counts,
+        peer_event_counts_by_peer,
         spectator_applied_frames,
         spectator_max_frame,
         spectator_final_hosts,
@@ -1885,6 +1902,11 @@ mod tests {
         assert_eq!(implicit.net_stats, explicit.net_stats);
         assert_eq!(implicit.recovered_within_b, explicit.recovered_within_b);
         assert_eq!(implicit.violation_census, explicit.violation_census);
+        assert_eq!(implicit.peer_event_counts, explicit.peer_event_counts);
+        assert_eq!(
+            implicit.peer_event_counts_by_peer,
+            explicit.peer_event_counts_by_peer
+        );
         assert_eq!(
             implicit.spectator_applied_frames,
             explicit.spectator_applied_frames

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -173,6 +173,23 @@ pub struct RunOptions {
     pub corrupt_spectator_status_from: Option<i32>,
 }
 
+/// Payload identity for user-facing peer events that name a remote endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PeerEventPayload {
+    Addr(SocketAddr),
+    PlayerAddr {
+        handle: PlayerHandle,
+        addr: SocketAddr,
+    },
+}
+
+/// Key used by census rows that need to prove which endpoint an event named.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PeerEventKey {
+    pub kind: EventKind,
+    pub payload: PeerEventPayload,
+}
+
 /// Outcome of one simulation run.
 #[derive(Clone, Debug)]
 pub struct RunReport {
@@ -221,6 +238,9 @@ pub struct RunReport {
     pub peer_event_counts: BTreeMap<EventKind, u64>,
     /// Same event counts split by observing peer. Indexed by peer.
     pub peer_event_counts_by_peer: Vec<BTreeMap<EventKind, u64>>,
+    /// Same event counts split by observing peer and relevant event payload.
+    /// Indexed by observing peer.
+    pub peer_event_payload_counts_by_peer: Vec<BTreeMap<PeerEventKey, u64>>,
     /// Number of frames the configured spectator displayed and handed to the
     /// oracle. Zero when `SimConfig::spectator_hosts` is empty.
     pub spectator_applied_frames: usize,
@@ -726,7 +746,7 @@ fn record_spectator_requests<I: SimInput>(
 }
 
 /// Synthetic mesh addresses (never bound): `127.0.0.1:(20001 + i)`.
-fn peer_addr(i: usize) -> SocketAddr {
+pub(super) fn peer_addr(i: usize) -> SocketAddr {
     let port = 20001 + u16::try_from(i).expect("peer index fits in u16");
     ([127, 0, 0, 1], port).into()
 }
@@ -734,6 +754,34 @@ fn peer_addr(i: usize) -> SocketAddr {
 /// Folds one hashable item into the running trace digest.
 fn fold_trace<T: std::hash::Hash>(hash: &mut u64, item: &T) {
     *hash = fnv1a_hash(&(*hash, fnv1a_hash(item)));
+}
+
+fn peer_event_key<I: SimInput>(event: &FortressEvent<I::SessionConfig>) -> Option<PeerEventKey> {
+    let kind = event.kind();
+    let payload = match event {
+        FortressEvent::Synchronizing { addr, .. }
+        | FortressEvent::Synchronized { addr }
+        | FortressEvent::Disconnected { addr }
+        | FortressEvent::NetworkInterrupted { addr, .. }
+        | FortressEvent::NetworkResumed { addr }
+        | FortressEvent::DesyncDetected { addr, .. }
+        | FortressEvent::SyncTimeout { addr, .. } => PeerEventPayload::Addr(*addr),
+        FortressEvent::PeerDropped { handle, addr } => PeerEventPayload::PlayerAddr {
+            handle: *handle,
+            addr: *addr,
+        },
+        #[cfg(feature = "hot-join")]
+        FortressEvent::JoinRequested { handle, addr }
+        | FortressEvent::PeerJoined { handle, addr } => PeerEventPayload::PlayerAddr {
+            handle: *handle,
+            addr: *addr,
+        },
+        FortressEvent::WaitRecommendation { .. }
+        | FortressEvent::ReplayDesync { .. }
+        | FortressEvent::SpectatorDivergence { .. }
+        | FortressEvent::InputDelayRecommendation { .. } => return None,
+    };
+    Some(PeerEventKey { kind, payload })
 }
 
 /// Per-step progress dump for the diagnostic path.
@@ -1187,6 +1235,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
     let mut trace_hash: u64 = 0xcbf2_9ce4_8422_2325; // FNV offset basis
     let mut peer_event_counts: BTreeMap<EventKind, u64> = BTreeMap::new();
     let mut peer_event_counts_by_peer = vec![BTreeMap::new(); n];
+    let mut peer_event_payload_counts_by_peer = vec![BTreeMap::new(); n];
     let mut next_event = 0usize;
     // Per-peer stall deadline (exclusive step): peer `i` is frozen while
     // `step < stalled_until[i]`. `0` means never stalled; a `PeerStall` event
@@ -1431,6 +1480,11 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                         if let Some(counts) = peer_event_counts_by_peer.get_mut(i) {
                             *counts.entry(kind).or_default() += 1;
                         }
+                        if let Some(key) = peer_event_key::<I>(event) {
+                            if let Some(counts) = peer_event_payload_counts_by_peer.get_mut(i) {
+                                *counts.entry(key).or_default() += 1;
+                            }
+                        }
                         if let FortressEvent::DesyncDetected { frame, .. } = event {
                             oracle.observe_desync_event(i, *frame);
                         }
@@ -1668,6 +1722,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
         violation_census,
         peer_event_counts,
         peer_event_counts_by_peer,
+        peer_event_payload_counts_by_peer,
         spectator_applied_frames,
         spectator_max_frame,
         spectator_final_hosts,
@@ -1906,6 +1961,10 @@ mod tests {
         assert_eq!(
             implicit.peer_event_counts_by_peer,
             explicit.peer_event_counts_by_peer
+        );
+        assert_eq!(
+            implicit.peer_event_payload_counts_by_peer,
+            explicit.peer_event_payload_counts_by_peer
         );
         assert_eq!(
             implicit.spectator_applied_frames,


### PR DESCRIPTION
## Summary

Adds the next M3 section 6.4 premise-asserted simulation census row for a frozen dropped slot plus a sub-timeout survivor link blip.

## What changed

- Adds harness-level drained peer event counters, both aggregate and split by observing peer.
- Adds payload-keyed peer event counters by observing peer so census rows can assert the exact endpoint named by drained events.
- Adds `frozen_queue_survivors_resume_after_network_blip`, a hand-built schedule that:
  - gracefully removes peer 2 under `ContinueWithout`, freezing the departed slot;
  - blocks live survivor traffic between peers 0 and 1 for a sub-timeout window;
  - heals at the actual blip restoration step, so bounded recovery is anchored to the real link restoration;
  - asserts blocked traffic was actually dropped by the fabric;
  - asserts both live survivors observed `PeerDropped` for removed peer 2;
  - asserts each survivor observed `NetworkInterrupted` and `NetworkResumed` for the other survivor's address;
  - asserts bounded post-heal recovery ran and passed;
  - asserts survivor confirmation progress and deterministic replay.
- Extends the harness default-vs-explicit input regression to cover the new event counter fields.

## Validation

- `cargo test --test simulation frozen_queue_survivors_resume_after_network_blip -- --nocapture`
- `cargo test --test simulation census -- --nocapture`
- `cargo test --test simulation default_run_matches_explicit_stub_input_run -- --nocapture`
- `cargo clippy --workspace --all-targets --features tokio,json`
- `python3 scripts/ci/agent-preflight.py --auto-fix`
- `git diff --check`
- `npx markdownlint PLAN.md progress/session-088-frozen-queue-network-blip-census.md --config .markdownlint.json --fix`
- `cargo nextest run --no-capture` -> `2442 passed, 58 skipped`

## Review follow-up

Cursor bugbot findings from the first revision are addressed in commit `7a7c5b6`: recovery is anchored at `blip_end`, event assertions are payload-specific, and `PeerDropped` propagation is asserted for survivor 1. A second adversarial sub-agent review reported zero issues.

## Notes

PLAN.md and progress logs are updated locally per agent workflow, but this repository ignores `PLAN.md` and `progress/**`. The H-RING candidate row was also explored and produced a real red result; it should be handled as a separate red-green investigation rather than included here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulation tests and harness reporting; production rollback/session code is untouched.
> 
> **Overview**
> Extends the simulation **harness** so census rows can assert on **drained peer events**, not only end-state oracles. **`RunReport`** now carries aggregate peer event counts, per-observer counts, and **payload-keyed** counts (`PeerEventKey` / `PeerEventPayload`) built while draining each peer’s event queue; **`peer_addr`** is exposed to tests for address-specific keys.
> 
> Adds the M3 §6.4 census **`frozen_queue_survivors_resume_after_network_blip`**: a 3-peer schedule that gracefully removes peer 2 under **`ContinueWithout`**, blocks survivor traffic between peers 0 and 1 for a sub-timeout window, heals when links unblock, then asserts blocked drops, bounded post-heal recovery, **`NetworkInterrupted`/`NetworkResumed`** per remote address, **`PeerDropped`** for the removed slot, survivor confirmation progress, and deterministic **`trace_hash`** replay.
> 
> The default-vs-explicit stub input harness regression now also compares the new event counter fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb198c31267102f08c07e10ca9d4258471c150dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->