### PR TITLE
Add sparse and multi-drop census rows

### DIFF
--- a/tests/common/sim_net.rs
+++ b/tests/common/sim_net.rs
@@ -570,14 +570,10 @@ impl<M: Clone> SimNet<M> {
         self.lock().stats
     }
 
-    /// Number of messages dropped because the directed link was blocked.
+    /// Snapshot of per-directed-link blocked-drop counters.
     #[must_use]
-    pub fn blocked_drop_count(&self, from: SocketAddr, to: SocketAddr) -> u64 {
-        self.lock()
-            .blocked_drop_counts
-            .get(&(from, to))
-            .copied()
-            .unwrap_or(0)
+    pub fn blocked_drop_counts(&self) -> BTreeMap<(SocketAddr, SocketAddr), u64> {
+        self.lock().blocked_drop_counts.clone()
     }
 }
 

--- a/tests/common/sim_net.rs
+++ b/tests/common/sim_net.rs
@@ -223,6 +223,7 @@ struct SimNetState<M> {
     inboxes: BTreeMap<SocketAddr, VecDeque<(SocketAddr, M)>>,
     unattached: UnattachedPolicy,
     stats: SimNetStats,
+    blocked_drop_counts: BTreeMap<(SocketAddr, SocketAddr), u64>,
 }
 
 impl<M: Clone> SimNetState<M> {
@@ -300,6 +301,7 @@ impl<M: Clone> SimNetState<M> {
 
         if blocked {
             self.stats.dropped_blocked += 1;
+            *self.blocked_drop_counts.entry(key).or_default() += 1;
             return;
         }
         if holding {
@@ -453,6 +455,7 @@ impl<M: Clone> SimNet<M> {
                 inboxes: BTreeMap::new(),
                 unattached: UnattachedPolicy::Drop,
                 stats: SimNetStats::default(),
+                blocked_drop_counts: BTreeMap::new(),
             })),
         }
     }
@@ -565,6 +568,16 @@ impl<M: Clone> SimNet<M> {
     #[must_use]
     pub fn stats(&self) -> SimNetStats {
         self.lock().stats
+    }
+
+    /// Number of messages dropped because the directed link was blocked.
+    #[must_use]
+    pub fn blocked_drop_count(&self, from: SocketAddr, to: SocketAddr) -> u64 {
+        self.lock()
+            .blocked_drop_counts
+            .get(&(from, to))
+            .copied()
+            .unwrap_or(0)
     }
 }
 

--- a/tests/simulation/census.rs
+++ b/tests/simulation/census.rs
@@ -277,8 +277,8 @@ fn sparse_save_mode_survives_graceful_drop_rollback() {
     assert!(
         survivor_post_drop_loads
             .iter()
-            .any(|load| load.frame < load.step as i32),
-        "sparse graceful-drop row must observe survivor LoadGameState after the drop: {:?}",
+            .any(|load| load.frame < SPARSE_DROP_AT as i32),
+        "sparse graceful-drop row must observe survivor pre-drop LoadGameState after the drop: {:?}",
         report.load_game_state_observations
     );
     let rollbacks: u64 = report

--- a/tests/simulation/census.rs
+++ b/tests/simulation/census.rs
@@ -1,12 +1,19 @@
 //! Premise-asserted simulation census rows for specific distributed failure modes.
 
 use super::harness::schedule::{
-    BackgroundNoise, DropPolicy, Schedule, ScheduleEvent, SimConfig, SCHEDULE_SCHEMA_VERSION,
+    BackgroundNoise, DropPolicy, SavePolicy, Schedule, ScheduleEvent, SimConfig,
+    SCHEDULE_SCHEMA_VERSION,
 };
 use super::harness::{peer_addr, run, PeerEventKey, PeerEventPayload, RunOptions, RunReport};
 use crate::common::sim_net::LinkPolicy;
 use fortress_rollback::{EventKind, PlayerHandle};
 use std::time::Duration;
+
+const SPARSE_DROP_AT: u32 = 180;
+const SPARSE_HEAL_AT: u32 = 300;
+const MULTI_STAGGER_START: u32 = 150;
+const MULTI_DROP_AT: u32 = 178;
+const MULTI_HEAL_AT: u32 = 300;
 
 fn clean_initial_links(n: usize) -> Vec<(usize, usize, LinkPolicy)> {
     let mut initial_links = Vec::new();
@@ -18,6 +25,14 @@ fn clean_initial_links(n: usize) -> Vec<(usize, usize, LinkPolicy)> {
         }
     }
     initial_links
+}
+
+fn blocked_drop_count(report: &RunReport, from: usize, to: usize) -> u64 {
+    report
+        .blocked_drops_by_link
+        .get(&(from, to))
+        .copied()
+        .unwrap_or(0)
 }
 
 fn peer_event_payload_count(report: &RunReport, peer: usize, key: PeerEventKey) -> u64 {
@@ -131,6 +146,81 @@ fn frozen_queue_network_blip_schedule() -> Schedule {
     }
 }
 
+fn sparse_graceful_drop_rollback_schedule() -> Schedule {
+    let n = 3;
+    let mut config = SimConfig::smoke(n);
+    config.steps = 680;
+    config.noise = BackgroundNoise::Clean;
+    config.disconnect_behavior = DropPolicy::ContinueWithout;
+    config.save_mode = SavePolicy::Sparse;
+
+    let mut events = vec![
+        (
+            SPARSE_DROP_AT,
+            ScheduleEvent::GracefulRemove { by: 0, target: 2 },
+        ),
+        (SPARSE_HEAL_AT, ScheduleEvent::HealAll),
+    ];
+    events.sort_by_key(|(step, _)| *step);
+
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0xCE45_0020,
+        link_seed: 0xCE45_0021,
+        config,
+        initial_links: clean_initial_links(n),
+        events,
+        heal_at: SPARSE_HEAL_AT,
+    }
+}
+
+fn same_step_multi_drop_schedule() -> Schedule {
+    let n = 4;
+    let mut config = SimConfig::smoke(n);
+    config.steps = 760;
+    config.noise = BackgroundNoise::Clean;
+    config.disconnect_behavior = DropPolicy::ContinueWithout;
+
+    let mut events = vec![
+        (
+            MULTI_STAGGER_START,
+            ScheduleEvent::Block {
+                from: 2,
+                to: 1,
+                blocked: true,
+            },
+        ),
+        (
+            MULTI_STAGGER_START,
+            ScheduleEvent::Block {
+                from: 3,
+                to: 0,
+                blocked: true,
+            },
+        ),
+        (
+            MULTI_DROP_AT,
+            ScheduleEvent::GracefulRemove { by: 0, target: 2 },
+        ),
+        (
+            MULTI_DROP_AT,
+            ScheduleEvent::GracefulRemove { by: 1, target: 3 },
+        ),
+        (MULTI_HEAL_AT, ScheduleEvent::HealAll),
+    ];
+    events.sort_by_key(|(step, _)| *step);
+
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0xCE45_0030,
+        link_seed: 0xCE45_0031,
+        config,
+        initial_links: clean_initial_links(n),
+        events,
+        heal_at: MULTI_HEAL_AT,
+    }
+}
+
 /// M3 §6.4 census: when RTT is far larger than `max_prediction`, peers should
 /// throttle by returning `Ok(empty)` rather than diverging or surfacing advance
 /// errors. The permanent oracle checks liveness and byte-consistent state; this
@@ -156,6 +246,165 @@ fn high_rtt_beyond_prediction_window_throttles_without_divergence() {
     assert_eq!(
         report.trace_hash, again.trace_hash,
         "high-RTT census row must reproduce its exact trace"
+    );
+}
+
+/// M3 §6.4 census: sparse saving must survive the graceful-drop rollback path.
+/// The row pins the test-only `SaveMode` schedule axis and proves a survivor
+/// loaded prior state after the graceful remove, then lets the permanent oracle
+/// check byte-consistent survivor state and freeze-frame agreement for the
+/// retired slot.
+#[test]
+fn sparse_save_mode_survives_graceful_drop_rollback() {
+    const SURVIVOR_A: usize = 0;
+    const SURVIVOR_B: usize = 1;
+
+    let schedule = sparse_graceful_drop_rollback_schedule();
+    assert_eq!(
+        schedule.config.save_mode,
+        SavePolicy::Sparse,
+        "census row must explicitly exercise sparse saving"
+    );
+
+    let report = run(&schedule, &RunOptions::default());
+    report.expect_pass(&schedule);
+
+    let survivor_post_drop_loads: Vec<_> = report
+        .rollback_loads
+        .iter()
+        .filter(|load| load.step >= SPARSE_DROP_AT && [SURVIVOR_A, SURVIVOR_B].contains(&load.peer))
+        .collect();
+    assert!(
+        survivor_post_drop_loads
+            .iter()
+            .any(|load| load.frame < load.step as i32),
+        "sparse graceful-drop row must observe survivor LoadGameState after the drop: {:?}",
+        report.rollback_loads
+    );
+    let rollbacks: u64 = report
+        .metrics
+        .iter()
+        .map(|metrics| metrics.rollback_count)
+        .sum();
+    let resimulated: u64 = report
+        .metrics
+        .iter()
+        .map(|metrics| metrics.resimulated_frames)
+        .sum();
+    assert!(
+        rollbacks > 0 && resimulated > 0,
+        "sparse graceful-drop row must exercise disconnect rollback repair: \
+         rollbacks={rollbacks}, resimulated={resimulated}"
+    );
+    assert_eq!(
+        report.recovered_within_b,
+        Some(true),
+        "sparse graceful-drop row must run and pass bounded post-heal liveness"
+    );
+    for observer in [SURVIVOR_A, SURVIVOR_B] {
+        assert!(
+            peer_event_payload_count(&report, observer, peer_dropped_key(2)) > 0,
+            "survivor {observer} must observe PeerDropped for removed peer 2: {:?}",
+            report.peer_event_payload_counts_by_peer
+        );
+    }
+    let survivor_0_confirmed = report.final_confirmed.first().copied().unwrap_or(i32::MIN);
+    let survivor_1_confirmed = report.final_confirmed.get(1).copied().unwrap_or(i32::MIN);
+    assert!(
+        survivor_0_confirmed > 400 && survivor_1_confirmed > 400,
+        "sparse survivors must keep confirming after the disconnect rollback: {:?}",
+        report.final_confirmed
+    );
+
+    let again = run(&schedule, &RunOptions::default());
+    assert_eq!(
+        report.trace_hash, again.trace_hash,
+        "sparse graceful-drop row must reproduce its exact trace"
+    );
+}
+
+/// M3 §6.4 census: two peers can drop in the same poll window after asymmetric
+/// survivor receipt loss, and the live mesh still converges. This pins the
+/// whole-mesh counterpart to the lower-level multi-drop guard: the schedule
+/// proves both intended blocked links dropped traffic, both survivors loaded
+/// prior state after the drops, and both survivors learned both graceful drops.
+#[test]
+fn same_step_multi_drop_after_asymmetric_block_converges() {
+    const SURVIVORS: [usize; 2] = [0, 1];
+    const DROPPED: [usize; 2] = [2, 3];
+
+    let schedule = same_step_multi_drop_schedule();
+
+    let report = run(&schedule, &RunOptions::default());
+    report.expect_pass(&schedule);
+
+    for (from, to) in [(2, 1), (3, 0)] {
+        assert!(
+            blocked_drop_count(&report, from, to) > 0,
+            "same-step multi-drop row must drop traffic on intended blocked link {from}->{to}: {:?}",
+            report.blocked_drops_by_link
+        );
+    }
+    let survivor_post_drop_loads: Vec<_> = report
+        .rollback_loads
+        .iter()
+        .filter(|load| load.step >= MULTI_DROP_AT && SURVIVORS.contains(&load.peer))
+        .collect();
+    for survivor in SURVIVORS {
+        assert!(
+            survivor_post_drop_loads
+                .iter()
+                .any(|load| load.peer == survivor && load.frame < MULTI_DROP_AT as i32),
+            "survivor {survivor} must load pre-drop state after same-step drops: {:?}",
+            report.rollback_loads
+        );
+    }
+    let rollbacks: u64 = report
+        .metrics
+        .iter()
+        .map(|metrics| metrics.rollback_count)
+        .sum();
+    let resimulated: u64 = report
+        .metrics
+        .iter()
+        .map(|metrics| metrics.resimulated_frames)
+        .sum();
+    assert!(
+        rollbacks > 0 && resimulated > 0,
+        "same-step multi-drop row must exercise disconnect rollback: \
+         rollbacks={rollbacks}, resimulated={resimulated}"
+    );
+    assert_eq!(
+        report.recovered_within_b,
+        Some(true),
+        "same-step multi-drop row must run and pass bounded post-heal liveness"
+    );
+    for observer in SURVIVORS {
+        for dropped in DROPPED {
+            assert!(
+                peer_event_payload_count(&report, observer, peer_dropped_key(dropped)) > 0,
+                "survivor {observer} must observe PeerDropped for removed peer {dropped}: {:?}",
+                report.peer_event_payload_counts_by_peer
+            );
+        }
+    }
+    for survivor in SURVIVORS {
+        let confirmed = report
+            .final_confirmed
+            .get(survivor)
+            .copied()
+            .unwrap_or(i32::MIN);
+        assert!(
+            confirmed > 400,
+            "survivor {survivor} must keep confirming after same-step drops: {:?}",
+            report.final_confirmed
+        );
+    }
+
+    let again = run(&schedule, &RunOptions::default());
+    assert_eq!(
+        report.trace_hash, again.trace_hash,
+        "same-step multi-drop row must reproduce its exact trace"
     );
 }
 

--- a/tests/simulation/census.rs
+++ b/tests/simulation/census.rs
@@ -270,7 +270,7 @@ fn sparse_save_mode_survives_graceful_drop_rollback() {
     report.expect_pass(&schedule);
 
     let survivor_post_drop_loads: Vec<_> = report
-        .rollback_loads
+        .load_game_state_observations
         .iter()
         .filter(|load| load.step >= SPARSE_DROP_AT && [SURVIVOR_A, SURVIVOR_B].contains(&load.peer))
         .collect();
@@ -279,7 +279,7 @@ fn sparse_save_mode_survives_graceful_drop_rollback() {
             .iter()
             .any(|load| load.frame < load.step as i32),
         "sparse graceful-drop row must observe survivor LoadGameState after the drop: {:?}",
-        report.rollback_loads
+        report.load_game_state_observations
     );
     let rollbacks: u64 = report
         .metrics
@@ -346,7 +346,7 @@ fn same_step_multi_drop_after_asymmetric_block_converges() {
         );
     }
     let survivor_post_drop_loads: Vec<_> = report
-        .rollback_loads
+        .load_game_state_observations
         .iter()
         .filter(|load| load.step >= MULTI_DROP_AT && SURVIVORS.contains(&load.peer))
         .collect();
@@ -356,7 +356,7 @@ fn same_step_multi_drop_after_asymmetric_block_converges() {
                 .iter()
                 .any(|load| load.peer == survivor && load.frame < MULTI_DROP_AT as i32),
             "survivor {survivor} must load pre-drop state after same-step drops: {:?}",
-            report.rollback_loads
+            report.load_game_state_observations
         );
     }
     let rollbacks: u64 = report

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -190,6 +190,14 @@ pub struct PeerEventKey {
     pub payload: PeerEventPayload,
 }
 
+/// One `LoadGameState` request observed while driving a peer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RollbackLoadObservation {
+    pub step: u32,
+    pub peer: usize,
+    pub frame: i32,
+}
+
 /// Outcome of one simulation run.
 #[derive(Clone, Debug)]
 pub struct RunReport {
@@ -203,6 +211,10 @@ pub struct RunReport {
     pub probe_confirmed: Vec<i32>,
     /// Network delivery/drop counters.
     pub net_stats: crate::common::sim_net::SimNetStats,
+    /// Blocked-drop counts split by directed peer index pair `(from, to)`.
+    pub blocked_drops_by_link: BTreeMap<(usize, usize), u64>,
+    /// Rollback load requests observed while driving peers.
+    pub rollback_loads: Vec<RollbackLoadObservation>,
     /// Each peer's final [`SessionMetrics`] snapshot (indexed by peer).
     pub metrics: Vec<fortress_rollback::SessionMetrics>,
     /// Each peer's wire-traffic totals, aggregated over all of that peer's
@@ -631,6 +643,7 @@ fn start_hot_join_for_slot<I: SimInput>(slot: usize, step: u32, ctx: &mut HotJoi
         .with_max_prediction_window(ctx.schedule.config.max_prediction)
         .with_input_delay(0)
         .expect("hot-join input delay is fixed at zero")
+        .with_save_mode(ctx.schedule.config.save_mode.into())
         .with_desync_detection_mode(DesyncDetection::On {
             interval: ctx.schedule.config.desync_interval,
         })
@@ -936,6 +949,11 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
             "HotJoin schedules must use max_prediction >= 1 (got {})",
             schedule.config.max_prediction
         );
+        assert!(
+            n < 3 || schedule.config.save_mode == schedule::SavePolicy::EveryFrame,
+            "N-peer HotJoin schedules must use save_mode EveryFrame (got {:?})",
+            schedule.config.save_mode
+        );
     }
     let expected_links = n * (n - 1);
     assert_eq!(
@@ -1135,6 +1153,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                 .with_max_prediction_window(schedule.config.max_prediction)
                 .with_input_delay(schedule.config.input_delay)
                 .expect("valid input delay")
+                .with_save_mode(schedule.config.save_mode.into())
                 .with_desync_detection_mode(DesyncDetection::On {
                     interval: schedule.config.desync_interval,
                 })
@@ -1236,6 +1255,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
     let mut peer_event_counts: BTreeMap<EventKind, u64> = BTreeMap::new();
     let mut peer_event_counts_by_peer = vec![BTreeMap::new(); n];
     let mut peer_event_payload_counts_by_peer = vec![BTreeMap::new(); n];
+    let mut rollback_loads: Vec<RollbackLoadObservation> = Vec::new();
     let mut next_event = 0usize;
     // Per-peer stall deadline (exclusive step): peer `i` is frozen while
     // `step < stalled_until[i]`. `0` means never stalled; a `PeerStall` event
@@ -1516,6 +1536,13 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                         }
                         match slot.session.advance_frame() {
                             Ok(requests) => {
+                                if let Some(frame) = SimGameStub::<I>::loaded_frame(&requests) {
+                                    rollback_loads.push(RollbackLoadObservation {
+                                        step,
+                                        peer: i,
+                                        frame: frame.as_i32(),
+                                    });
+                                }
                                 if let Some(handoff_floor) = slot.pending_replacement_handoff_floor
                                 {
                                     if let Some(frame) =
@@ -1704,12 +1731,26 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
         spectator_required_min_frame,
     );
     let recovered_within_b = verdict.recovered_within_b;
+    let mut blocked_drops_by_link = BTreeMap::new();
+    for from in 0..n_players {
+        for to in 0..n_players {
+            if from == to {
+                continue;
+            }
+            let drops = net.blocked_drop_count(addrs[from], addrs[to]);
+            if drops > 0 {
+                blocked_drops_by_link.insert((from, to), drops);
+            }
+        }
+    }
     RunReport {
         verdict,
         trace_hash,
         final_confirmed,
         probe_confirmed,
         net_stats: net.stats(),
+        blocked_drops_by_link,
+        rollback_loads,
         metrics,
         peer_wire,
         confirmed_at_heal,
@@ -1832,6 +1873,7 @@ mod tests {
             .with_max_prediction_window(1)
             .with_input_delay(0)
             .expect("valid input delay")
+            .with_save_mode(schedule.config.save_mode.into())
             .with_desync_detection_mode(DesyncDetection::On {
                 interval: schedule.config.desync_interval,
             })
@@ -1951,6 +1993,11 @@ mod tests {
         assert_eq!(implicit.trace_hash, explicit.trace_hash);
         assert_eq!(implicit.final_confirmed, explicit.final_confirmed);
         assert_eq!(implicit.net_stats, explicit.net_stats);
+        assert_eq!(
+            implicit.blocked_drops_by_link,
+            explicit.blocked_drops_by_link
+        );
+        assert_eq!(implicit.rollback_loads, explicit.rollback_loads);
         assert_eq!(implicit.recovered_within_b, explicit.recovered_within_b);
         assert_eq!(implicit.violation_census, explicit.violation_census);
         assert_eq!(implicit.peer_event_counts, explicit.peer_event_counts);

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -192,7 +192,7 @@ pub struct PeerEventKey {
 
 /// One `LoadGameState` request observed while driving a peer.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct RollbackLoadObservation {
+pub struct LoadGameStateObservation {
     pub step: u32,
     pub peer: usize,
     pub frame: i32,
@@ -213,8 +213,8 @@ pub struct RunReport {
     pub net_stats: crate::common::sim_net::SimNetStats,
     /// Blocked-drop counts split by directed peer index pair `(from, to)`.
     pub blocked_drops_by_link: BTreeMap<(usize, usize), u64>,
-    /// Rollback load requests observed while driving peers.
-    pub rollback_loads: Vec<RollbackLoadObservation>,
+    /// `LoadGameState` requests observed while driving peers.
+    pub load_game_state_observations: Vec<LoadGameStateObservation>,
     /// Each peer's final [`SessionMetrics`] snapshot (indexed by peer).
     pub metrics: Vec<fortress_rollback::SessionMetrics>,
     /// Each peer's wire-traffic totals, aggregated over all of that peer's
@@ -1255,7 +1255,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
     let mut peer_event_counts: BTreeMap<EventKind, u64> = BTreeMap::new();
     let mut peer_event_counts_by_peer = vec![BTreeMap::new(); n];
     let mut peer_event_payload_counts_by_peer = vec![BTreeMap::new(); n];
-    let mut rollback_loads: Vec<RollbackLoadObservation> = Vec::new();
+    let mut load_game_state_observations: Vec<LoadGameStateObservation> = Vec::new();
     let mut next_event = 0usize;
     // Per-peer stall deadline (exclusive step): peer `i` is frozen while
     // `step < stalled_until[i]`. `0` means never stalled; a `PeerStall` event
@@ -1537,7 +1537,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                         match slot.session.advance_frame() {
                             Ok(requests) => {
                                 if let Some(frame) = SimGameStub::<I>::loaded_frame(&requests) {
-                                    rollback_loads.push(RollbackLoadObservation {
+                                    load_game_state_observations.push(LoadGameStateObservation {
                                         step,
                                         peer: i,
                                         frame: frame.as_i32(),
@@ -1732,15 +1732,15 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
     );
     let recovered_within_b = verdict.recovered_within_b;
     let mut blocked_drops_by_link = BTreeMap::new();
-    for from in 0..n_players {
-        for to in 0..n_players {
-            if from == to {
-                continue;
-            }
-            let drops = net.blocked_drop_count(addrs[from], addrs[to]);
-            if drops > 0 {
-                blocked_drops_by_link.insert((from, to), drops);
-            }
+    let peer_by_addr: BTreeMap<SocketAddr, usize> = addrs
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(peer, addr)| (addr, peer))
+        .collect();
+    for ((from_addr, to_addr), drops) in net.blocked_drop_counts() {
+        if let (Some(from), Some(to)) = (peer_by_addr.get(&from_addr), peer_by_addr.get(&to_addr)) {
+            blocked_drops_by_link.insert((*from, *to), drops);
         }
     }
     RunReport {
@@ -1750,7 +1750,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
         probe_confirmed,
         net_stats: net.stats(),
         blocked_drops_by_link,
-        rollback_loads,
+        load_game_state_observations,
         metrics,
         peer_wire,
         confirmed_at_heal,
@@ -1997,7 +1997,10 @@ mod tests {
             implicit.blocked_drops_by_link,
             explicit.blocked_drops_by_link
         );
-        assert_eq!(implicit.rollback_loads, explicit.rollback_loads);
+        assert_eq!(
+            implicit.load_game_state_observations,
+            explicit.load_game_state_observations
+        );
         assert_eq!(implicit.recovered_within_b, explicit.recovered_within_b);
         assert_eq!(implicit.violation_census, explicit.violation_census);
         assert_eq!(implicit.peer_event_counts, explicit.peer_event_counts);

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -17,7 +17,7 @@
 
 use crate::common::sim_net::LinkPolicy;
 use fortress_rollback::rng::{Pcg32, SeedableRng};
-use fortress_rollback::DisconnectBehavior;
+use fortress_rollback::{DisconnectBehavior, SaveMode};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -37,6 +37,26 @@ impl From<DropPolicy> for DisconnectBehavior {
         match policy {
             DropPolicy::Halt => Self::Halt,
             DropPolicy::ContinueWithout => Self::ContinueWithout,
+        }
+    }
+}
+
+/// Serializable mirror of [`SaveMode`] (the production enum does not derive
+/// serde; schedules must round-trip as corpus artifacts).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SavePolicy {
+    /// Mirror of [`SaveMode::EveryFrame`] (the library default).
+    #[default]
+    EveryFrame,
+    /// Mirror of [`SaveMode::Sparse`].
+    Sparse,
+}
+
+impl From<SavePolicy> for SaveMode {
+    fn from(policy: SavePolicy) -> Self {
+        match policy {
+            SavePolicy::EveryFrame => Self::EveryFrame,
+            SavePolicy::Sparse => Self::Sparse,
         }
     }
 }
@@ -123,6 +143,11 @@ pub struct SimConfig {
     /// replayable without a schema bump.
     #[serde(default)]
     pub disconnect_behavior: DropPolicy,
+    /// Game-state save strategy for every P2P session in the mesh.
+    /// `#[serde(default)]` (= `EveryFrame`, the library default) keeps
+    /// pre-existing corpus artifacts replayable without a schema bump.
+    #[serde(default)]
+    pub save_mode: SavePolicy,
     /// How every peer's app model reacts to `WaitRecommendation`.
     /// `#[serde(default)]` (= `Ignore`, the open-loop behavior every prior run
     /// used) keeps pre-existing corpus artifacts replayable without a bump.
@@ -182,6 +207,7 @@ impl SimConfig {
             desync_interval: 30,
             noise: BackgroundNoise::Mild,
             disconnect_behavior: DropPolicy::default(),
+            save_mode: SavePolicy::default(),
             app_model: AppModel::default(),
             clock_skew_ppm: Vec::new(),
             starve_events: Vec::new(),
@@ -803,10 +829,11 @@ mod tests {
 
     /// A corpus artifact predating the `#[serde(default)]` config axes (its
     /// `config` object lacks those fields) must deserialize to their defaults —
-    /// `app_model = Ignore` (open-loop) and `clock_skew_ppm = []` (no skew) —
-    /// so old schedules replay bit-identically. This pins the "no schema bump"
-    /// claim. Each field is asserted present-and-removed so the test can't pass
-    /// vacuously (a full config also deserializes fine).
+    /// including `save_mode = EveryFrame`, `app_model = Ignore` (open-loop), and
+    /// `clock_skew_ppm = []` (no skew) — so old schedules replay bit-identically.
+    /// This pins the "no schema bump" claim. Each field is asserted
+    /// present-and-removed so the test can't pass vacuously (a full config also
+    /// deserializes fine).
     #[test]
     fn config_without_serde_default_fields_uses_defaults() {
         let schedule = generate(42, SimConfig::smoke(2));
@@ -815,6 +842,10 @@ mod tests {
             .get_mut("config")
             .and_then(|c| c.as_object_mut())
             .expect("a serialized schedule must have a `config` object");
+        assert!(
+            config.remove("save_mode").is_some(),
+            "config must serialize a `save_mode` field for this test to remove"
+        );
         assert!(
             config.remove("app_model").is_some(),
             "config must serialize an `app_model` field for this test to remove"
@@ -836,6 +867,11 @@ mod tests {
             "config must serialize a `spectator_hosts` field for this test to remove"
         );
         let back: Schedule = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            back.config.save_mode,
+            SavePolicy::EveryFrame,
+            "a pre-axis config (no save_mode) must default to EveryFrame"
+        );
         assert_eq!(
             back.config.app_model,
             AppModel::Ignore,


### PR DESCRIPTION
## Summary

- add a serializable simulation `SavePolicy` axis and wire it into P2P harness session builders
- add harness observations for directed blocked drops and observed `LoadGameState` requests
- add premise-asserted census rows for `SaveMode::Sparse` graceful-drop rollback and same-step multi-drop after asymmetric receipt loss

## Validation

- `cargo fmt --check`
- `cargo test --test simulation sparse_save_mode_survives_graceful_drop_rollback -- --nocapture`
- `cargo test --test simulation same_step_multi_drop_after_asymmetric_block_converges -- --nocapture`
- `cargo test --test simulation census -- --nocapture`
- `cargo test --test simulation config_without_serde_default_fields_uses_defaults -- --nocapture`
- `cargo test --test simulation default_run_matches_explicit_stub_input_run -- --nocapture`
- `cargo test --test simulation census --features hot-join -- --nocapture`
- `npx markdownlint 'PLAN.md' 'progress/session-089-m3-sparse-and-multidrop-census.md' --config .markdownlint.json --fix`
- `cargo clippy --workspace --all-targets --features tokio,json`
- `python3 scripts/ci/agent-preflight.py --auto-fix`
- `cargo nextest run --no-capture` (2444 passed, 58 skipped)
- `cargo nextest run --features hot-join --no-capture` (2687 passed, 58 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulation test infrastructure and census coverage; production rollback code is only consumed via existing `SaveMode` APIs.
> 
> **Overview**
> Adds a serializable **`SavePolicy`** on simulation schedules (default **`EveryFrame`**) and wires it into P2P session builders via **`with_save_mode`**, so corpus runs can exercise **`SaveMode::Sparse`** without a schema bump.
> 
> **SimNet** now tracks **per-directed-link blocked-drop counts**; the harness maps those to peer indices on **`RunReport::blocked_drops_by_link`** and records **`LoadGameState`** requests as **`load_game_state_observations`**. Hot-join schedules with three or more peers must use **`EveryFrame`** saving.
> 
> Two **M3 §6.4 census** tests pin graceful-drop rollback under sparse saves and same-step multi-drop after asymmetric blocks, with premise checks (loads, rollbacks, **`PeerDropped`**, blocked links) plus the existing oracle and trace-hash reproducibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c26963c9a6c29a5c92462192e1fbb9a98b918d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->