### PR TITLE
Harden hot-join metrics and bounded event retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Legacy `disconnect_player` (`Halt`-style) drops, and drops on a host that does not serve hot-joins, are
     not made re-joinable.
 - Always-on session metrics: `SessionMetrics` (a cheap, `Copy`, `serde::Serialize` snapshot of cumulative
-  counters), exposed via `P2PSession::metrics()` and `SpectatorSession::metrics()`. Counters are plain
+  counters), exposed via `P2PSession::metrics()`, `SpectatorSession::metrics()`, and
+  `ReplaySession::metrics()`. Counters are plain
   integers updated inline on the paths they measure — no timers, no allocation, no `Instant` — so reads are
   deterministic and WASM-safe. The first surface is **event-queue-overflow accounting**:
   `SessionMetrics::events_discarded_total` counts events dropped because the application drained the bounded
@@ -318,14 +319,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   framing as the existing protocol messages). Byzantine peers are out of scope. The existing
   defense-in-depth — the prediction-window rollback clamp, the sparse earlier-checkpoint search, and the
   disconnect-rollback checksum invalidation/deferral — is unchanged and now mostly dormant.
-- **Pre-existing:** Event-queue overflow no longer discards events **silently**. When the bounded event
-  queue exceeds its configured size the session still drops the oldest events (unchanged retention — that
-  policy is revisited separately), but each drop is now recorded in `SessionMetrics` (see *Added*) and a
+- **Pre-existing:** Event-queue overflow no longer discards events **silently** or evicts routine and
+  safety-relevant notifications indiscriminately. P2P, spectator, and replay sessions all enforce the
+  configured bound. When an event arrives at capacity, sessions first discard the oldest queued routine
+  progress/advisory event, if one exists, and retain the new arrival. If the queue contains only durable
+  events, an incoming routine event is discarded; an incoming durable event replaces the oldest durable
+  event to preserve the hard allocation bound. Each drop is recorded in `SessionMetrics` (see *Added*) and a
   rate-limited `Warning`/`NetworkProtocol` violation is reported once per overflow episode (re-armed each
   time the application drains events), so a churn burst warns once rather than once per message. Previously the
   oldest event — even a safety-critical `Disconnected` or `DesyncDetected` — was dropped with no violation
   and no counter, so an application draining events slower than they arrive could miss a disconnect or a
-  desync with no way to detect the loss. Both `P2PSession` and `SpectatorSession` are covered. The cap is
+  desync with no way to detect the loss. `P2PSession`, `SpectatorSession`, and `ReplaySession` are covered.
+  The cap is
   now enforced at **every** event-emission path — including events raised from `advance_frame` (wait
   recommendations, desync detection), `remove_player`/`disconnect_player`, and the hot-join lifecycle —
   not only when an inbound message is handled, so the queue can no longer sit above its configured size

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -847,6 +847,23 @@ fn handle_event(event: FortressEvent<GameConfig>) {
 }
 ```
 
+### Bounded Event Retention
+
+P2P, spectator, and replay sessions keep events in a bounded queue (100 events
+by default, configurable with `with_event_queue_size`). When an event arrives at
+capacity, Fortress Rollback evicts the oldest queued routine progress or advisory
+event first. If the queue contains only durable events, an incoming routine event
+is discarded; an incoming durable event replaces the oldest durable event.
+Routine events are `Synchronizing`,
+`WaitRecommendation`, `InputDelayRecommendation`, and (with hot join)
+`JoinRequested`. All other event kinds are durable.
+
+The bound always wins, and relative order among retained events does not change. Read
+`SessionMetrics::events_discarded_total` and `events_discarded_by_kind` to detect
+loss, and compare `event_queue_high_water` with the configured cap when sizing
+the queue. Drain `events()` regularly; increasing the cap reduces burst loss but
+does not create backpressure or guarantee unlimited retention.
+
 ---
 
 ## Determinism Requirements
@@ -3407,7 +3424,7 @@ This section documents all configuration options available when building a sessi
 | `with_spectator_config(config)`          | `SpectatorConfig::default()`  | Spectator session behavior                                                                         |
 | `with_time_sync_config(config)`          | `TimeSyncConfig::default()`   | Time synchronization averaging                                                                     |
 | `with_input_queue_config(config)`        | `InputQueueConfig::default()` | Input queue buffer sizing                                                                          |
-| `with_event_queue_size(size)`            | 100                           | Maximum buffered events before dropping                                                            |
+| `with_event_queue_size(size)`            | 100                           | Hard event bound; queued routine first, else incoming routine or oldest durable is discarded        |
 | `with_max_frames_behind(frames)`         | 10                            | When spectator starts catching up                                                                  |
 | `with_catchup_speed(speed)`              | 1                             | Frames per step when spectator catches up                                                          |
 | `with_sparse_saving_mode(bool)`          | `false`                       | Deprecated: use `with_save_mode()` instead                                                         |

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -297,9 +297,11 @@ impl Serialize for RollbackDepthHistogram {
 
 /// A cumulative snapshot of session-level metrics.
 ///
-/// In normal use you read a snapshot from [`P2PSession::metrics`] or
-/// [`SpectatorSession::metrics`]; every counter is monotonic for the life of the
-/// session and cheap to read (the type is `Copy`).
+/// In normal use you read a snapshot from [`P2PSession::metrics`],
+/// [`SpectatorSession::metrics`], or [`ReplaySession::metrics`]. Cumulative
+/// counters and high-water marks are monotonic for the life of the session;
+/// current-value gauges may move in either direction. Every snapshot is cheap to
+/// read (the type is `Copy`).
 ///
 /// This type is `#[non_exhaustive]`: future library versions may add counters
 /// without a breaking change, so it cannot be built with a struct literal
@@ -307,13 +309,14 @@ impl Serialize for RollbackDepthHistogram {
 ///
 /// # Which counters each session type populates
 ///
-/// The rollback and pacing counters (everything except the
-/// `events_discarded_*` family) are populated by [`P2PSession`]. A
-/// [`SpectatorSession`] shares this type but currently records only the
-/// event-discard counters (plus its own `frames_behind_host`, exposed
-/// separately); its rollback/pacing counters stay at their default `0`.
+/// Rollback, pacing, checksum, and checksum-history counters are populated by
+/// [`P2PSession`]. [`SpectatorSession`] and [`ReplaySession`] populate
+/// `event_queue_high_water` plus the `events_discarded_*` counters; their other
+/// fields stay at the default `0`. Spectators expose `frames_behind_host`
+/// separately.
 ///
 /// [`P2PSession`]: crate::P2PSession
+/// [`ReplaySession`]: crate::ReplaySession
 /// [`SpectatorSession`]: crate::SpectatorSession
 ///
 /// # Example
@@ -326,6 +329,7 @@ impl Serialize for RollbackDepthHistogram {
 /// ```
 ///
 /// [`P2PSession::metrics`]: crate::P2PSession::metrics
+/// [`ReplaySession::metrics`]: crate::ReplaySession::metrics
 /// [`SpectatorSession::metrics`]: crate::SpectatorSession::metrics
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/src/sessions/builder.rs
+++ b/src/sessions/builder.rs
@@ -61,8 +61,9 @@ const DEFAULT_MAX_FRAMES_BEHIND: usize = 10;
 // The amount of frames the spectator advances in a single step if too far behind
 const DEFAULT_CATCHUP_SPEED: usize = 1;
 /// Default event queue size.
-/// Events older than this threshold may be dropped if not polled.
-const DEFAULT_EVENT_QUEUE_SIZE: usize = 100;
+/// At capacity, the oldest queued routine is evicted first. Otherwise an incoming
+/// routine is discarded or an incoming durable replaces the oldest durable.
+pub(crate) const DEFAULT_EVENT_QUEUE_SIZE: usize = 100;
 
 /// The [`SessionBuilder`] builds all Fortress Rollback Sessions.
 ///
@@ -101,7 +102,7 @@ where
     time_sync_config: TimeSyncConfig,
     /// Configuration for input queue sizing.
     input_queue_config: InputQueueConfig,
-    /// Maximum number of events to queue before oldest are dropped.
+    /// Hard event-queue bound; queued routine events are evicted first at capacity.
     event_queue_size: usize,
     /// Whether to enable replay recording during P2P sessions.
     recording: bool,
@@ -967,10 +968,15 @@ impl<T: Config> SessionBuilder<T> {
         self
     }
 
-    /// Sets the maximum number of events to queue before oldest are dropped.
+    /// Sets the maximum number of events retained by the bounded event queue.
     ///
-    /// When the event queue exceeds this size, the oldest events are discarded.
-    /// This provides backpressure if the application isn't consuming events quickly enough.
+    /// When an event arrives at capacity, the oldest queued routine
+    /// progress/advisory event is discarded first. If the queue contains only
+    /// durable events, an incoming routine event is discarded; an incoming
+    /// durable event replaces the oldest durable event to preserve the hard
+    /// allocation bound. This does not apply backpressure to session processing; inspect
+    /// [`SessionMetrics::events_discarded_total`](crate::SessionMetrics::events_discarded_total)
+    /// to detect an undersized queue.
     ///
     /// # Arguments
     ///
@@ -979,6 +985,9 @@ impl<T: Config> SessionBuilder<T> {
     /// # Errors
     ///
     /// Returns a [`FortressError`] if `size` is less than 10.
+    /// Session construction can subsequently return an allocation error (or
+    /// `None` for spectator constructors) if this many event slots cannot be
+    /// reserved.
     ///
     /// # Example
     ///
@@ -1841,8 +1850,8 @@ impl<T: Config> SessionBuilder<T> {
     ///
     /// # Returns
     /// Returns `None` if the protocol or spectator configuration is invalid,
-    /// or if protocol initialization fails (e.g., due to serialization issues
-    /// with the Input type).
+    /// protocol initialization fails (e.g., due to serialization issues with
+    /// the Input type), or the configured event queue cannot be reserved.
     pub fn start_spectator_session(
         self,
         host_addr: T::Address,
@@ -1899,8 +1908,9 @@ impl<T: Config> SessionBuilder<T> {
     /// # Returns
     ///
     /// Returns `None` if `host_addrs` is empty, if the protocol or spectator
-    /// configuration is invalid, or if protocol initialization fails for any address
-    /// (e.g. due to serialization issues with the Input type).
+    /// configuration is invalid, protocol initialization fails for any address
+    /// (e.g. due to serialization issues with the Input type), or the configured
+    /// event queue cannot be reserved.
     ///
     /// # Example
     ///
@@ -2039,8 +2049,10 @@ impl<T: Config> SessionBuilder<T> {
     /// frame by frame when [`advance_frame`](crate::Session::advance_frame)
     /// is called. No network, save/load, or local input is needed.
     ///
-    /// The builder is consumed but most configuration is ignored since
-    /// replay playback does not require networking or synchronization.
+    /// The builder is consumed but most configuration is ignored since replay
+    /// playback does not require networking or synchronization. The configured
+    /// event-queue size and violation observer are retained for bounded replay
+    /// validation events.
     ///
     /// # Example
     ///
@@ -2078,12 +2090,18 @@ impl<T: Config> SessionBuilder<T> {
     /// # Errors
     ///
     /// Returns an error if the replay fails internal consistency validation
-    /// (see [`Replay::validate`]).
+    /// (see [`Replay::validate`]) or the configured event queue cannot be
+    /// reserved.
     pub fn start_replay_session(
         self,
         replay: Replay<T::Input>,
     ) -> crate::FortressResult<ReplaySession<T>> {
-        ReplaySession::new(replay)
+        ReplaySession::new_with_options(
+            replay,
+            false,
+            self.event_queue_size,
+            self.violation_observer,
+        )
     }
 
     /// Creates a replay playback session with checksum validation enabled.
@@ -2135,12 +2153,18 @@ impl<T: Config> SessionBuilder<T> {
     /// # Errors
     ///
     /// Returns an error if the replay fails internal consistency validation
-    /// (see [`Replay::validate`]).
+    /// (see [`Replay::validate`]) or the configured event queue cannot be
+    /// reserved.
     pub fn start_replay_session_with_validation(
         self,
         replay: Replay<T::Input>,
     ) -> crate::FortressResult<ReplaySession<T>> {
-        ReplaySession::new_with_validation(replay)
+        ReplaySession::new_with_options(
+            replay,
+            true,
+            self.event_queue_size,
+            self.violation_observer,
+        )
     }
 
     fn create_endpoint(
@@ -2356,7 +2380,7 @@ mod tests {
     #[test]
     fn test_with_event_queue_size_accepts_valid_values() {
         // Test various valid values
-        for size in [10, 50, 100, 200, 500, usize::MAX] {
+        for size in [10, 50, 100, 200, 500] {
             let builder = SessionBuilder::<TestConfig>::new()
                 .with_event_queue_size(size)
                 .expect("Valid event queue size should be accepted");
@@ -2529,6 +2553,17 @@ mod tests {
     }
 
     #[test]
+    fn start_p2p_session_reports_event_queue_allocation_failure() {
+        let err = single_local_builder()
+            .with_event_queue_size(usize::MAX)
+            .expect("configuration accepts platform-sized caps")
+            .start_p2p_session(DummySocket)
+            .unwrap_err();
+
+        assert_allocation_failed(err, "p2p.event_queue");
+    }
+
+    #[test]
     fn start_p2p_session_reports_time_sync_allocation_failure() {
         let err = SessionBuilder::<TestConfig>::new()
             .with_num_players(2)
@@ -2571,6 +2606,48 @@ mod tests {
             .start_spectator_session(test_addr(7_500), DummySocket);
 
         assert!(session.is_none());
+    }
+
+    #[test]
+    fn start_spectator_session_returns_none_when_event_queue_reservation_fails() {
+        let session = SessionBuilder::<TestConfig>::new()
+            .with_num_players(2)
+            .unwrap()
+            .with_event_queue_size(usize::MAX)
+            .unwrap()
+            .start_spectator_session(test_addr(7_501), DummySocket);
+
+        assert!(session.is_none());
+    }
+
+    #[test]
+    fn replay_builders_report_event_queue_allocation_failure() {
+        use crate::replay::{Replay, ReplayMetadata};
+
+        for validate_checksums in [false, true] {
+            let replay = Replay::<TestInput> {
+                num_players: 1,
+                frames: vec![vec![TestInput { inp: 0 }]],
+                checksums: vec![Some(1)],
+                metadata: ReplayMetadata {
+                    library_version: "test".to_string(),
+                    num_players: 1,
+                    total_frames: 1,
+                    skipped_frames: 0,
+                },
+            };
+            let builder = SessionBuilder::<TestConfig>::new()
+                .with_event_queue_size(usize::MAX)
+                .unwrap();
+            let err = if validate_checksums {
+                builder.start_replay_session_with_validation(replay)
+            } else {
+                builder.start_replay_session(replay)
+            }
+            .unwrap_err();
+
+            assert_allocation_failed(err, "replay.event_queue");
+        }
     }
 
     #[test]

--- a/src/sessions/event_drain.rs
+++ b/src/sessions/event_drain.rs
@@ -1,7 +1,96 @@
-use std::collections::vec_deque::Drain;
+use std::collections::{vec_deque::Drain, VecDeque};
 use std::iter::FusedIterator;
 
-use crate::{Config, FortressEvent};
+use crate::{Config, EventKind, FortressEvent};
+
+/// Whether an event should survive queue pressure ahead of routine updates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EventRetention {
+    Routine,
+    Durable,
+}
+
+/// Classifies every public event kind for bounded-queue retention.
+///
+/// Routine progress and advisory events may be superseded by newer observations.
+/// Durable events describe lifecycle changes, link-state transitions, or faults
+/// that applications commonly need to act on.
+const fn event_retention(kind: EventKind) -> EventRetention {
+    match kind {
+        EventKind::Synchronizing
+        | EventKind::WaitRecommendation
+        | EventKind::InputDelayRecommendation => EventRetention::Routine,
+        EventKind::Synchronized
+        | EventKind::Disconnected
+        | EventKind::NetworkInterrupted
+        | EventKind::NetworkResumed
+        | EventKind::DesyncDetected
+        | EventKind::SyncTimeout
+        | EventKind::ReplayDesync
+        | EventKind::SpectatorDivergence
+        | EventKind::PeerDropped => EventRetention::Durable,
+        #[cfg(feature = "hot-join")]
+        EventKind::JoinRequested => EventRetention::Routine,
+        #[cfg(feature = "hot-join")]
+        EventKind::PeerJoined => EventRetention::Durable,
+    }
+}
+
+/// Removes one event to restore a bounded queue after overflow.
+///
+/// The oldest routine event is removed first, wherever it sits in the queue.
+/// If the queue contains only durable events, the oldest durable event is
+/// removed: bounded allocation remains mandatory even during a fault storm.
+/// Relative order among all retained events is preserved.
+#[cfg(test)]
+pub(crate) fn remove_event_for_overflow<T: Config>(
+    queue: &mut VecDeque<FortressEvent<T>>,
+) -> Option<FortressEvent<T>> {
+    let routine_index = queue
+        .iter()
+        .position(|event| event_retention(event.kind()) == EventRetention::Routine);
+    match routine_index {
+        Some(index) => queue.remove(index),
+        None => queue.pop_front(),
+    }
+}
+
+/// Inserts an event without ever letting the queue exceed its reserved cap.
+///
+/// Callers reserve `cap` elements fallibly during session construction. At
+/// capacity, this removes the oldest queued routine event and inserts the new
+/// event when one exists. Otherwise it rejects an incoming routine event, or
+/// removes the oldest durable event before inserting an incoming durable event.
+/// The returned event is exactly the rejected incoming event or removed queued
+/// event. Thus every insertion stays within the reservation and cannot trigger
+/// growth. A zero cap rejects every event.
+pub(crate) fn enqueue_event_bounded<T: Config>(
+    queue: &mut VecDeque<FortressEvent<T>>,
+    cap: usize,
+    event: FortressEvent<T>,
+) -> Option<FortressEvent<T>> {
+    if cap == 0 {
+        return Some(event);
+    }
+    if queue.len() >= cap {
+        if let Some(routine_index) = queue
+            .iter()
+            .position(|queued| event_retention(queued.kind()) == EventRetention::Routine)
+        {
+            let dropped = queue.remove(routine_index);
+            queue.push_back(event);
+            return dropped;
+        }
+        if event_retention(event.kind()) == EventRetention::Routine {
+            return Some(event);
+        }
+        let dropped = queue.pop_front();
+        queue.push_back(event);
+        return dropped;
+    }
+    queue.push_back(event);
+    None
+}
 
 /// A zero-allocation opaque iterator that drains events from a session.
 ///
@@ -10,8 +99,8 @@ use crate::{Config, FortressEvent};
 /// [`Iterator`], [`DoubleEndedIterator`], [`ExactSizeIterator`], and [`FusedIterator`].
 ///
 /// Obtain an `EventDrain` by calling [`P2PSession::events()`],
-/// [`SpectatorSession::events()`], [`SyncTestSession::events()`], or the
-/// [`Session::events()`] trait method.
+/// [`SpectatorSession::events()`], [`ReplaySession::events()`],
+/// [`SyncTestSession::events()`], or the [`Session::events()`] trait method.
 ///
 /// # Examples
 ///
@@ -27,6 +116,7 @@ use crate::{Config, FortressEvent};
 /// ```
 ///
 /// [`P2PSession::events()`]: crate::P2PSession::events
+/// [`ReplaySession::events()`]: crate::ReplaySession::events
 /// [`SpectatorSession::events()`]: crate::SpectatorSession::events
 /// [`SyncTestSession::events()`]: crate::SyncTestSession::events
 /// [`Session::events()`]: crate::Session::events
@@ -127,6 +217,114 @@ mod tests {
 
     fn make_event(skip: u32) -> FortressEvent<TestConfig> {
         FortressEvent::WaitRecommendation { skip_frames: skip }
+    }
+
+    fn addr(port: u16) -> SocketAddr {
+        ([127, 0, 0, 1], port).into()
+    }
+
+    #[test]
+    fn event_retention_classifies_every_kind() {
+        let cases = [
+            (EventKind::Synchronizing, EventRetention::Routine),
+            (EventKind::Synchronized, EventRetention::Durable),
+            (EventKind::Disconnected, EventRetention::Durable),
+            (EventKind::NetworkInterrupted, EventRetention::Durable),
+            (EventKind::NetworkResumed, EventRetention::Durable),
+            (EventKind::WaitRecommendation, EventRetention::Routine),
+            (EventKind::DesyncDetected, EventRetention::Durable),
+            (EventKind::SyncTimeout, EventRetention::Durable),
+            (EventKind::ReplayDesync, EventRetention::Durable),
+            (EventKind::SpectatorDivergence, EventRetention::Durable),
+            (EventKind::InputDelayRecommendation, EventRetention::Routine),
+            (EventKind::PeerDropped, EventRetention::Durable),
+        ];
+        assert_eq!(cases.len(), 12);
+        for (kind, expected) in cases {
+            assert_eq!(
+                event_retention(kind),
+                expected,
+                "classification for {kind:?}"
+            );
+        }
+
+        #[cfg(feature = "hot-join")]
+        {
+            assert_eq!(EventKind::COUNT, 14);
+            assert_eq!(
+                event_retention(EventKind::JoinRequested),
+                EventRetention::Routine
+            );
+            assert_eq!(
+                event_retention(EventKind::PeerJoined),
+                EventRetention::Durable
+            );
+        }
+    }
+
+    #[test]
+    fn overflow_removes_oldest_routine_and_preserves_relative_order() {
+        let durable_a = FortressEvent::Synchronized { addr: addr(7001) };
+        let routine_a = make_event(1);
+        let durable_b = FortressEvent::Disconnected { addr: addr(7002) };
+        let routine_b = make_event(2);
+        let mut queue = VecDeque::from([durable_a, routine_a, durable_b, routine_b]);
+
+        assert_eq!(remove_event_for_overflow(&mut queue), Some(routine_a));
+        assert_eq!(
+            queue,
+            VecDeque::from([durable_a, durable_b, routine_b]),
+            "removing a middle event must preserve FIFO order among survivors"
+        );
+        assert_eq!(remove_event_for_overflow(&mut queue), Some(routine_b));
+        assert_eq!(queue, VecDeque::from([durable_a, durable_b]));
+    }
+
+    #[test]
+    fn routine_arrival_cannot_displace_full_durable_queue() {
+        let durable_a = FortressEvent::Synchronized { addr: addr(7011) };
+        let durable_b = FortressEvent::Disconnected { addr: addr(7012) };
+        let routine = make_event(3);
+        let mut queue = VecDeque::from([durable_a, durable_b]);
+
+        assert_eq!(enqueue_event_bounded(&mut queue, 2, routine), Some(routine));
+        assert_eq!(queue, VecDeque::from([durable_a, durable_b]));
+    }
+
+    #[test]
+    fn durable_arrival_to_full_durable_queue_drops_oldest_and_stays_bounded() {
+        let peer_dropped: FortressEvent<TestConfig> = FortressEvent::PeerDropped {
+            handle: crate::PlayerHandle::new(1),
+            addr: addr(7021),
+        };
+        let disconnected = FortressEvent::Disconnected { addr: addr(7021) };
+        let synchronized = FortressEvent::Synchronized { addr: addr(7022) };
+        let mut queue = VecDeque::from([peer_dropped, disconnected]);
+
+        assert_eq!(
+            enqueue_event_bounded(&mut queue, 2, synchronized),
+            Some(peer_dropped),
+            "a durable-only queue must still stay bounded by dropping its oldest event"
+        );
+        assert_eq!(queue, VecDeque::from([disconnected, synchronized]));
+    }
+
+    #[test]
+    fn bounded_enqueue_pre_evicts_without_exceeding_reserved_capacity() {
+        let mut queue = VecDeque::new();
+        queue.try_reserve_exact(2).expect("test queue reserves");
+        let capacity = queue.capacity();
+        let durable = FortressEvent::Disconnected { addr: addr(7031) };
+        assert_eq!(enqueue_event_bounded(&mut queue, 2, durable), None);
+        assert_eq!(enqueue_event_bounded(&mut queue, 2, make_event(1)), None);
+
+        assert_eq!(
+            enqueue_event_bounded(&mut queue, 2, make_event(2)),
+            Some(make_event(1))
+        );
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.capacity(), capacity, "bounded insert must not grow");
+        assert_eq!(queue, VecDeque::from([durable, make_event(2)]));
     }
 
     #[test]

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -7905,11 +7905,11 @@ impl<T: Config> P2PSession<T> {
 
         // everyone is synchronized, so we can change state and accept input
         self.state = SessionState::Running;
-        // A hot-join joiner that was fail-closed to `Synchronizing` mid-handshake
-        // (before applying a snapshot) resumes to `Running` here rather than via
-        // the snapshot-apply sites — instrument this path too so a joiner's
-        // `hot_join_metrics().completed` is never stuck false while `Running`.
-        // Idempotent and a no-op for a non-joiner.
+        // Defensive hot-join metrics coverage. Durable fail-closed joiners are
+        // rejected above and the reachable joiner transitions record at their
+        // snapshot-apply sites. Keep this idempotent call so a future valid
+        // synchronization path cannot leave a Running joiner's metrics partial;
+        // it remains a no-op for ordinary sessions.
         #[cfg(feature = "hot-join")]
         self.record_hot_join_activation();
     }
@@ -23216,6 +23216,12 @@ mod tests {
             let mut duo = mesh_with_dropped_slot_public_api(600, 6);
             let mut c2 = RealJoiner::new_public(&duo.bus.clone(), &duo.clock.clone());
             assert_eq!(c2.session.current_state(), SessionState::HotJoining);
+            let metrics_before = c2
+                .session
+                .hot_join_metrics()
+                .expect("the public N-peer joiner has hot-join metrics");
+            assert!(!metrics_before.completed);
+            assert_eq!(metrics_before.millis_to_running, 0);
             assert!(matches!(
                 c2.session.advance_frame(),
                 Err(FortressError::NotSynchronized)
@@ -23268,6 +23274,19 @@ mod tests {
                 saw_buffered,
                 "the joiner observably buffered before the commit (late-apply lifecycle)"
             );
+            let completed_metrics = c2
+                .session
+                .hot_join_metrics()
+                .expect("the public N-peer joiner retains hot-join metrics");
+            assert!(completed_metrics.completed);
+            assert!(
+                completed_metrics.polls_to_running > 1,
+                "the public N-peer join spans multiple polls: {completed_metrics:?}"
+            );
+            assert!(
+                completed_metrics.millis_to_running > 0,
+                "the injected clock advances during the public N-peer join: {completed_metrics:?}"
+            );
 
             // Un-defer-all at the apply: every remote endpoint.
             for endpoint in c2.session.player_reg.remotes.values() {
@@ -23280,6 +23299,11 @@ mod tests {
             // First advance: [LoadGameState(S), AdvanceFrame(bridge)] -> real
             // from F.
             let requests = c2.session.advance_frame().expect("post-commit advance");
+            assert_eq!(
+                c2.session.hot_join_metrics(),
+                Some(completed_metrics),
+                "completed N-peer hot-join metrics stay stable after later session work"
+            );
             assert_eq!(requests.len(), 2, "load + bridge advance, in order");
             assert!(matches!(
                 requests.first(),

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -13,6 +13,7 @@ use crate::safe_frame_sub;
 #[cfg(feature = "hot-join")]
 use crate::sessions::config::ClockFn;
 use crate::sessions::config::{DisconnectBehavior, ProtocolConfig, SaveMode};
+use crate::sessions::event_drain::enqueue_event_bounded;
 use crate::sessions::player_registry::PlayerRegistry;
 use crate::sessions::session_trait::Session;
 use crate::sessions::sync_health::SyncHealth;
@@ -51,11 +52,11 @@ const RECOMMENDATION_INTERVAL: Frame = Frame::new(60);
 /// and provides enough time for network conditions to improve.
 const MIN_RECOMMENDATION: u32 = 3;
 
-/// Default maximum number of events to queue before oldest are dropped.
+/// Default maximum number of retained events.
 ///
 /// This prevents unbounded memory growth if events aren't being consumed.
 /// At 100 events, there's ample buffer for typical network jitter while
-/// providing backpressure if the application isn't processing events.
+/// bounding memory if the application isn't processing events.
 ///
 /// Note: This constant documents the default; the actual value is now
 /// configurable via SessionBuilder::with_event_queue_size().
@@ -219,7 +220,7 @@ where
     telemetry: Option<Arc<dyn SessionTelemetry>>,
     /// Protocol configuration for network behavior.
     protocol_config: ProtocolConfig,
-    /// Maximum number of events to queue before oldest are dropped.
+    /// Hard event-queue bound; routine events are discarded first on overflow.
     max_event_queue_size: usize,
     /// Optional replay recorder for capturing confirmed inputs.
     recording: Option<ReplayRecorder<T::Input>>,
@@ -942,6 +943,11 @@ impl<T: Config> P2PSession<T> {
             save_mode
         };
 
+        let mut event_queue = VecDeque::new();
+        event_queue
+            .try_reserve_exact(event_queue_size)
+            .map_err(|_err| allocation_failed("p2p.event_queue", event_queue_size))?;
+
         Ok(Self {
             state,
             num_players,
@@ -955,7 +961,7 @@ impl<T: Config> P2PSession<T> {
             sync_layer,
             disconnect_frame: Frame::NULL,
             player_reg: players,
-            event_queue: VecDeque::new(),
+            event_queue,
             local_inputs: BTreeMap::new(),
             desync_detection,
             local_checksum_history: BTreeMap::new(),
@@ -1682,8 +1688,7 @@ impl<T: Config> P2PSession<T> {
                 },
             );
 
-            self.event_queue
-                .push_back(FortressEvent::JoinRequested { handle, addr });
+            self.enqueue_event(FortressEvent::JoinRequested { handle, addr });
         }
 
         // Phase 2: the SOLE snapshot-send site (reliable retransmit). Send the
@@ -1809,8 +1814,7 @@ impl<T: Config> P2PSession<T> {
             self.hot_join.joining.remove(&handle);
             self.hot_join.reserved_slots.remove(&handle);
 
-            self.event_queue
-                .push_back(FortressEvent::PeerJoined { handle, addr });
+            self.enqueue_event(FortressEvent::PeerJoined { handle, addr });
         }
 
         // Phase 4: abort any serve that has been open too long. The slot stays in
@@ -1849,9 +1853,6 @@ impl<T: Config> P2PSession<T> {
         // phases above are unaffected.
         self.poll_npeer_host_serve();
         self.poll_npeer_post_serve();
-        // JoinRequested/PeerJoined above are emitted during poll, outside
-        // `handle_event`'s trim; bound the queue (D9 telemetry must cover them).
-        self.trim_event_queue();
     }
 
     /// Returns the **survivor set** for a prospective N-peer serve: the
@@ -2070,10 +2071,7 @@ impl<T: Config> P2PSession<T> {
             polls_since_serve: 0,
         });
 
-        self.event_queue
-            .push_back(FortressEvent::JoinRequested { handle, addr });
-        // Runs during poll outside `handle_event`'s trim; bound the queue.
-        self.trim_event_queue();
+        self.enqueue_event(FortressEvent::JoinRequested { handle, addr });
     }
 
     /// Returns `true` while a freeze-frame convergence re-adjust whose forced
@@ -2482,12 +2480,10 @@ impl<T: Config> P2PSession<T> {
             resends_left: NPEER_JOIN_LIFECYCLE_RESENDS,
         });
 
-        self.event_queue.push_back(FortressEvent::PeerJoined {
+        self.enqueue_event(FortressEvent::PeerJoined {
             handle,
             addr: joiner_addr,
         });
-        // Runs during poll outside `handle_event`'s trim; bound the queue.
-        self.trim_event_queue();
     }
 
     /// Concludes an N-peer serve unsuccessfully: announces `JoinAborted` to the
@@ -5038,10 +5034,7 @@ impl<T: Config> P2PSession<T> {
         // (Running-arm only, latched once per incarnation), and endpoint
         // events never survive a poll's drain. Apps should treat a repeated
         // coordinator `Disconnected` as an idempotent teardown cue.
-        self.event_queue
-            .push_back(FortressEvent::Disconnected { addr: host_addr });
-        // Runs during poll outside `handle_event`'s trim; bound the queue.
-        self.trim_event_queue();
+        self.enqueue_event(FortressEvent::Disconnected { addr: host_addr });
     }
 
     /// Post-apply late-sync backfill (S34 fix round 1, discovered finding
@@ -5529,17 +5522,13 @@ impl<T: Config> P2PSession<T> {
             }
             .into());
         }
-        let result = self.disconnect_player_with_policy(
+        self.disconnect_player_with_policy(
             player_handle,
             None,
             DisconnectBehavior::ContinueWithout,
             DisconnectEventPolicy::Emit,
             GracefulDropFailurePolicy::Abort,
-        );
-        // `remove_player` emits PeerDropped/Disconnected outside `handle_event`'s
-        // trim; bound the queue before returning control to the caller (D9).
-        self.trim_event_queue();
-        result
+        )
     }
 
     /// Disconnects a remote player and all other remote players with the same address from the session.
@@ -5633,8 +5622,6 @@ impl<T: Config> P2PSession<T> {
                         DisconnectEventPolicy::Suppress,
                         GracefulDropFailurePolicy::DisconnectAndHalt,
                     );
-                    // Emitted outside `handle_event`'s trim; bound the queue (D9).
-                    self.trim_event_queue();
                     return result;
                 }
                 Err(InvalidRequestKind::AlreadyDisconnected {
@@ -5645,7 +5632,6 @@ impl<T: Config> P2PSession<T> {
             // disconnecting spectators is simpler
             Some(PlayerType::Spectator(_)) => {
                 self.disconnect_player_at_frame(player_handle, Frame::NULL);
-                self.trim_event_queue();
                 Ok(())
             },
         }
@@ -6056,21 +6042,23 @@ impl<T: Config> P2PSession<T> {
         self.state
     }
 
-    /// Returns all events that happened since last queried for events. If the
-    /// number of stored events exceeds the configured event queue size, the
-    /// oldest events will be discarded.
+    /// Returns all events that happened since last queried for events. When an
+    /// event arrives at capacity, the oldest queued routine progress/advisory
+    /// event is discarded first. If only durable events are queued, an incoming
+    /// routine is discarded; an incoming durable replaces the oldest durable.
     #[must_use = "events should be handled to react to session state changes"]
     pub fn events(&mut self) -> EventDrain<'_, T> {
-        // Draining starts a new overflow episode: re-arm the rate-limited
-        // event-queue-overflow warning (see `trim_event_queue`).
+        // Draining starts a new overflow episode: re-arm the warning emitted by
+        // `record_event_discard` when a bounded enqueue discards an event.
         self.event_discard_warned = false;
         EventDrain::from_drain(self.event_queue.drain(..))
     }
 
     /// Returns a snapshot of this session's cumulative [`SessionMetrics`].
     ///
-    /// Counters are always-on, monotonic for the life of the session, and cheap
-    /// to read (the returned value is `Copy`). The first surface is event-queue
+    /// Cumulative counters and high-water marks are always-on and monotonic for
+    /// the life of the session; current-value gauges may move in either
+    /// direction. The returned snapshot is cheap to read (`Copy`). The first surface is event-queue
     /// overflow accounting: a non-zero
     /// [`events_discarded_total`](SessionMetrics::events_discarded_total) means
     /// the application is draining [`events`](Self::events) slower than they
@@ -7300,7 +7288,7 @@ impl<T: Config> P2PSession<T> {
             }
             let freeze_frame = freeze_frames.get(&handle).copied().unwrap_or(Frame::NULL);
             self.sync_layer.freeze_player(handle, freeze_frame)?;
-            self.event_queue.push_back(FortressEvent::PeerDropped {
+            self.enqueue_event(FortressEvent::PeerDropped {
                 handle,
                 addr: addr.clone(),
             });
@@ -7462,8 +7450,31 @@ impl<T: Config> P2PSession<T> {
         event_policy: DisconnectEventPolicy,
         graceful_failure_policy: GracefulDropFailurePolicy,
     ) -> Result<(), FortressError> {
+        self.disconnect_player_with_policy_tracked(
+            player_handle,
+            last_frame_overrides,
+            behavior,
+            event_policy,
+            graceful_failure_policy,
+        )
+        .0
+    }
+
+    /// Applies a disconnect and reports whether this call emitted its terminal
+    /// `Disconnected` event, even when graceful-drop cleanup returns an error.
+    fn disconnect_player_with_policy_tracked(
+        &mut self,
+        player_handle: PlayerHandle,
+        last_frame_overrides: Option<&BTreeMap<PlayerHandle, Frame>>,
+        behavior: DisconnectBehavior,
+        event_policy: DisconnectEventPolicy,
+        graceful_failure_policy: GracefulDropFailurePolicy,
+    ) -> (Result<(), FortressError>, bool) {
         let (addr, handles, earliest_last_frame) =
-            self.remote_disconnect_snapshot(player_handle, last_frame_overrides)?;
+            match self.remote_disconnect_snapshot(player_handle, last_frame_overrides) {
+                Ok(snapshot) => snapshot,
+                Err(error) => return (Err(error), false),
+            };
         let confirmed_before_disconnect = self.confirmed_frame();
 
         let mut graceful_drop_error = None;
@@ -7494,7 +7505,7 @@ impl<T: Config> P2PSession<T> {
             && graceful_failure_policy == GracefulDropFailurePolicy::Abort
         {
             if let Some(e) = graceful_drop_error {
-                return Err(e);
+                return (Err(e), false);
             }
         }
 
@@ -7523,16 +7534,16 @@ impl<T: Config> P2PSession<T> {
             self.enter_fail_closed_disconnect_state_at(confirmed_before_disconnect);
         }
 
-        if event_policy == DisconnectEventPolicy::Emit {
-            self.event_queue
-                .push_back(FortressEvent::Disconnected { addr });
+        let disconnected_emitted = event_policy == DisconnectEventPolicy::Emit;
+        if disconnected_emitted {
+            self.enqueue_event(FortressEvent::Disconnected { addr });
         }
 
         if let Some(e) = graceful_drop_error {
-            return Err(e);
+            return (Err(e), disconnected_emitted);
         }
 
-        Ok(())
+        (Ok(()), disconnected_emitted)
     }
 
     /// Re-arms a cleanly gracefully-dropped slot so a returning peer can hot-join
@@ -9396,11 +9407,6 @@ impl<T: Config> P2PSession<T> {
                 self.enter_fail_closed_disconnect_state_at(confirmed_ceiling);
             }
         }
-        // Propagated auto-disconnects (disconnect_timeout + ContinueWithout) emit
-        // PeerDropped/Disconnected here, inside `advance_frame` and outside
-        // `handle_event`'s trim; bound the queue so they can't exceed the cap
-        // (or defer the D9 discard telemetry) before the next poll.
-        self.trim_event_queue();
     }
 
     /// Gather average frame advantage from each remote player endpoint and return the maximum.
@@ -9440,13 +9446,9 @@ impl<T: Config> P2PSession<T> {
             // frames_ahead is guaranteed to be >= MIN_RECOMMENDATION (positive), so try_into should succeed.
             // Using unwrap_or(0) as defense-in-depth; 0 effectively skips the recommendation.
             let skip_frames = self.frames_ahead.try_into().unwrap_or(0);
-            self.event_queue
-                .push_back(FortressEvent::WaitRecommendation { skip_frames });
+            self.enqueue_event(FortressEvent::WaitRecommendation { skip_frames });
             self.metrics.record_wait_recommendation();
         }
-        // This runs from `advance_frame`, outside `handle_event`'s trim, so bound
-        // the queue here too (D9: overflow must stay accounted + telemetered).
-        self.trim_event_queue();
     }
 
     fn check_last_saved_state(
@@ -9635,7 +9637,7 @@ impl<T: Config> P2PSession<T> {
                 total_requests_sent,
                 elapsed_ms,
             } => {
-                self.event_queue.push_back(FortressEvent::Synchronizing {
+                self.enqueue_event(FortressEvent::Synchronizing {
                     addr,
                     total,
                     count,
@@ -9645,22 +9647,19 @@ impl<T: Config> P2PSession<T> {
             },
             // forward to user
             Event::NetworkInterrupted { disconnect_timeout } => {
-                self.event_queue
-                    .push_back(FortressEvent::NetworkInterrupted {
-                        addr,
-                        disconnect_timeout,
-                    });
+                self.enqueue_event(FortressEvent::NetworkInterrupted {
+                    addr,
+                    disconnect_timeout,
+                });
             },
             // forward to user
             Event::NetworkResumed => {
-                self.event_queue
-                    .push_back(FortressEvent::NetworkResumed { addr });
+                self.enqueue_event(FortressEvent::NetworkResumed { addr });
             },
             // check if all remotes are synced, then forward to user
             Event::Synchronized => {
                 self.check_initial_sync();
-                self.event_queue
-                    .push_back(FortressEvent::Synchronized { addr });
+                self.enqueue_event(FortressEvent::Synchronized { addr });
             },
             // disconnect the player, then forward to user
             Event::Disconnected => {
@@ -9763,23 +9762,23 @@ impl<T: Config> P2PSession<T> {
                         addr,
                         player_handles
                     );
-                    self.event_queue
-                        .push_back(FortressEvent::Disconnected { addr });
+                    self.enqueue_event(FortressEvent::Disconnected { addr });
                     return;
                 };
-                let event_count_before_disconnect = self.event_queue.len();
                 // `resolve_disconnect_handle` only returns Remote or Spectator handles, never
                 // Local; the registry-missing case is also filtered upstream. The catch-all
                 // arm is therefore an invariant guard rather than a regular branch.
                 match self.player_reg.handles.get(&target_handle) {
                     Some(PlayerType::Remote(_)) => {
-                        if let Err(e) = self.disconnect_player_with_policy(
-                            target_handle,
-                            None,
-                            self.disconnect_behavior,
-                            DisconnectEventPolicy::Emit,
-                            GracefulDropFailurePolicy::DisconnectAndHalt,
-                        ) {
+                        let (result, disconnected_emitted) = self
+                            .disconnect_player_with_policy_tracked(
+                                target_handle,
+                                None,
+                                self.disconnect_behavior,
+                                DisconnectEventPolicy::Emit,
+                                GracefulDropFailurePolicy::DisconnectAndHalt,
+                            );
+                        if let Err(e) = result {
                             report_violation!(
                                 ViolationSeverity::Error,
                                 ViolationKind::InternalError,
@@ -9789,9 +9788,8 @@ impl<T: Config> P2PSession<T> {
                                 player_handles,
                                 e
                             );
-                            if self.event_queue.len() == event_count_before_disconnect {
-                                self.event_queue
-                                    .push_back(FortressEvent::Disconnected { addr });
+                            if !disconnected_emitted {
+                                self.enqueue_event(FortressEvent::Disconnected { addr });
                             }
                             // Fail closed: a remote endpoint reported a
                             // disconnect that we could not fully apply.
@@ -9802,8 +9800,7 @@ impl<T: Config> P2PSession<T> {
                     },
                     Some(PlayerType::Spectator(_)) => {
                         self.disconnect_player_at_frame(target_handle, Frame::NULL);
-                        self.event_queue
-                            .push_back(FortressEvent::Disconnected { addr });
+                        self.enqueue_event(FortressEvent::Disconnected { addr });
                     },
                     Some(PlayerType::Local) | None => {
                         report_violation!(
@@ -9814,10 +9811,7 @@ impl<T: Config> P2PSession<T> {
                             addr,
                             player_handles
                         );
-                        if self.event_queue.len() == event_count_before_disconnect {
-                            self.event_queue
-                                .push_back(FortressEvent::Disconnected { addr });
-                        }
+                        self.enqueue_event(FortressEvent::Disconnected { addr });
                         // Registry state is reported as potentially corrupt;
                         // fail closed rather than continue advancing on a
                         // disconnect observation we could not apply.
@@ -9840,8 +9834,7 @@ impl<T: Config> P2PSession<T> {
                 {
                     return;
                 }
-                self.event_queue
-                    .push_back(FortressEvent::SyncTimeout { addr, elapsed_ms });
+                self.enqueue_event(FortressEvent::SyncTimeout { addr, elapsed_ms });
             },
             // add the input and all associated information
             Event::Input { input, player, .. } => {
@@ -9913,14 +9906,8 @@ impl<T: Config> P2PSession<T> {
         }
     }
 
-    /// Handles a protocol event and then enforces the event-queue cap.
-    ///
-    /// The cap (and its D9 overflow telemetry) is applied here, after
-    /// [`handle_event_inner`](Self::handle_event_inner) returns through *any*
-    /// path — including its early returns (e.g. an unresolvable disconnect that
-    /// emits `Disconnected` then returns) — so an event emitted just before an
-    /// early return cannot leave the queue above its configured size or defer
-    /// the discard accounting.
+    /// Handles a protocol event. Every emission is bounded and accounted inline,
+    /// including emissions immediately before an early return.
     fn handle_event(
         &mut self,
         event: Event<T>,
@@ -9928,47 +9915,32 @@ impl<T: Config> P2PSession<T> {
         addr: T::Address,
     ) {
         self.handle_event_inner(event, player_handles, addr);
-        self.trim_event_queue();
     }
 
-    /// Bounds the event queue to `max_event_queue_size`, dropping the oldest
-    /// events first.
-    ///
-    /// Overflow means the application is draining events slower than they
-    /// arrive; the dropped events are lost. This used to happen silently
-    /// (defect D9) — a discarded [`FortressEvent::Disconnected`] or
-    /// [`FortressEvent::DesyncDetected`] left no trace. Every drop is now
-    /// recorded in [`SessionMetrics`] (total + per-[`EventKind`](crate::metrics::EventKind)),
-    /// and one rate-limited `Warning` violation is reported per overflow episode so the
-    /// loss is observable via the metrics snapshot and any registered violation
-    /// observer.
-    ///
-    /// The `Warning` is rate-limited to at most once between drains: the flag is
-    /// cleared in [`events`](Self::events), so a churn burst that overflows on
-    /// many messages within one poll produces a single `Warning`, not one per
-    /// message, while the always-incrementing counters keep the full history.
-    fn trim_event_queue(&mut self) {
-        // Sample the queue length before trimming to capture the true peak
-        // (including any just-pushed overflow) as the high-water mark.
-        self.metrics.observe_event_queue_len(self.event_queue.len());
-        let mut discarded = 0u64;
-        while self.event_queue.len() > self.max_event_queue_size {
-            if let Some(dropped) = self.event_queue.pop_front() {
-                self.metrics.record_event_discard(dropped.kind());
-                discarded += 1;
-            } else {
-                break;
-            }
+    /// Enqueues within the fallibly reserved hard cap: evict the oldest queued
+    /// routine first; otherwise discard an incoming routine or replace the oldest
+    /// durable with an incoming durable.
+    fn enqueue_event(&mut self, event: FortressEvent<T>) {
+        if let Some(dropped) =
+            enqueue_event_bounded(&mut self.event_queue, self.max_event_queue_size, event)
+        {
+            self.record_event_discard(dropped);
         }
-        if discarded > 0 && !self.event_discard_warned {
+        self.metrics.observe_event_queue_len(self.event_queue.len());
+    }
+
+    fn record_event_discard(&mut self, dropped: FortressEvent<T>) {
+        self.metrics.record_event_discard(dropped.kind());
+        if !self.event_discard_warned {
             self.event_discard_warned = true;
             report_violation!(
                 ViolationSeverity::Warning,
                 ViolationKind::NetworkProtocol,
-                "event queue overflow: discarding undrained event(s) (queue cap {}); \
+                "event queue overflow at capacity: evicting the oldest queued routine first; \
+                 otherwise discarding an incoming routine or replacing the oldest durable with \
+                 an incoming durable (queue cap {}); \
                  drain events every poll or raise the event-queue size to avoid losing \
-                 notifications (possibly Disconnected/DesyncDetected). See \
-                 SessionMetrics::events_discarded_total for the running count",
+                 notifications. See SessionMetrics::events_discarded_total for the running count",
                 self.max_event_queue_size
             );
         }
@@ -9991,12 +9963,28 @@ impl<T: Config> P2PSession<T> {
                             self.metrics
                                 .record_checksum_comparison(local_checksum == remote_checksum);
                             if local_checksum != remote_checksum {
-                                self.event_queue.push_back(FortressEvent::DesyncDetected {
+                                let event = FortressEvent::DesyncDetected {
                                     frame: remote_frame,
                                     local_checksum,
                                     remote_checksum,
                                     addr: remote.peer_addr(),
-                                });
+                                };
+                                if let Some(dropped) = enqueue_event_bounded(
+                                    &mut self.event_queue,
+                                    self.max_event_queue_size,
+                                    event,
+                                ) {
+                                    self.metrics.record_event_discard(dropped.kind());
+                                    if !self.event_discard_warned {
+                                        self.event_discard_warned = true;
+                                        report_violation!(
+                                            ViolationSeverity::Warning,
+                                            ViolationKind::NetworkProtocol,
+                                            "event queue overflow at capacity: evicting the oldest queued routine first; otherwise discarding an incoming routine or replacing the oldest durable with an incoming durable (queue cap {}); drain events every poll or raise the event-queue size to avoid losing notifications. See SessionMetrics::events_discarded_total for the running count",
+                                            self.max_event_queue_size
+                                        );
+                                    }
+                                }
                                 // B3 (Byzantine hardening): track per-peer
                                 // mismatch persistence. On a confirmed frame a
                                 // mismatch is a genuine divergence in the
@@ -10057,10 +10045,7 @@ impl<T: Config> P2PSession<T> {
             },
             DesyncDetection::Off => (),
         }
-        // The `DesyncDetected` pushes above run from `advance_frame`, outside
-        // `handle_event`'s trim; bound the queue so the overflow accounting and
-        // telemetry (D9) cover them too.
-        self.trim_event_queue();
+        self.metrics.observe_event_queue_len(self.event_queue.len());
     }
 
     fn check_checksum_send_interval(&mut self) {
@@ -10396,7 +10381,7 @@ mod tests {
     }
 
     /// Regression for defect D9 (PLAN.md §2): event-queue overflow used to
-    /// discard the oldest event — even a safety-critical `Disconnected` — with
+    /// discard the oldest event — even a durable `Disconnected` — with
     /// **zero** telemetry (no violation, no counter, nothing an application
     /// could use to learn an event was lost). The M2 metrics layer makes the
     /// loss observable: every discarded event increments [`SessionMetrics`]
@@ -10420,7 +10405,7 @@ mod tests {
         // Nothing discarded before the overflow.
         assert_eq!(session.metrics().events_discarded_total, 0);
 
-        // Canary: an undrained Disconnected event at the front of the queue.
+        // Canary: an undrained durable Disconnected event at the front.
         session
             .event_queue
             .push_back(FortressEvent::Disconnected { addr });
@@ -10444,18 +10429,18 @@ mod tests {
         assert_eq!(
             session.event_queue.len(),
             session.max_event_queue_size,
-            "queue must be trimmed to its cap"
+            "bounded enqueue must keep the queue at its cap"
         );
         let disconnected_still_queued = session
             .event_queue
             .iter()
             .any(|e| matches!(e, FortressEvent::Disconnected { .. }));
         assert!(
-            !disconnected_still_queued,
-            "the Disconnected canary must have been evicted by the overflow trim"
+            disconnected_still_queued,
+            "routine churn must not evict the durable Disconnected canary"
         );
 
-        // GREEN (D9 fixed): the loss is recorded, not silent.
+        // The routine event selected for eviction is still fully attributed.
         let metrics = session.metrics();
         assert!(
             metrics.events_discarded_total >= 1,
@@ -10465,9 +10450,16 @@ mod tests {
         assert_eq!(
             metrics
                 .events_discarded_by_kind
-                .get(EventKind::Disconnected),
+                .get(EventKind::Synchronizing),
             1,
-            "the safety-critical Disconnected canary must be attributed to its kind"
+            "the oldest routine Synchronizing event must be attributed to its kind"
+        );
+        assert_eq!(
+            metrics
+                .events_discarded_by_kind
+                .get(EventKind::Disconnected),
+            0,
+            "the retained Disconnected canary must not be counted as discarded"
         );
         // And a rate-limited Warning/NetworkProtocol violation was reported.
         let violations = observer.violations();
@@ -10478,6 +10470,41 @@ mod tests {
                     && v.kind == ViolationKind::NetworkProtocol
                     && v.message.contains("event queue overflow")),
             "expected a rate-limited overflow Warning; observed: {violations:?}"
+        );
+    }
+
+    #[test]
+    fn saturated_disconnect_error_emits_one_terminal_event() {
+        let mut session = SessionBuilder::<TestConfig>::new()
+            .with_num_players(2)
+            .unwrap()
+            .with_disconnect_behavior(DisconnectBehavior::ContinueWithout)
+            .with_event_queue_size(10)
+            .unwrap()
+            .add_player(PlayerType::Local, PlayerHandle::new(0))
+            .unwrap()
+            .add_player(PlayerType::Remote(test_addr(8080)), PlayerHandle::new(1))
+            .unwrap()
+            .start_p2p_session(DummySocket)
+            .unwrap();
+        let addr = test_addr(8080);
+
+        for _ in 0..session.max_event_queue_size {
+            session.enqueue_event(FortressEvent::Synchronized { addr });
+        }
+        session.sync_layer.truncate_input_queues_for_test(1);
+
+        session.handle_event(Event::Disconnected, Arc::from([PlayerHandle::new(1)]), addr);
+
+        assert_eq!(session.event_queue.len(), session.max_event_queue_size);
+        assert_eq!(
+            session
+                .event_queue
+                .iter()
+                .filter(|event| matches!(event, FortressEvent::Disconnected { addr: event_addr } if *event_addr == addr))
+                .count(),
+            1,
+            "an emitted-then-error disconnect must not be duplicated when pre-eviction keeps the saturated queue length unchanged"
         );
     }
 
@@ -10495,8 +10522,8 @@ mod tests {
             Arc::clone(&observer) as Arc<dyn crate::telemetry::ViolationObserver>
         );
 
-        // Overflow the queue on many separate messages (each `handle_event`
-        // trims), all within a single drain gap.
+        // Overflow the queue on many separate messages, all within a single
+        // drain gap. Each event is bounded and accounted at its enqueue site.
         let burst = |session: &mut P2PSession<TestConfig>| {
             for _ in 0..(session.max_event_queue_size + 5) {
                 session.handle_event(
@@ -10578,11 +10605,10 @@ mod tests {
         }
 
         // Saturate the event queue with benign events first.
-        let filler = test_addr(9999);
         for _ in 0..session.max_event_queue_size {
             session
                 .event_queue
-                .push_back(FortressEvent::NetworkResumed { addr: filler });
+                .push_back(FortressEvent::WaitRecommendation { skip_frames: 1 });
         }
         assert_eq!(session.event_queue.len(), session.max_event_queue_size);
         let before = session.metrics().events_discarded_total;
@@ -10599,29 +10625,42 @@ mod tests {
             session.metrics().events_discarded_total > before,
             "the overflow discard from the DesyncDetected push must be counted"
         );
+        assert!(
+            session
+                .event_queue
+                .iter()
+                .any(|event| matches!(event, FortressEvent::DesyncDetected { .. })),
+            "the durable DesyncDetected event must displace routine filler"
+        );
+        assert_eq!(
+            session
+                .metrics()
+                .events_discarded_by_kind
+                .get(crate::metrics::EventKind::WaitRecommendation),
+            1,
+            "the evicted routine filler must be attributed"
+        );
     }
 
     /// `handle_event` has early-return paths that emit an event then return
     /// before the handler's normal end (e.g. a `Disconnected` for an endpoint
-    /// with no resolvable handles). The cap must still hold: `handle_event`
-    /// wraps `handle_event_inner` and trims after **every** exit, so an
-    /// early-return emission cannot escape the cap or the D9 accounting.
+    /// with no resolvable handles). The bounded enqueue at the emission site
+    /// must enforce the cap and D9 accounting before that return.
     #[test]
-    fn handle_event_early_return_emission_is_bounded_by_wrapper_trim() {
+    fn handle_event_early_return_emission_is_bounded_at_enqueue() {
         let mut session = create_two_player_session();
 
         // Saturate the queue.
-        let filler = test_addr(9998);
         for _ in 0..session.max_event_queue_size {
             session
                 .event_queue
-                .push_back(FortressEvent::NetworkResumed { addr: filler });
+                .push_back(FortressEvent::WaitRecommendation { skip_frames: 1 });
         }
         assert_eq!(session.event_queue.len(), session.max_event_queue_size);
         let before = session.metrics().events_discarded_total;
 
         // A `Disconnected` for an unregistered address with only a local handle
-        // resolves to no target, taking the early-return branch that pushes a
+        // resolves to no target, taking the early-return branch that enqueues a
         // `Disconnected` event and returns before the handler's normal end.
         let unknown = test_addr(9997);
         session.handle_event(
@@ -10633,11 +10672,25 @@ mod tests {
         assert_eq!(
             session.event_queue.len(),
             session.max_event_queue_size,
-            "the wrapper trim must bound handle_event's early-return emission paths"
+            "bounded enqueue must cover handle_event's early-return emission paths"
         );
         assert!(
             session.metrics().events_discarded_total > before,
             "the early-return emission's overflow discard must be counted"
+        );
+        assert!(
+            session.event_queue.iter().any(
+                |event| matches!(event, FortressEvent::Disconnected { addr } if *addr == unknown)
+            ),
+            "the durable Disconnected event must survive routine filler pressure"
+        );
+        assert_eq!(
+            session
+                .metrics()
+                .events_discarded_by_kind
+                .get(crate::metrics::EventKind::WaitRecommendation),
+            1,
+            "the oldest routine filler must be attributed"
         );
     }
 

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -9921,29 +9921,41 @@ impl<T: Config> P2PSession<T> {
     /// routine first; otherwise discard an incoming routine or replace the oldest
     /// durable with an incoming durable.
     fn enqueue_event(&mut self, event: FortressEvent<T>) {
-        if let Some(dropped) =
-            enqueue_event_bounded(&mut self.event_queue, self.max_event_queue_size, event)
-        {
-            self.record_event_discard(dropped);
-        }
-        self.metrics.observe_event_queue_len(self.event_queue.len());
+        Self::enqueue_event_fields(
+            &mut self.event_queue,
+            self.max_event_queue_size,
+            &mut self.metrics,
+            &mut self.event_discard_warned,
+            event,
+        );
     }
 
-    fn record_event_discard(&mut self, dropped: FortressEvent<T>) {
-        self.metrics.record_event_discard(dropped.kind());
-        if !self.event_discard_warned {
-            self.event_discard_warned = true;
-            report_violation!(
-                ViolationSeverity::Warning,
-                ViolationKind::NetworkProtocol,
-                "event queue overflow at capacity: evicting the oldest queued routine first; \
-                 otherwise discarding an incoming routine or replacing the oldest durable with \
-                 an incoming durable (queue cap {}); \
-                 drain events every poll or raise the event-queue size to avoid losing \
-                 notifications. See SessionMetrics::events_discarded_total for the running count",
-                self.max_event_queue_size
-            );
+    /// Field-level enqueue used when another field of the session is already
+    /// mutably borrowed (notably a remote endpoint during checksum comparison).
+    fn enqueue_event_fields(
+        event_queue: &mut VecDeque<FortressEvent<T>>,
+        max_event_queue_size: usize,
+        metrics: &mut SessionMetrics,
+        event_discard_warned: &mut bool,
+        event: FortressEvent<T>,
+    ) {
+        if let Some(dropped) = enqueue_event_bounded(event_queue, max_event_queue_size, event) {
+            metrics.record_event_discard(dropped.kind());
+            if !*event_discard_warned {
+                *event_discard_warned = true;
+                report_violation!(
+                    ViolationSeverity::Warning,
+                    ViolationKind::NetworkProtocol,
+                    "event queue overflow at capacity: evicting the oldest queued routine first; \
+                     otherwise discarding an incoming routine or replacing the oldest durable with \
+                     an incoming durable (queue cap {}); \
+                     drain events every poll or raise the event-queue size to avoid losing \
+                     notifications. See SessionMetrics::events_discarded_total for the running count",
+                    max_event_queue_size
+                );
+            }
         }
+        metrics.observe_event_queue_len(event_queue.len());
     }
 
     fn compare_local_checksums_against_peers(&mut self) {
@@ -9969,22 +9981,13 @@ impl<T: Config> P2PSession<T> {
                                     remote_checksum,
                                     addr: remote.peer_addr(),
                                 };
-                                if let Some(dropped) = enqueue_event_bounded(
+                                Self::enqueue_event_fields(
                                     &mut self.event_queue,
                                     self.max_event_queue_size,
+                                    &mut self.metrics,
+                                    &mut self.event_discard_warned,
                                     event,
-                                ) {
-                                    self.metrics.record_event_discard(dropped.kind());
-                                    if !self.event_discard_warned {
-                                        self.event_discard_warned = true;
-                                        report_violation!(
-                                            ViolationSeverity::Warning,
-                                            ViolationKind::NetworkProtocol,
-                                            "event queue overflow at capacity: evicting the oldest queued routine first; otherwise discarding an incoming routine or replacing the oldest durable with an incoming durable (queue cap {}); drain events every poll or raise the event-queue size to avoid losing notifications. See SessionMetrics::events_discarded_total for the running count",
-                                            self.max_event_queue_size
-                                        );
-                                    }
-                                }
+                                );
                                 // B3 (Byzantine hardening): track per-peer
                                 // mismatch persistence. On a confirmed frame a
                                 // mismatch is a genuine divergence in the
@@ -10045,7 +10048,6 @@ impl<T: Config> P2PSession<T> {
             },
             DesyncDetection::Off => (),
         }
-        self.metrics.observe_event_queue_len(self.event_queue.len());
     }
 
     fn check_checksum_send_interval(&mut self) {

--- a/src/sessions/p2p_spectator_session.rs
+++ b/src/sessions/p2p_spectator_session.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::error::{allocation_failed, try_reserve_hint};
+#[cfg(test)]
+use crate::sessions::event_drain::remove_event_for_overflow;
 use crate::{
     frame_info::PlayerInput,
     network::{
@@ -10,6 +12,7 @@ use crate::{
         protocol::{Event, UdpProtocol},
     },
     report_violation, report_violation_to,
+    sessions::event_drain::enqueue_event_bounded,
     sessions::session_trait::Session,
     telemetry::{ViolationKind, ViolationObserver, ViolationSeverity},
     Config, EventDrain, FortressError, FortressEvent, FortressRequest, FortressResult, Frame,
@@ -173,7 +176,7 @@ where
     state_buffer: Vec<GameStateCell<T::State>>,
     /// Optional observer for specification violations.
     violation_observer: Option<Arc<dyn ViolationObserver>>,
-    /// Maximum number of events to queue before oldest are dropped.
+    /// Hard event-queue bound; routine events are discarded first on overflow.
     max_event_queue_size: usize,
     /// Cumulative, always-on session metrics (see [`SpectatorSession::metrics`]).
     metrics: SessionMetrics,
@@ -307,6 +310,11 @@ impl<T: Config> SpectatorSession<T> {
             canonical_hosts.push(None);
         }
 
+        let mut event_queue = VecDeque::new();
+        event_queue
+            .try_reserve_exact(event_queue_size)
+            .map_err(|_err| allocation_failed("spectator.event_queue", event_queue_size))?;
+
         Ok(Self {
             state: SessionState::Synchronizing,
             num_players,
@@ -319,7 +327,7 @@ impl<T: Config> SpectatorSession<T> {
             host_drop_witness,
             host_status_epoch,
             canonical_hosts,
-            event_queue: VecDeque::new(),
+            event_queue,
             current_frame: Frame::NULL,
             last_recv_frame: Frame::NULL,
             max_frames_behind,
@@ -579,21 +587,23 @@ impl<T: Config> SpectatorSession<T> {
         .into())
     }
 
-    /// Returns all events that happened since last queried for events. If the
-    /// number of stored events exceeds the configured event queue size, the
-    /// oldest events will be discarded.
+    /// Returns all events that happened since last queried for events. When an
+    /// event arrives at capacity, the oldest queued routine progress/advisory
+    /// event is discarded first. If only durable events are queued, an incoming
+    /// routine is discarded; an incoming durable replaces the oldest durable.
     #[must_use = "events should be handled to react to session state changes"]
     pub fn events(&mut self) -> EventDrain<'_, T> {
-        // Draining starts a new overflow episode: re-arm the rate-limited
-        // event-queue-overflow warning (see `trim_event_queue`).
+        // Draining starts a new overflow episode: re-arm the warning emitted by
+        // `record_event_discard` when a bounded enqueue discards an event.
         self.event_discard_warned = false;
         EventDrain::from_drain(self.event_queue.drain(..))
     }
 
     /// Returns a snapshot of this spectator's cumulative [`SessionMetrics`].
     ///
-    /// Counters are always-on, monotonic for the life of the session, and cheap
-    /// to read (the returned value is `Copy`). A non-zero
+    /// Cumulative counters and high-water marks are always-on and monotonic for
+    /// the life of the session; current-value gauges may move in either
+    /// direction. The returned snapshot is cheap to read (`Copy`). A non-zero
     /// [`events_discarded_total`](SessionMetrics::events_discarded_total) means
     /// the application is draining [`events`](Self::events) slower than they
     /// arrive and has lost notifications.
@@ -1341,23 +1351,24 @@ impl<T: Config> SpectatorSession<T> {
             player,
             frame
         );
-        self.event_queue
-            .push_back(FortressEvent::SpectatorDivergence {
-                frame,
-                player,
-                primary_addr,
-                conflicting_addr,
-            });
+        self.enqueue_event(FortressEvent::SpectatorDivergence {
+            frame,
+            player,
+            primary_addr,
+            conflicting_addr,
+        });
         self.spectator_divergence = Some(SpectatorDivergenceState {
             frame,
             player,
             _marker: std::marker::PhantomData,
         });
-        self.trim_event_queue();
     }
 
-    /// Bounds the event queue to `max_event_queue_size`, dropping the oldest
-    /// events first.
+    /// Corrects a test queue that is already over `max_event_queue_size`, dropping
+    /// the oldest queued routine first, or the oldest durable if none is routine.
+    /// Production enqueue retains the incoming event's identity: at capacity it
+    /// evicts the oldest queued routine first; otherwise it discards an incoming
+    /// routine or replaces the oldest durable with an incoming durable.
     ///
     /// Overflow means the application is draining events slower than they
     /// arrive; the dropped events are lost. This used to happen silently
@@ -1367,23 +1378,41 @@ impl<T: Config> SpectatorSession<T> {
     /// on each [`events`](Self::events) drain) so the loss is observable via
     /// [`metrics`](Self::metrics) and any registered violation observer without
     /// flooding on a churn burst.
+    #[cfg(test)]
     fn trim_event_queue(&mut self) {
-        let mut discarded = 0u64;
         while self.event_queue.len() > self.max_event_queue_size {
-            if let Some(dropped) = self.event_queue.pop_front() {
-                self.metrics.record_event_discard(dropped.kind());
-                discarded += 1;
+            if let Some(dropped) = remove_event_for_overflow(&mut self.event_queue) {
+                self.record_event_discard(dropped);
             } else {
                 break;
             }
         }
-        if discarded > 0 && !self.event_discard_warned {
+        self.metrics.observe_event_queue_len(self.event_queue.len());
+    }
+
+    /// Enqueues within the fallibly reserved hard cap: evict the oldest queued
+    /// routine first; otherwise discard an incoming routine or replace the oldest
+    /// durable with an incoming durable.
+    fn enqueue_event(&mut self, event: FortressEvent<T>) {
+        if let Some(dropped) =
+            enqueue_event_bounded(&mut self.event_queue, self.max_event_queue_size, event)
+        {
+            self.record_event_discard(dropped);
+        }
+        self.metrics.observe_event_queue_len(self.event_queue.len());
+    }
+
+    fn record_event_discard(&mut self, dropped: FortressEvent<T>) {
+        self.metrics.record_event_discard(dropped.kind());
+        if !self.event_discard_warned {
             self.event_discard_warned = true;
             report_violation_to!(
                 &self.violation_observer,
                 ViolationSeverity::Warning,
                 ViolationKind::NetworkProtocol,
-                "spectator event queue overflow: discarding undrained event(s) (queue cap {}); \
+                "spectator event queue overflow at capacity: evicting the oldest queued routine \
+                 first; otherwise discarding an incoming routine or replacing the oldest durable \
+                 with an incoming durable (queue cap {}); \
                  drain events every poll or raise the event-queue size to avoid losing \
                  notifications. See SessionMetrics::events_discarded_total for the running count",
                 self.max_event_queue_size
@@ -2098,7 +2127,7 @@ impl<T: Config> SpectatorSession<T> {
                 total_requests_sent,
                 elapsed_ms,
             } => {
-                self.event_queue.push_back(FortressEvent::Synchronizing {
+                self.enqueue_event(FortressEvent::Synchronizing {
                     addr,
                     total,
                     count,
@@ -2108,35 +2137,30 @@ impl<T: Config> SpectatorSession<T> {
             },
             // forward to user
             Event::NetworkInterrupted { disconnect_timeout } => {
-                self.event_queue
-                    .push_back(FortressEvent::NetworkInterrupted {
-                        addr,
-                        disconnect_timeout,
-                    });
+                self.enqueue_event(FortressEvent::NetworkInterrupted {
+                    addr,
+                    disconnect_timeout,
+                });
             },
             // forward to user
             Event::NetworkResumed => {
-                self.event_queue
-                    .push_back(FortressEvent::NetworkResumed { addr });
+                self.enqueue_event(FortressEvent::NetworkResumed { addr });
             },
             // synced with a host, then forward to user. The first host to sync flips
             // the session to Running; subsequent hosts are idempotent.
             Event::Synchronized => {
                 self.state = SessionState::Running;
-                self.event_queue
-                    .push_back(FortressEvent::Synchronized { addr });
+                self.enqueue_event(FortressEvent::Synchronized { addr });
             },
             // disconnect the host, then forward to user. The host is removed by the
             // caller after all events have been handled.
             Event::Disconnected => {
                 disconnected_host = Some(host_index);
-                self.event_queue
-                    .push_back(FortressEvent::Disconnected { addr });
+                self.enqueue_event(FortressEvent::Disconnected { addr });
             },
             // forward sync timeout to user
             Event::SyncTimeout { elapsed_ms } => {
-                self.event_queue
-                    .push_back(FortressEvent::SyncTimeout { addr, elapsed_ms });
+                self.enqueue_event(FortressEvent::SyncTimeout { addr, elapsed_ms });
             },
             // add the input and all associated information
             Event::Input {
@@ -2147,9 +2171,6 @@ impl<T: Config> SpectatorSession<T> {
                 self.handle_host_input(host_index, input, player, peer_connect_status, addr);
             },
         }
-
-        // check event queue size and discard oldest events if too big
-        self.trim_event_queue();
 
         disconnected_host
     }
@@ -2644,15 +2665,19 @@ mod tests {
         assert_eq!(session.metrics().events_discarded_total, 0);
 
         let addr = test_addr(9000);
-        // Canary at the front: a safety-critical Disconnected.
+        // Canary at the front: a durable Disconnected.
         session
             .event_queue
             .push_back(FortressEvent::Disconnected { addr });
-        // Push past the cap with benign events so the canary overflows out.
+        // Push past the cap with routine events; they must be selected first.
         for _ in 0..session.max_event_queue_size {
             session
                 .event_queue
-                .push_back(FortressEvent::NetworkResumed { addr });
+                .push_back(FortressEvent::InputDelayRecommendation {
+                    player_handle: PlayerHandle::new(0),
+                    current_delay: 0,
+                    suggested_delay: 1,
+                });
         }
         session.trim_event_queue();
 
@@ -2660,6 +2685,18 @@ mod tests {
             session.event_queue.len(),
             session.max_event_queue_size,
             "queue must be trimmed to its cap"
+        );
+        assert_eq!(
+            session.metrics().event_queue_high_water,
+            u64::try_from(session.max_event_queue_size).unwrap_or(u64::MAX),
+            "bounded enqueue high-water must never exceed the configured cap"
+        );
+        assert!(
+            session
+                .event_queue
+                .iter()
+                .any(|event| matches!(event, FortressEvent::Disconnected { .. })),
+            "routine churn must not evict the durable Disconnected canary"
         );
         let metrics = session.metrics();
         assert!(
@@ -2670,9 +2707,16 @@ mod tests {
         assert_eq!(
             metrics
                 .events_discarded_by_kind
-                .get(EventKind::Disconnected),
+                .get(EventKind::InputDelayRecommendation),
             1,
-            "the safety-critical Disconnected canary must be attributed to its kind"
+            "the oldest routine recommendation must be attributed to its kind"
+        );
+        assert_eq!(
+            metrics
+                .events_discarded_by_kind
+                .get(EventKind::Disconnected),
+            0,
+            "the retained Disconnected canary must not be counted as discarded"
         );
         let violations = observer.violations();
         assert!(
@@ -2703,7 +2747,6 @@ mod tests {
             .start_spectator_session(test_addr(7101), DummySocket)
             .expect("spectator session builds");
 
-        let addr = test_addr(9001);
         let overflow_warnings = |observer: &CollectingObserver| {
             observer
                 .violations()
@@ -2721,7 +2764,11 @@ mod tests {
             for _ in 0..(session.max_event_queue_size + 1) {
                 session
                     .event_queue
-                    .push_back(FortressEvent::NetworkResumed { addr });
+                    .push_back(FortressEvent::InputDelayRecommendation {
+                        player_handle: PlayerHandle::new(0),
+                        current_delay: 0,
+                        suggested_delay: 1,
+                    });
             }
             session.trim_event_queue();
         }
@@ -2741,7 +2788,11 @@ mod tests {
         for _ in 0..(session.max_event_queue_size + 1) {
             session
                 .event_queue
-                .push_back(FortressEvent::NetworkResumed { addr });
+                .push_back(FortressEvent::InputDelayRecommendation {
+                    player_handle: PlayerHandle::new(0),
+                    current_delay: 0,
+                    suggested_delay: 1,
+                });
         }
         session.trim_event_queue();
         assert_eq!(

--- a/src/sessions/replay_session.rs
+++ b/src/sessions/replay_session.rs
@@ -58,14 +58,19 @@
 
 use std::collections::VecDeque;
 use std::fmt;
+use std::sync::Arc;
 
 use crate::error::allocation_failed;
 use crate::replay::Replay;
+use crate::sessions::builder::DEFAULT_EVENT_QUEUE_SIZE;
+use crate::sessions::event_drain::enqueue_event_bounded;
 use crate::sessions::session_trait::Session;
 use crate::sync_layer::GameStateCell;
+use crate::telemetry::{ViolationKind, ViolationObserver, ViolationSeverity};
 use crate::{
-    Config, EventDrain, FortressError, FortressEvent, FortressRequest, FortressResult, Frame,
-    InputStatus, InputVec, InvalidRequestKind, PlayerHandle, RequestVec, SessionState,
+    report_violation_to, Config, EventDrain, FortressError, FortressEvent, FortressRequest,
+    FortressResult, Frame, InputStatus, InputVec, InvalidRequestKind, PlayerHandle, RequestVec,
+    SessionMetrics, SessionState,
 };
 
 /// A session that plays back a recorded [`Replay`] deterministically.
@@ -135,6 +140,15 @@ where
     current_frame: Frame,
     /// Event queue for desync detection and other events.
     event_queue: VecDeque<FortressEvent<T>>,
+    /// Hard event-queue bound, configured by `SessionBuilder` or the shared
+    /// default for direct constructors.
+    max_event_queue_size: usize,
+    /// Event overflow counters and high-water mark.
+    metrics: SessionMetrics,
+    /// Whether this drain gap already reported its rate-limited overflow warning.
+    event_discard_warned: bool,
+    /// Optional session-specific violation observer supplied by the builder.
+    violation_observer: Option<Arc<dyn ViolationObserver>>,
     /// Whether checksum validation is enabled.
     validate_checksums: bool,
     /// Pending validation cell from the previous frame's `SaveGameState` request.
@@ -189,16 +203,9 @@ impl<T: Config> ReplaySession<T> {
     /// # Errors
     ///
     /// Returns an error if the replay fails internal consistency validation
-    /// (see [`Replay::validate`]).
+    /// (see [`Replay::validate`]) or the default event queue cannot be reserved.
     pub fn new(replay: Replay<T::Input>) -> FortressResult<Self> {
-        replay.validate()?;
-        Ok(Self {
-            replay,
-            current_frame: Frame::NULL,
-            event_queue: VecDeque::new(),
-            validate_checksums: false,
-            pending_validation: None,
-        })
+        Self::new_with_options(replay, false, DEFAULT_EVENT_QUEUE_SIZE, None)
     }
 
     /// Creates a new [`ReplaySession`] with checksum validation enabled.
@@ -255,14 +262,32 @@ impl<T: Config> ReplaySession<T> {
     /// # Errors
     ///
     /// Returns an error if the replay fails internal consistency validation
-    /// (see [`Replay::validate`]).
+    /// (see [`Replay::validate`]) or the default event queue cannot be reserved.
     pub fn new_with_validation(replay: Replay<T::Input>) -> FortressResult<Self> {
+        Self::new_with_options(replay, true, DEFAULT_EVENT_QUEUE_SIZE, None)
+    }
+
+    /// Shared construction tail for public direct constructors and builder paths.
+    pub(crate) fn new_with_options(
+        replay: Replay<T::Input>,
+        validate_checksums: bool,
+        max_event_queue_size: usize,
+        violation_observer: Option<Arc<dyn ViolationObserver>>,
+    ) -> FortressResult<Self> {
         replay.validate()?;
+        let mut event_queue = VecDeque::new();
+        event_queue
+            .try_reserve_exact(max_event_queue_size)
+            .map_err(|_err| allocation_failed("replay.event_queue", max_event_queue_size))?;
         Ok(Self {
             replay,
             current_frame: Frame::NULL,
-            event_queue: VecDeque::new(),
-            validate_checksums: true,
+            event_queue,
+            max_event_queue_size,
+            metrics: SessionMetrics::new(),
+            event_discard_warned: false,
+            violation_observer,
+            validate_checksums,
             pending_validation: None,
         })
     }
@@ -283,7 +308,7 @@ impl<T: Config> ReplaySession<T> {
 
             if let (Some(expected), Some(actual)) = (replay_checksum, actual_checksum) {
                 if expected != actual {
-                    self.event_queue.push_back(FortressEvent::ReplayDesync {
+                    self.enqueue_event(FortressEvent::ReplayDesync {
                         frame: prev_frame,
                         expected_checksum: expected,
                         actual_checksum: actual,
@@ -571,16 +596,61 @@ impl<T: Config> ReplaySession<T> {
 
     /// Returns all events that happened since last queried for events.
     ///
+    /// Replay validation events use the same configured hard bound as P2P and
+    /// spectator sessions: evict the oldest queued routine first; otherwise
+    /// discard an incoming routine or replace the oldest durable with an incoming
+    /// durable. Replay currently emits only durable `ReplayDesync` events, so an
+    /// arrival at capacity replaces and records the oldest mismatch in [`metrics`](Self::metrics).
+    ///
     /// When replay validation is enabled and playback has completed, this method
     /// also flushes any final pending checksum validation that is ready. This makes
     /// last-frame desyncs observable for the common `while !is_complete()` loop
     /// pattern without requiring an additional failing `advance_frame()` call.
     #[must_use = "events should be handled to react to session state changes"]
     pub fn events(&mut self) -> EventDrain<'_, T> {
+        // A drain starts a fresh overflow episode. Re-arm before resolving the
+        // final pending checksum because that resolution may itself enqueue.
+        self.event_discard_warned = false;
         if self.is_complete() && self.pending_validation_ready_to_check() {
             self.check_pending_validation();
         }
         EventDrain::from_drain(self.event_queue.drain(..))
+    }
+
+    /// Returns cumulative replay-session metrics.
+    ///
+    /// Replay sessions populate the bounded event-queue high-water and discard
+    /// counters. Rollback, pacing, network, and checksum-comparison counters stay
+    /// at zero because replay playback has no network rollback loop.
+    pub fn metrics(&self) -> SessionMetrics {
+        self.metrics
+    }
+
+    fn enqueue_event(&mut self, event: FortressEvent<T>) {
+        if let Some(dropped) =
+            enqueue_event_bounded(&mut self.event_queue, self.max_event_queue_size, event)
+        {
+            self.record_event_discard(dropped);
+        }
+        self.metrics.observe_event_queue_len(self.event_queue.len());
+    }
+
+    fn record_event_discard(&mut self, dropped: FortressEvent<T>) {
+        self.metrics.record_event_discard(dropped.kind());
+        if !self.event_discard_warned {
+            self.event_discard_warned = true;
+            report_violation_to!(
+                &self.violation_observer,
+                ViolationSeverity::Warning,
+                ViolationKind::NetworkProtocol,
+                "replay event queue overflow at capacity: evicting the oldest queued routine \
+                 first; otherwise discarding an incoming routine or replacing the oldest durable \
+                 with an incoming durable (queue cap {}); drain events during validation or raise \
+                 the event-queue size to avoid losing notifications. See \
+                 SessionMetrics::events_discarded_total for the running count",
+                self.max_event_queue_size
+            );
+        }
     }
 
     /// Returns the current session state.
@@ -740,7 +810,10 @@ impl<T: Config> fmt::Debug for ReplaySession<T> {
 )]
 mod tests {
     use super::*;
+    use crate::metrics::EventKind;
     use crate::replay::ReplayMetadata;
+    use crate::telemetry::CollectingObserver;
+    use crate::SessionBuilder;
     use std::net::SocketAddr;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -989,6 +1062,89 @@ mod tests {
             },
             other => panic!("Expected ReplayDesync, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn validation_overflow_is_bounded_counted_and_retains_newest_desyncs() {
+        const CAP: usize = 10;
+        const FRAMES: usize = CAP + 2;
+
+        let replay = make_replay_with_checksums(FRAMES, 1, vec![Some(0xCAFE); FRAMES]);
+        let observer = Arc::new(CollectingObserver::new());
+        let mut session = SessionBuilder::<TestConfig>::new()
+            .with_event_queue_size(CAP)
+            .expect("minimum queue cap is valid")
+            .with_violation_observer(Arc::clone(&observer) as Arc<dyn ViolationObserver>)
+            .start_replay_session_with_validation(replay)
+            .expect("valid replay builds");
+
+        for _ in 0..FRAMES {
+            let requests = session.advance_frame().expect("replay frame advances");
+            match requests.first() {
+                Some(FortressRequest::SaveGameState { cell, frame }) => {
+                    cell.save(*frame, Some(vec![1u8]), Some(0xBAD));
+                },
+                other => panic!("expected SaveGameState first, got {other:?}"),
+            }
+        }
+        assert!(
+            session.advance_frame().is_err(),
+            "the exhausted advance flushes final-frame validation"
+        );
+
+        let metrics = session.metrics();
+        assert_eq!(
+            metrics.event_queue_high_water,
+            u64::try_from(CAP).expect("small test cap fits u64")
+        );
+        assert_eq!(metrics.events_discarded_total, 2);
+        assert_eq!(
+            metrics
+                .events_discarded_by_kind
+                .get(EventKind::ReplayDesync),
+            2,
+            "a durable-only overflow honestly counts its oldest-event fallback"
+        );
+
+        let events: Vec<_> = session.events().collect();
+        assert_eq!(events.len(), CAP, "builder-configured cap must be enforced");
+        let frames: Vec<_> = events
+            .iter()
+            .filter_map(|event| match event {
+                FortressEvent::ReplayDesync { frame, .. } => Some(*frame),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(frames.len(), CAP);
+        assert_eq!(frames.first(), Some(&Frame::new(2)));
+        assert_eq!(
+            frames.last(),
+            Some(&Frame::new(
+                i32::try_from(FRAMES - 1).expect("small test frame fits i32")
+            ))
+        );
+
+        let warnings = observer
+            .violations()
+            .iter()
+            .filter(|violation| {
+                violation.severity == ViolationSeverity::Warning
+                    && violation.kind == ViolationKind::NetworkProtocol
+                    && violation.message.contains("replay event queue overflow")
+            })
+            .count();
+        assert_eq!(warnings, 1, "one drain gap emits one overflow warning");
+    }
+
+    #[test]
+    fn direct_constructors_use_shared_default_event_queue_size() {
+        let replay = make_replay(1, 1);
+        let normal = ReplaySession::<TestConfig>::new(replay.clone()).expect("normal replay");
+        let validating =
+            ReplaySession::<TestConfig>::new_with_validation(replay).expect("validating replay");
+
+        assert_eq!(normal.max_event_queue_size, DEFAULT_EVENT_QUEUE_SIZE);
+        assert_eq!(validating.max_event_queue_size, DEFAULT_EVENT_QUEUE_SIZE);
     }
 
     #[test]

--- a/src/sync_layer/mod.rs
+++ b/src/sync_layer/mod.rs
@@ -1097,6 +1097,12 @@ impl<T: Config> SyncLayer<T> {
         Ok(())
     }
 
+    /// Test-only invariant fault injection for disconnect error-path regressions.
+    #[cfg(test)]
+    pub(crate) fn truncate_input_queues_for_test(&mut self, len: usize) {
+        self.input_queues.truncate(len);
+    }
+
     /// Resets the prediction state for all input queues.
     ///
     /// # Note

--- a/wiki/User-Guide.md
+++ b/wiki/User-Guide.md
@@ -847,6 +847,23 @@ fn handle_event(event: FortressEvent<GameConfig>) {
 }
 ```
 
+### Bounded Event Retention
+
+P2P, spectator, and replay sessions keep events in a bounded queue (100 events
+by default, configurable with `with_event_queue_size`). When an event arrives at
+capacity, Fortress Rollback evicts the oldest queued routine progress or advisory
+event first. If the queue contains only durable events, an incoming routine event
+is discarded; an incoming durable event replaces the oldest durable event.
+Routine events are `Synchronizing`,
+`WaitRecommendation`, `InputDelayRecommendation`, and (with hot join)
+`JoinRequested`. All other event kinds are durable.
+
+The bound always wins, and relative order among retained events does not change. Read
+`SessionMetrics::events_discarded_total` and `events_discarded_by_kind` to detect
+loss, and compare `event_queue_high_water` with the configured cap when sizing
+the queue. Drain `events()` regularly; increasing the cap reduces burst loss but
+does not create backpressure or guarantee unlimited retention.
+
 ---
 
 ## Determinism Requirements
@@ -3407,7 +3424,7 @@ This section documents all configuration options available when building a sessi
 | `with_spectator_config(config)`          | `SpectatorConfig::default()`  | Spectator session behavior                                                                         |
 | `with_time_sync_config(config)`          | `TimeSyncConfig::default()`   | Time synchronization averaging                                                                     |
 | `with_input_queue_config(config)`        | `InputQueueConfig::default()` | Input queue buffer sizing                                                                          |
-| `with_event_queue_size(size)`            | 100                           | Maximum buffered events before dropping                                                            |
+| `with_event_queue_size(size)`            | 100                           | Hard event bound; queued routine first, else incoming routine or oldest durable is discarded        |
 | `with_max_frames_behind(frames)`         | 10                            | When spectator starts catching up                                                                  |
 | `with_catchup_speed(speed)`              | 1                             | Frames per step when spectator catches up                                                          |
 | `with_sparse_saving_mode(bool)`          | `false`                       | Deprecated: use `with_save_mode()` instead                                                         |


### PR DESCRIPTION
## Summary

- Pin the public N-peer hot-join metrics lifecycle: incomplete → completed, multi-poll, positive injected-clock latency, and stable completion.
- Close D9 across P2P, spectator, and replay sessions with fallibly reserved event queues and allocation-free priority retention at capacity.
- Retain routine-vs-durable ordering honestly: evict queued routine events first; reject an incoming routine against a durable-only queue; otherwise replace the oldest durable event and record the exact loss.
- Add replay metrics/observer integration, constructor allocation-failure coverage, and explicit disconnect-emission tracking for saturated queues.
- Update user-facing retention contracts and changelog.

## Validation

- `cargo fmt --all -- --check`
- strict workspace clippy with `tokio,json,hot-join`
- rustdoc with `tokio,json,hot-join`
- changed-file agent preflight, changelog rule, link checks, and markdown lint
- default nextest: 2,506 passed, 69 skipped
- hot-join nextest: 2,753 passed, 69 skipped
- nine adversarial sub-agent rounds; final verdict: zero D9 issues
- mutation check proves the N-peer metrics assertion detects removal of activation recording

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how session event queues drop notifications under load (including disconnect/desync paths) across P2P, spectator, and replay; behavior is heavily tested but affects core session lifecycle semantics.
> 
> **Overview**
> Replaces **FIFO event-queue trimming** with **routine-vs-durable retention** shared by P2P, spectator, and replay sessions. At capacity, the oldest queued routine/advisory event is evicted first; if the queue is durable-only, incoming routine events are dropped and incoming durable events replace the oldest durable slot. Enqueues go through `enqueue_event_bounded` with **fallible queue reservation** at session build time, **inline** `SessionMetrics` discard accounting, and rate-limited overflow warnings on every emission path (not only after `handle_event`).
> 
> **Replay** gains the same bound plus `ReplaySession::metrics()`, builder wiring for queue size and violation observer, and allocation-failure handling. **P2P disconnect** uses tracked emission so a saturated queue does not duplicate `Disconnected` when graceful-drop cleanup fails after the terminal event was already enqueued. Docs/changelog describe the retention contract; regressions cover durable canaries, desync under pressure, and replay validation overflow.
> 
> N-peer **hot-join metrics** tests assert completion, multi-poll span, and positive clock latency on the public mesh path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da603e5b03be2905228308c87aec627b792969f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->