### PR TITLE
Add asymmetric minority partition census

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -280,20 +280,20 @@ For docs/wiki mirrors, use a first-line `<!-- SYNC: ... -->` header with explici
 
 ## Quality Checklist
 
-- [ ] `cargo fmt` run
-- [ ] `cargo clippy --workspace --all-targets --features tokio,json` passes
+- [ ] `cargo fmt` and `cargo clippy --workspace --all-targets --features tokio,json` pass
 - [ ] All tests pass (`cargo nextest run`)
-- [ ] Tests for new functionality included
-- [ ] Rustdoc comments with examples
-- [ ] 100% safe Rust (no unsafe)
-- [ ] All error cases handled
-- [ ] No duplicate methods (e.g., don't add method duplicating `Display` impl)
-- [ ] Feature-dependent APIs documented in rustdoc
+- [ ] New functionality has tests and Rustdoc examples
+- [ ] Code is 100% safe Rust and handles every error path
+- [ ] Public APIs have no duplicate methods and document feature dependencies
 - [ ] Changelog reviewed for pub/user-observable changes
 
 ## For Agents
 
 When spawning sub-agents or using Task tools: the sub-agent MUST run `cargo fmt` and verify `cargo clippy --workspace --all-targets --features tokio,json` passes on any modified files. If the sub-agent cannot run these, the parent agent must run them after receiving changes.
+
+### GitHub Access in Devcontainers
+
+Do not treat `gh auth status` as a universal publish prerequisite. First use `git ls-remote origin HEAD` as a read-connectivity check, then verify write access with a targeted `git push --dry-run origin HEAD:<branch>` before relying on the push path. SSH origins normally use the VS Code-forwarded `SSH_AUTH_SOCK`, while HTTPS origins may use its credential helper. Use local `git` for branches, commits, and pushes, and prefer the connected GitHub app for PR creation, comments, reviews, checks, workflow logs, and review threads. Use authenticated `gh` when an applicable workflow explicitly requires it, or after confirming a required operation is unavailable or fails through the connector. An unauthenticated `gh` is not a blocker when Git transport and the connector cover the requested workflow. Never print or persist credentials.
 
 ---
 

--- a/tests/simulation/census.rs
+++ b/tests/simulation/census.rs
@@ -4,7 +4,10 @@ use super::harness::schedule::{
     BackgroundNoise, DropPolicy, SavePolicy, Schedule, ScheduleEvent, SimConfig,
     SCHEDULE_SCHEMA_VERSION,
 };
-use super::harness::{peer_addr, run, PeerEventKey, PeerEventPayload, RunOptions, RunReport};
+use super::harness::{
+    oracle::OracleFailure, peer_addr, run, PeerEventKey, PeerEventPayload, RunOptions, RunReport,
+    TraceSessionState,
+};
 use crate::common::sim_net::LinkPolicy;
 use fortress_rollback::{EventKind, PlayerHandle};
 use std::time::Duration;
@@ -14,6 +17,8 @@ const SPARSE_HEAL_AT: u32 = 300;
 const MULTI_STAGGER_START: u32 = 150;
 const MULTI_DROP_AT: u32 = 178;
 const MULTI_HEAL_AT: u32 = 300;
+const ASYMMETRIC_PARTITION_START: u32 = 140;
+const ASYMMETRIC_PARTITION_HEAL: u32 = 450;
 
 fn clean_initial_links(n: usize) -> Vec<(usize, usize, LinkPolicy)> {
     let mut initial_links = Vec::new();
@@ -221,6 +226,36 @@ fn same_step_multi_drop_schedule() -> Schedule {
     }
 }
 
+fn asymmetric_partition_schedule() -> Schedule {
+    let n = 5;
+    let mut config = SimConfig::smoke(n);
+    config.steps = 900;
+    config.noise = BackgroundNoise::Clean;
+    config.disconnect_behavior = DropPolicy::ContinueWithout;
+
+    let events = vec![
+        (
+            ASYMMETRIC_PARTITION_START,
+            ScheduleEvent::Block {
+                from: 4,
+                to: 0,
+                blocked: true,
+            },
+        ),
+        (ASYMMETRIC_PARTITION_HEAL, ScheduleEvent::HealAll),
+    ];
+
+    Schedule {
+        schema_version: SCHEDULE_SCHEMA_VERSION,
+        seed: 0xCE45_0040,
+        link_seed: 0xCE45_0041,
+        config,
+        initial_links: clean_initial_links(n),
+        events,
+        heal_at: ASYMMETRIC_PARTITION_HEAL,
+    }
+}
+
 /// M3 §6.4 census: when RTT is far larger than `max_prediction`, peers should
 /// throttle by returning `Ok(empty)` rather than diverging or surfacing advance
 /// errors. The permanent oracle checks liveness and byte-consistent state; this
@@ -406,6 +441,239 @@ fn same_step_multi_drop_after_asymmetric_block_converges() {
         report.trace_hash, again.trace_hash,
         "same-step multi-drop row must reproduce its exact trace"
     );
+}
+
+/// M3 §28.3 known-red census: a one-way partition lasts beyond the disconnect
+/// timeout, so peer 0 drops peer 4 even though the reverse network direction
+/// is never blocked.
+/// This reproduces D14 at whole-mesh scale: the unilateral graceful freeze
+/// rewrites already-confirmed history. The four-peer majority and one-peer
+/// island both keep advancing, but their confirmed histories fork permanently.
+/// Flip this to a green convergence regression when M5's coordinated
+/// prepare/backfill/commit barrier lands.
+#[test]
+#[ignore = "known D14 confirmed-history rewrite under asymmetric partition"]
+fn one_way_minority_partition_rewrites_confirmed_history_known_defect() {
+    let schedule = asymmetric_partition_schedule();
+
+    let report = run(&schedule, &RunOptions::default());
+
+    assert!(
+        blocked_drop_count(&report, 4, 0) > 0,
+        "asymmetric-partition row must drop traffic on blocked link 4->0: {:?}",
+        report.blocked_drops_by_link
+    );
+    assert_eq!(
+        blocked_drop_count(&report, 0, 4),
+        0,
+        "reverse network direction 0->4 must never be blocked: {:?}",
+        report.blocked_drops_by_link
+    );
+    for to in 1..=3 {
+        assert_eq!(
+            blocked_drop_count(&report, 4, to),
+            0,
+            "other 4->majority network directions must remain unblocked ({to}): {:?}",
+            report.blocked_drops_by_link
+        );
+    }
+    assert_eq!(
+        report.net_stats.dropped_blocked,
+        blocked_drop_count(&report, 4, 0),
+        "4->0 must be the schedule's only blocked link: {:?}",
+        report.blocked_drops_by_link
+    );
+    assert!(
+        peer_event_payload_count(&report, 0, peer_dropped_key(4)) > 0,
+        "peer 0 must time out and gracefully drop peer 4: {:?}",
+        report.peer_event_payload_counts_by_peer
+    );
+    assert!(
+        peer_event_payload_count(&report, 0, addr_event_key(EventKind::Disconnected, 4)) > 0,
+        "peer 0 must surface peer 4's terminal disconnect: {:?}",
+        report.peer_event_payload_counts_by_peer
+    );
+    assert!(
+        peer_event_payload_count(&report, 0, addr_event_key(EventKind::NetworkInterrupted, 4)) > 0,
+        "peer 0 must directly observe peer 4's one-way silence: {:?}",
+        report.peer_event_payload_counts_by_peer
+    );
+    for observer in 1..=3 {
+        assert!(
+            peer_event_payload_count(&report, observer, peer_dropped_key(4)) > 0,
+            "majority peer {observer} must learn peer 4's drop through gossip: {:?}",
+            report.peer_event_payload_counts_by_peer
+        );
+        assert_eq!(
+            peer_event_payload_count(
+                &report,
+                observer,
+                addr_event_key(EventKind::NetworkInterrupted, 4)
+            ),
+            0,
+            "majority peer {observer} must learn the drop before its own timeout: {:?}",
+            report.peer_event_payload_counts_by_peer
+        );
+        assert!(
+            peer_event_payload_count(
+                &report,
+                observer,
+                addr_event_key(EventKind::Disconnected, 4)
+            ) > 0,
+            "majority peer {observer} must surface peer 4's gossiped disconnect: {:?}",
+            report.peer_event_payload_counts_by_peer
+        );
+    }
+    for observer in 0..=3 {
+        for retained in 0..=3 {
+            if observer == retained {
+                continue;
+            }
+            assert_eq!(
+                peer_event_payload_count(&report, observer, peer_dropped_key(retained)),
+                0,
+                "majority peer {observer} must retain majority peer {retained}: {:?}",
+                report.peer_event_payload_counts_by_peer
+            );
+        }
+    }
+    for dropped in 0..=3 {
+        assert!(
+            peer_event_payload_count(&report, 4, peer_dropped_key(dropped)) > 0,
+            "minority peer 4 must eventually drop majority peer {dropped}: {:?}",
+            report.peer_event_payload_counts_by_peer
+        );
+        assert!(
+            peer_event_payload_count(
+                &report,
+                4,
+                addr_event_key(EventKind::NetworkInterrupted, dropped)
+            ) > 0,
+            "minority peer 4 must observe majority peer {dropped}'s silence: {:?}",
+            report.peer_event_payload_counts_by_peer
+        );
+        assert!(
+            peer_event_payload_count(&report, 4, addr_event_key(EventKind::Disconnected, dropped))
+                > 0,
+            "minority peer 4 must surface majority peer {dropped}'s disconnect: {:?}",
+            report.peer_event_payload_counts_by_peer
+        );
+    }
+    assert_eq!(
+        report.recovered_within_b,
+        Some(true),
+        "both sides of the intentional ContinueWithout fork must keep advancing"
+    );
+    let confirmed_rewrites: Vec<_> = report
+        .verdict
+        .failures
+        .iter()
+        .filter_map(|failure| match failure {
+            OracleFailure::ConfirmedInputDivergence {
+                peer,
+                first_author,
+                expected,
+                actual,
+                ..
+            } => Some((*peer, *first_author, expected, actual)),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !confirmed_rewrites.is_empty()
+            && confirmed_rewrites.iter().all(
+                |(peer, first_author, expected, actual)| {
+                    *peer < 4
+                        && *first_author == 4
+                        && expected.len() == 5
+                        && actual.len() == 5
+                        && expected.get(..4) == actual.get(..4)
+                        && expected.get(4) != actual.get(4)
+                }
+            ),
+        "every confirmed divergence must be D14 rewriting only peer 4's input at the majority: {:?}",
+        report.verdict.failures
+    );
+    assert!(
+        report
+            .final_confirmed
+            .iter()
+            .all(|confirmed| *confirmed > 200),
+        "the majority and minority island must remain available after the fork: {:?}",
+        report.final_confirmed
+    );
+    let final_snapshot = report
+        .trace_tail
+        .last()
+        .expect("a non-empty run must retain a final trace snapshot");
+    assert!(
+        final_snapshot
+            .session_states
+            .iter()
+            .all(|state| *state == TraceSessionState::Running),
+        "both sides must finish Running rather than wedged: {:?}",
+        final_snapshot.session_states
+    );
+    let majority_state = final_snapshot
+        .game_states
+        .get(1)
+        .expect("five-player trace must contain peer 1 state");
+    assert!(
+        final_snapshot
+            .game_states
+            .iter()
+            .skip(1)
+            .take(3)
+            .all(|state| state == majority_state),
+        "gossip-driven majority peers 1..=3 must converge on one final state: {:?}",
+        final_snapshot.game_states
+    );
+    assert!(
+        report.verdict.failures.iter().all(|failure| matches!(
+            failure,
+            OracleFailure::ConfirmedInputDivergence { .. }
+                | OracleFailure::StateDivergence { .. }
+                | OracleFailure::InbandDesyncDetected { .. }
+                | OracleFailure::ChecksumMismatchMetric { .. }
+        )),
+        "known D14 divergence must be the complete failure surface: {:?}",
+        report.verdict.failures
+    );
+    assert!(
+        report.verdict.failures.iter().any(|failure| matches!(
+            failure,
+            OracleFailure::StateDivergence {
+                peer: 4,
+                first_author: 0,
+                ..
+            }
+        )),
+        "minority peer 4 must diverge in state from canonical majority peer 0: {:?}",
+        report.verdict.failures
+    );
+    assert!(
+        report
+            .verdict
+            .failures
+            .iter()
+            .filter_map(|failure| match failure {
+                OracleFailure::StateDivergence {
+                    peer, first_author, ..
+                } => Some((*peer, *first_author)),
+                _ => None,
+            })
+            .all(|pair| pair == (4, 0)),
+        "all state divergence must be minority peer 4 versus canonical majority peer 0: {:?}",
+        report.verdict.failures
+    );
+
+    let again = run(&schedule, &RunOptions::default());
+    assert_eq!(
+        report.trace_hash, again.trace_hash,
+        "asymmetric-partition row must reproduce its exact trace"
+    );
+    assert_eq!(report.final_confirmed, again.final_confirmed);
+    assert_eq!(report.blocked_drops_by_link, again.blocked_drops_by_link);
 }
 
 /// M3 §6.4 census: after a graceful drop freezes a departed slot, a survivor


### PR DESCRIPTION
## Summary

- add a premise-asserted N=5 one-way/minority partition census for PLAN.md §28.3(a,b)
- pin the resulting D14 confirmed-history rewrite as an ignored known-red regression until the M5 coordinated drop barrier lands
- document the devcontainer's connector-first GitHub workflow: local Git over the VS Code-forwarded SSH agent, connected GitHub app for PR/review operations, and `gh` only when an applicable workflow requires it

## Why

The asymmetric/minority partition row had remained unexecuted. The experiment showed that a single blocked `4→0` direction forms a four-peer majority and one-peer island through disconnect gossip, but also independently reproduces D14. The regression now proves the exact causal premises and accepts only the D14-shaped peer-4 input rewrite.

Previous automation also incorrectly treated an unauthenticated `gh` CLI as a publish blocker even though the devcontainer's SSH Git transport and connected GitHub app were both functional. The canonical LLM instructions now describe the verified hybrid path.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features tokio,json`
- `cargo nextest run --no-capture` (2,506 passed)
- focused census suite under default and `hot-join`
- ignored D14 census regression executed directly
- `scripts/docs/check-llm-skills.sh`
- `python3 scripts/ci/agent-preflight.py --auto-fix`
- `git push --dry-run origin HEAD:refs/heads/dev/wallstop/hardening-30`

No changelog entry: production behavior and public API are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulation tests and agent documentation; production networking behavior and public APIs are unchanged.
> 
> **Overview**
> Adds a **PLAN §28.3** simulation census for a five-peer mesh with a **one-way block on `4→0`**: peer 0 times out and drops peer 4 while `0→4` stays open, forming a four-peer majority and a one-peer island under `ContinueWithout`.
> 
> The new **`one_way_minority_partition_rewrites_confirmed_history_known_defect`** test is **`#[ignore]`** and pins the **D14** failure shape—`ConfirmedInputDivergence` rewriting only peer 4’s input on the majority, plus expected gossip/drop/network-interruption premises and deterministic trace replay—until an M5 coordinated drop barrier is expected to fix it.
> 
> **`.llm/context.md`** tightens the quality checklist bullets and adds **GitHub Access in Devcontainers**: prefer `git ls-remote` / `git push --dry-run` and the connected GitHub app over treating unauthenticated `gh` as a publish blocker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e139e46d1821d77aff6a1a0992c46f4581629d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->