### PR TITLE
Model clock-skewed frame production

### DIFF
--- a/.github/workflows/ci-simulation-nightly.yml
+++ b/.github/workflows/ci-simulation-nightly.yml
@@ -65,13 +65,13 @@ jobs:
             simulation-nightly-${{ runner.os }}-cargo-
             network-nightly-${{ runner.os }}-cargo-
 
-      - name: Run sharded deterministic simulation fleet
+      - name: Run sharded fleet and hour-equivalent clock-skew probe
         run: >-
           cargo nextest run
           --profile ci-simulation-nightly
           --release
           --run-ignored ignored-only
-          -E 'test(simulation::fleet::nightly_seed_shard_)'
+          -E 'test(simulation::fleet::nightly_seed_shard_) or test(simulation::fleet::h_skew_hour_equivalent_measures_lag_correction_and_cost)'
           --test simulation
           --features hot-join
           --no-capture

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ proposed_fix
 ci-log*.txt
 ci-log*.log
 N-PLAYER-DESYNC-AUDIT.md
+GOAL.md

--- a/tests/simulation/corpus_replay.rs
+++ b/tests/simulation/corpus_replay.rs
@@ -272,6 +272,26 @@ fn reproduce_artifact(artifact: &FailureArtifact) -> Result<(), String> {
             artifact.trace_hash, report.trace_hash
         ));
     }
+    for (name, matches) in [
+        (
+            "progress_samples",
+            report.progress_samples == artifact.progress_samples,
+        ),
+        (
+            "frame_opportunities",
+            report.frame_opportunities == artifact.frame_opportunities,
+        ),
+        (
+            "wait_frames_obeyed",
+            report.wait_frames_obeyed == artifact.wait_frames_obeyed,
+        ),
+    ] {
+        if !matches {
+            return Err(format!(
+                "candidate {name} evidence changed independently of the recorded trace hash"
+            ));
+        }
+    }
     let expected = artifact.failures[0].class;
     if report.verdict.failures.first().map(OracleFailure::class) != Some(expected.as_str()) {
         return Err(format!(
@@ -335,6 +355,27 @@ mod tests {
     use super::*;
     use crate::simulation::harness::artifact::{write_artifact, ExistingArtifact, FailureArtifact};
     use crate::simulation::harness::schedule::{generate, SimConfig};
+
+    #[test]
+    fn artifact_reproduction_rejects_mutated_progress_evidence() {
+        let schedule = generate(17, SimConfig::smoke(2));
+        let options = RunOptions {
+            corrupt_state_from: Some((1, 10)),
+            ..RunOptions::default()
+        };
+        let report = run(&schedule, &options);
+        assert!(!report.verdict.passed(), "negative control must fail");
+        let artifact = FailureArtifact::from_report(&schedule, &report);
+        assert_eq!(reproduce_artifact(&artifact), Ok(()));
+
+        let mut mutated = artifact;
+        mutated.frame_opportunities[0] = mutated.frame_opportunities[0].saturating_add(1);
+        let error = reproduce_artifact(&mutated).expect_err("mutated evidence must be rejected");
+        assert!(
+            error.contains("frame_opportunities"),
+            "wrong error: {error}"
+        );
+    }
 
     fn temp_root(label: &str) -> PathBuf {
         std::env::temp_dir().join(format!(

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -6,8 +6,8 @@
 //! proves nothing.
 
 use super::harness::schedule::{
-    generate, validate_schedule, AppModel, BackgroundNoise, DropPolicy, ScenarioMix, Schedule,
-    ScheduleEvent, SimConfig, SCHEDULE_SCHEMA_VERSION,
+    generate, validate_schedule, AppModel, BackgroundNoise, DropPolicy, FrameModel, ScenarioMix,
+    Schedule, ScheduleEvent, SimConfig, SCHEDULE_SCHEMA_VERSION,
 };
 use super::harness::{
     oracle::{OracleFailure, ViolationAllowlistEntry, ViolationSignature, POST_HEAL_MIN_ADVANCE},
@@ -2681,7 +2681,7 @@ fn clock_skew_long_run_schedule(steps: u32, ppm: i32) -> Schedule {
 ///
 /// **What it does NOT do — H-SKEW (PLAN.md §13) is NOT executed here.** H-SKEW
 /// predicts a *rate* effect: a clock running 0.1% fast drives the frame loop
-/// 0.1% faster in wall-clock time, so the fast peer produces ~43 more frames/hour
+/// 0.1% faster in wall-clock time, so the fast peer produces 216 more frames/hour
 /// than the network confirms and `local_frame_advantage` accumulates. This
 /// harness advances **every peer exactly one frame per step** (`harness/mod.rs`,
 /// lockstep) and reads the clock only for timestamps, so that accumulation is
@@ -2720,6 +2720,160 @@ fn clock_skew_holds_consistency_over_a_long_run() {
         "skew must not drift the peers' confirmed frames apart (spread={spread}, \
          final_confirmed={confirmed:?})"
     );
+}
+
+fn skew_gated_schedule(steps: u32, ppm: i32, app_model: AppModel) -> Schedule {
+    let mut schedule = clock_skew_long_run_schedule(steps, ppm);
+    schedule.config.frame_model = FrameModel::SkewGated60Hz;
+    schedule.config.app_model = app_model;
+    schedule
+}
+
+/// The skew-gated model must turn clock-rate differences into actual frame
+/// opportunities while preserving deterministic, byte-consistent simulation.
+#[test]
+fn skew_gated_frame_model_exercises_rate_drift_deterministically() {
+    let exact = skew_gated_schedule(1_200, 0, AppModel::Obey);
+    let mut exact = exact;
+    exact.config.step_dt_ms = 8;
+    let mut skewed = skew_gated_schedule(1_200, 1_000_000, AppModel::Obey);
+    skewed.config.step_dt_ms = 8;
+
+    let exact_report = run(&exact, &RunOptions::default());
+    exact_report.expect_pass(&exact);
+    let skewed_report = run(&skewed, &RunOptions::default());
+    skewed_report.expect_pass(&skewed);
+    let replay = run(&skewed, &RunOptions::default());
+
+    assert_eq!(exact_report.frame_opportunities, vec![575, 575]);
+    assert_eq!(skewed_report.frame_opportunities, vec![1_151, 575]);
+    assert_eq!(skewed_report.trace_hash, replay.trace_hash);
+    assert_eq!(skewed_report.progress_samples, replay.progress_samples);
+    assert!(!skewed_report.progress_samples.is_empty());
+    assert!(skewed_report.progress_samples.len() <= 12);
+    assert_ne!(exact_report.trace_hash, skewed_report.trace_hash);
+}
+
+/// H-SKEW hour-equivalent experiment: +0.1% produces exactly 216 additional
+/// 60 Hz opportunities over one virtual hour. Nightly records both the bounded
+/// lag/correction result and the currently-red work-amplification observation.
+#[test]
+#[ignore = "hour-equivalent H-SKEW experiment; selected by nightly CI"]
+#[allow(clippy::print_stdout, clippy::disallowed_macros)]
+fn h_skew_hour_equivalent_measures_lag_correction_and_cost() {
+    let exact = skew_gated_schedule(225_001, 0, AppModel::Obey);
+    let skewed = skew_gated_schedule(225_001, 1_000, AppModel::Obey);
+
+    let exact_report = run(&exact, &RunOptions::default());
+    exact_report.expect_pass(&exact);
+    let skewed_report = run(&skewed, &RunOptions::default());
+    skewed_report.expect_pass(&skewed);
+    let replay = run(&skewed, &RunOptions::default());
+
+    assert_eq!(exact_report.frame_opportunities, vec![216_000, 216_000]);
+    assert_eq!(skewed_report.frame_opportunities, vec![216_216, 216_000]);
+    assert_eq!(skewed_report.trace_hash, replay.trace_hash);
+    assert_eq!(skewed_report.progress_samples, replay.progress_samples);
+    let exact_total_work = exact_report
+        .metrics
+        .iter()
+        .map(|metrics| metrics.frames_advanced)
+        .fold(0_u64, u64::saturating_add);
+    let skewed_total_work = skewed_report
+        .metrics
+        .iter()
+        .map(|metrics| metrics.frames_advanced)
+        .fold(0_u64, u64::saturating_add);
+    let exact_resimulation = exact_report
+        .metrics
+        .iter()
+        .map(|metrics| metrics.resimulated_frames)
+        .fold(0_u64, u64::saturating_add);
+    let skewed_resimulation = skewed_report
+        .metrics
+        .iter()
+        .map(|metrics| metrics.resimulated_frames)
+        .fold(0_u64, u64::saturating_add);
+    println!(
+        "H-SKEW exact_opportunities={:?} exact_metrics={:?} \
+         skewed_opportunities={:?} wait_frames_obeyed={:?} \
+         skewed_metrics={:?} exact_total_work={} skewed_total_work={} \
+         exact_resimulation={} skewed_resimulation={} samples={:?}",
+        exact_report.frame_opportunities,
+        exact_report.metrics,
+        skewed_report.frame_opportunities,
+        skewed_report.wait_frames_obeyed,
+        skewed_report.metrics,
+        exact_total_work,
+        skewed_total_work,
+        exact_resimulation,
+        skewed_resimulation,
+        skewed_report.progress_samples
+    );
+    assert!(
+        skewed_total_work.saturating_mul(100) <= exact_total_work.saturating_mul(120),
+        "H-SKEW total work amplification must not exceed 20%: \
+         exact={exact_total_work}, skewed={skewed_total_work}"
+    );
+    assert!(
+        skewed_resimulation.saturating_mul(100) <= exact_resimulation.saturating_mul(140),
+        "H-SKEW resimulation amplification must not exceed 40%: \
+         exact={exact_resimulation}, skewed={skewed_resimulation}"
+    );
+
+    assert_eq!(skewed_report.wait_frames_obeyed[1], 0);
+    assert!(
+        (200..=230).contains(&skewed_report.wait_frames_obeyed[0]),
+        "the correction duty should track the injected 216-frame/hour drift \
+         without escalating: {:?}",
+        skewed_report.wait_frames_obeyed
+    );
+    assert_eq!(skewed_report.metrics[1].wait_recommendations, 0);
+    assert!(
+        skewed_report.metrics[0].wait_recommendations <= 120,
+        "the fast peer should correct at most twice per minute, not saturate \
+         the one-second recommendation cooldown: {:?}",
+        skewed_report.metrics
+    );
+    assert!(
+        skewed_report
+            .metrics
+            .iter()
+            .all(|metric| metric.stall_count == 0),
+        "clock correction must not exhaust the prediction window: {:?}",
+        skewed_report.metrics
+    );
+
+    let final_sample = skewed_report
+        .progress_samples
+        .last()
+        .expect("the skew-gated run records bounded progress samples");
+    assert!(
+        final_sample
+            .confirmation_lag
+            .iter()
+            .all(|&lag| lag <= skewed.config.max_prediction as u64),
+        "steady-state confirmation lag must remain inside max_prediction: {:?}",
+        final_sample.confirmation_lag
+    );
+    let steady_samples = &skewed_report.progress_samples[6..];
+    for peer in 0..2 {
+        let min = steady_samples
+            .iter()
+            .map(|sample| sample.confirmation_lag[peer])
+            .min()
+            .expect("steady-state sample set is non-empty");
+        let max = steady_samples
+            .iter()
+            .map(|sample| sample.confirmation_lag[peer])
+            .max()
+            .expect("steady-state sample set is non-empty");
+        assert!(
+            max.saturating_sub(min) <= 1,
+            "steady-state lag must stay flat rather than creep (peer={peer}, \
+             samples={steady_samples:?})"
+        );
+    }
 }
 
 /// Diagnostic probe for a failing schedule: prints per-peer progress every 50

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -2761,8 +2761,10 @@ fn skew_gated_frame_model_exercises_rate_drift_deterministically() {
 #[ignore = "hour-equivalent H-SKEW experiment; selected by nightly CI"]
 #[allow(clippy::print_stdout, clippy::disallowed_macros)]
 fn h_skew_hour_equivalent_measures_lag_correction_and_cost() {
-    let exact = skew_gated_schedule(225_001, 0, AppModel::Obey);
-    let skewed = skew_gated_schedule(225_001, 1_000, AppModel::Obey);
+    let mut exact = skew_gated_schedule(240_001, 0, AppModel::Obey);
+    exact.config.step_dt_ms = 15;
+    let mut skewed = skew_gated_schedule(240_001, 1_000, AppModel::Obey);
+    skewed.config.step_dt_ms = 15;
 
     let exact_report = run(&exact, &RunOptions::default());
     exact_report.expect_pass(&exact);

--- a/tests/simulation/harness/artifact.rs
+++ b/tests/simulation/harness/artifact.rs
@@ -2,17 +2,18 @@
 
 use super::oracle::OracleFailure;
 use super::schedule::{validate_schedule, Schedule};
-use super::{RunReport, TraceSnapshot, TRACE_STEP_EVENT_CAPACITY, TRACE_TAIL_CAPACITY};
+use super::{
+    ProgressSample, RunReport, TraceSnapshot, TRACE_STEP_EVENT_CAPACITY, TRACE_TAIL_CAPACITY,
+};
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Schema version for [`FailureArtifact`].
-// Version 2 makes end-of-step per-link probe counters identity-bearing. Older
-// probe-bearing artifacts cannot reproduce that stronger trace identity and
-// are rejected explicitly rather than reported as nondeterministic.
-pub const FAILURE_ARTIFACT_SCHEMA_VERSION: u32 = 2;
+// Version 3 preserves schema-v15 clock/control-loop evidence. Older artifacts
+// cannot diagnose that stronger trace identity and are rejected explicitly.
+pub const FAILURE_ARTIFACT_SCHEMA_VERSION: u32 = 3;
 /// Maximum serialized artifact size accepted at the filesystem boundary.
 pub const MAX_FAILURE_ARTIFACT_BYTES: usize = 8 * 1024 * 1024;
 /// Oracle failures are capped at 64 per run; artifacts preserve at most that cap.
@@ -126,6 +127,12 @@ pub struct FailureArtifact {
     pub trace_hash: u64,
     /// Per-peer final confirmed frames.
     pub final_confirmed: Vec<i32>,
+    /// Bounded clock/control-loop samples retained for skew failures.
+    pub progress_samples: Vec<ProgressSample>,
+    /// Final per-peer frame-opportunity totals.
+    pub frame_opportunities: Vec<u64>,
+    /// Final per-peer obeyed-wait totals.
+    pub wait_frames_obeyed: Vec<u64>,
     /// Bounded final step snapshots.
     pub trace_tail: Vec<TraceSnapshot>,
 }
@@ -150,6 +157,9 @@ impl FailureArtifact {
                 .collect(),
             trace_hash: report.trace_hash,
             final_confirmed: report.final_confirmed.clone(),
+            progress_samples: report.progress_samples.clone(),
+            frame_opportunities: report.frame_opportunities.clone(),
+            wait_frames_obeyed: report.wait_frames_obeyed.clone(),
             trace_tail: report.trace_tail.clone(),
         }
     }
@@ -217,6 +227,46 @@ impl FailureArtifact {
                 "artifact has {} final confirmed frames for {n} peers",
                 self.final_confirmed.len()
             ));
+        }
+        for (name, len) in [
+            ("frame_opportunities", self.frame_opportunities.len()),
+            ("wait_frames_obeyed", self.wait_frames_obeyed.len()),
+        ] {
+            if len != n {
+                return Err(format!("artifact has {len} {name} entries for {n} peers"));
+            }
+        }
+        if self.progress_samples.len() > 12 {
+            return Err(format!(
+                "artifact has {} progress samples (maximum 12)",
+                self.progress_samples.len()
+            ));
+        }
+        for sample in &self.progress_samples {
+            for (name, len) in [
+                ("current_frames", sample.current_frames.len()),
+                ("confirmed_frames", sample.confirmed_frames.len()),
+                ("confirmation_lag", sample.confirmation_lag.len()),
+                ("wait_recommendations", sample.wait_recommendations.len()),
+                ("rollback_count", sample.rollback_count.len()),
+                ("resimulated_frames", sample.resimulated_frames.len()),
+                ("prediction_miss_count", sample.prediction_miss_count.len()),
+                ("frame_opportunities", sample.frame_opportunities.len()),
+                ("wait_frames_obeyed", sample.wait_frames_obeyed.len()),
+            ] {
+                if len != n {
+                    return Err(format!(
+                        "artifact progress sample at step {} has {len} {name} entries for {n} peers",
+                        sample.step
+                    ));
+                }
+            }
+            if sample.step >= self.schedule.config.steps {
+                return Err(format!(
+                    "artifact progress sample step {} is outside embedded schedule",
+                    sample.step
+                ));
+            }
         }
         let expected_tail_len = usize::try_from(self.schedule.config.steps)
             .unwrap_or(usize::MAX)
@@ -539,6 +589,9 @@ mod tests {
             }],
             trace_hash: 99,
             final_confirmed: vec![10, 10],
+            progress_samples: Vec::new(),
+            frame_opportunities: vec![600, 600],
+            wait_frames_obeyed: vec![0, 0],
             trace_tail: (0..TRACE_TAIL_CAPACITY)
                 .map(|step| TraceSnapshot {
                     step: 536 + u32::try_from(step).expect("small trace step"),
@@ -593,7 +646,10 @@ mod tests {
         );
         let decoded = read_artifact(&path).expect("artifact schema round trips");
         assert_eq!(decoded, artifact);
-        assert_eq!(decoded.artifact_schema_version, 2);
+        assert_eq!(
+            decoded.artifact_schema_version,
+            FAILURE_ARTIFACT_SCHEMA_VERSION
+        );
         assert_eq!(decoded.trace_tail.len(), TRACE_TAIL_CAPACITY);
 
         std::fs::remove_dir_all(&root).expect("temporary artifact tree removes");
@@ -699,6 +755,12 @@ mod tests {
             Box::new(|artifact| artifact.failures.clear()),
             Box::new(|artifact| {
                 let _ = artifact.final_confirmed.pop();
+            }),
+            Box::new(|artifact| {
+                let _ = artifact.frame_opportunities.pop();
+            }),
+            Box::new(|artifact| {
+                let _ = artifact.wait_frames_obeyed.pop();
             }),
             Box::new(|artifact| artifact.trace_tail.clear()),
             Box::new(|artifact| artifact.trace_tail[1].step += 1),

--- a/tests/simulation/harness/artifact.rs
+++ b/tests/simulation/harness/artifact.rs
@@ -128,10 +128,13 @@ pub struct FailureArtifact {
     /// Per-peer final confirmed frames.
     pub final_confirmed: Vec<i32>,
     /// Bounded clock/control-loop samples retained for skew failures.
+    #[serde(default)]
     pub progress_samples: Vec<ProgressSample>,
     /// Final per-peer frame-opportunity totals.
+    #[serde(default)]
     pub frame_opportunities: Vec<u64>,
     /// Final per-peer obeyed-wait totals.
+    #[serde(default)]
     pub wait_frames_obeyed: Vec<u64>,
     /// Bounded final step snapshots.
     pub trace_tail: Vec<TraceSnapshot>,
@@ -747,6 +750,33 @@ mod tests {
         let mut artifact = sample_artifact();
         artifact.schedule.schema_version = SCHEDULE_SCHEMA_VERSION + 1;
         assert!(artifact.validate().is_err());
+    }
+
+    #[test]
+    fn artifact_v2_without_progress_fields_reaches_explicit_schema_rejection() {
+        let mut value = serde_json::to_value(sample_artifact()).expect("artifact serializes");
+        let object = value
+            .as_object_mut()
+            .expect("failure artifact serializes as an object");
+        object.insert(
+            "artifact_schema_version".to_owned(),
+            serde_json::Value::from(2),
+        );
+        for field in [
+            "progress_samples",
+            "frame_opportunities",
+            "wait_frames_obeyed",
+        ] {
+            assert!(object.remove(field).is_some(), "fixture contains {field}");
+        }
+
+        let artifact: FailureArtifact =
+            serde_json::from_value(value).expect("v2 envelope reaches validation");
+        let error = artifact.validate().expect_err("v2 schema is unsupported");
+        assert!(
+            error.contains("unsupported failure artifact schema 2"),
+            "wrong diagnostic: {error}"
+        );
     }
 
     #[test]

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -2405,6 +2405,12 @@ mod tests {
         assert_eq!(skew_gated_target(last_step, 16, 1_000), 216_216);
         assert_eq!(skew_gated_target(last_step, 16, -1_000), 215_784);
         assert_eq!(skew_gated_target(last_step, 16, -1_000_000), 0);
+        assert_eq!(
+            skew_gated_target(225_000, 16, 1_000)
+                .saturating_sub(skew_gated_target(224_999, 16, 1_000)),
+            2,
+            "the rejected 16ms/+0.1% boundary demonstrates cumulative rounding"
+        );
     }
 
     #[test]

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -36,7 +36,9 @@ use oracle::{
     validate_violation_allowlist, HealLiveness, InputFingerprint, Oracle, OracleFailure, Verdict,
     ViolationSignature, ViolationSource, DEFAULT_VIOLATION_ALLOWLIST, POST_HEAL_MIN_ADVANCE,
 };
-use schedule::{hot_join_host_for_slot, validate_schedule, AppModel, Schedule, ScheduleEvent};
+use schedule::{
+    hot_join_host_for_slot, validate_schedule, AppModel, FrameModel, Schedule, ScheduleEvent,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::{BTreeMap, VecDeque};
 use std::hash::Hasher as _;
@@ -226,6 +228,21 @@ pub struct LoadGameStateObservation {
     pub step: u32,
     pub peer: usize,
     pub frame: i32,
+}
+
+/// Bounded time-series sample for clock-driven frame-production experiments.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProgressSample {
+    pub step: u32,
+    pub current_frames: Vec<i32>,
+    pub confirmed_frames: Vec<i32>,
+    pub confirmation_lag: Vec<u64>,
+    pub wait_recommendations: Vec<u64>,
+    pub rollback_count: Vec<u64>,
+    pub resimulated_frames: Vec<u64>,
+    pub prediction_miss_count: Vec<u64>,
+    pub frame_opportunities: Vec<u64>,
+    pub wait_frames_obeyed: Vec<u64>,
 }
 
 /// Maximum number of final simulation steps retained in a failure artifact.
@@ -483,6 +500,12 @@ struct TraceFinalSummary {
     spectator_applied_frames: usize,
     spectator_max_frame: Option<i32>,
     spectator_final_hosts: Option<usize>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    progress_samples: Vec<ProgressSample>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    frame_opportunities: Vec<u64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    wait_frames_obeyed: Vec<u64>,
     net: TraceNetStats,
 }
 
@@ -521,6 +544,13 @@ pub struct RunReport {
     pub load_game_state_observations: Vec<LoadGameStateObservation>,
     /// Each peer's final [`SessionMetrics`] snapshot (indexed by peer).
     pub metrics: Vec<fortress_rollback::SessionMetrics>,
+    /// Twelve-or-fewer evenly spaced samples for skew/control-loop analysis.
+    /// Empty for legacy lockstep schedules.
+    pub progress_samples: Vec<ProgressSample>,
+    /// Frame opportunities produced by each peer's selected frame model.
+    pub frame_opportunities: Vec<u64>,
+    /// Opportunities suppressed because the `Obey` app model honored a wait.
+    pub wait_frames_obeyed: Vec<u64>,
     /// Each peer's wire-traffic totals, aggregated over all of that peer's
     /// remote links from the always-on `PeerMetrics` counters (indexed by peer).
     /// This is the per-player bandwidth ledger the M2 baseline sweep consumes.
@@ -1138,6 +1168,17 @@ fn input_for<I: SimInput>(step: u32, peer: usize) -> I {
     I::from_word(word, step, peer)
 }
 
+/// Returns the cumulative 60 Hz frame opportunities visible at the beginning
+/// of `step` on a clock running at `ppm` relative to base virtual time.
+fn skew_gated_target(step: u32, step_dt_ms: u64, ppm: i32) -> u64 {
+    let rate = u64::try_from(i64::from(1_000_000) + i64::from(ppm)).unwrap_or(0);
+    let base_ms = u128::from(step).saturating_mul(u128::from(step_dt_ms));
+    // Match TestClock's integer-millisecond skew exactly, then gate at 60 Hz.
+    let local_ms = base_ms.saturating_mul(u128::from(rate)) / 1_000_000;
+    let target = local_ms.saturating_mul(60) / 1_000;
+    u64::try_from(target).unwrap_or(u64::MAX)
+}
+
 fn corrupt_fingerprint(fingerprint: InputFingerprint) -> InputFingerprint {
     InputFingerprint {
         logical: fingerprint.logical.wrapping_add(1),
@@ -1585,6 +1626,13 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
     // does not advance, letting the others catch up — the closed time-sync loop.
     let app_model = schedule.config.app_model;
     let mut wait_skip: Vec<u32> = vec![0; n];
+    let frame_model = schedule.config.frame_model;
+    let mut frame_opportunities = vec![0_u64; n];
+    let mut skew_targets_seen = vec![0_u64; n];
+    let mut wait_frames_obeyed = vec![0_u64; n];
+    let mut local_input_ordinals = vec![0_u32; n];
+    let mut progress_samples = Vec::new();
+    let progress_interval = schedule.config.steps.div_ceil(12).max(1);
     // Peers whose app model never drains the session event queue (models a
     // wedged event consumer). Their bounded `event_queue` fills and the session
     // trims oldest events, firing the D9 `events_discarded_*` telemetry. Because
@@ -1831,6 +1879,20 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
         // a dead peer never does. Either way its state is still folded into the
         // trace below so the digest stays uniform and reproduces bit-for-bit.
         for (i, slot) in peers.iter_mut().enumerate() {
+            // Clock-gated opportunities are consumed even while a peer is
+            // stalled, dead, or synchronizing. A resumed application must not
+            // burst through a wall-clock backlog that it never simulated.
+            let opportunities = match frame_model {
+                FrameModel::Lockstep => 1,
+                FrameModel::SkewGated60Hz => {
+                    let ppm = schedule.config.clock_skew_ppm.get(i).copied().unwrap_or(0);
+                    let target = skew_gated_target(step, schedule.config.step_dt_ms, ppm);
+                    let due = target.saturating_sub(skew_targets_seen[i]);
+                    skew_targets_seen[i] = target;
+                    due
+                },
+            };
+            frame_opportunities[i] = frame_opportunities[i].saturating_add(opportunities);
             // Confirmed frame after this step's drive (or the frozen value for a
             // stalled/dead peer): read exactly once and reused for both the
             // trace fold and any probe snapshot.
@@ -1873,7 +1935,10 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                     }
                 }
 
-                if slot.session.current_state() == SessionState::Running {
+                for _ in 0..opportunities {
+                    if slot.session.current_state() != SessionState::Running {
+                        break;
+                    }
                     if wait_skip[i] > 0 {
                         // Obeying a WaitRecommendation: poll/receive this step
                         // (done above) but skip the advance so the ahead peer
@@ -1883,11 +1948,20 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                         // resync) must not silently consume its owed skips, or it
                         // would stop obeying once it resumes.
                         wait_skip[i] -= 1;
+                        wait_frames_obeyed[i] = wait_frames_obeyed[i].saturating_add(1);
                     } else {
+                        let input_ordinal = match frame_model {
+                            FrameModel::Lockstep => step,
+                            FrameModel::SkewGated60Hz => {
+                                let ordinal = local_input_ordinals[i];
+                                local_input_ordinals[i] = ordinal.saturating_add(1);
+                                ordinal
+                            },
+                        };
                         for handle in slot.session.local_player_handles() {
                             if let Err(error) = slot
                                 .session
-                                .add_local_input(handle, input_for::<I>(step, i))
+                                .add_local_input(handle, input_for::<I>(input_ordinal, i))
                             {
                                 oracle.observe_session_error("add_local_input", i, step, &error);
                             }
@@ -1917,7 +1991,10 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                                     slot.game.handle_requests(requests);
                                 }
                             },
-                            Err(error) => oracle.observe_advance_error(i, step, &error),
+                            Err(error) => {
+                                oracle.observe_advance_error(i, step, &error);
+                                break;
+                            },
                         }
                     }
                 }
@@ -1970,6 +2047,42 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
             if run_c && step == recovery_anchor_at {
                 confirmed_after_recovery.push(confirmed.as_i32());
             }
+        }
+
+        if frame_model == FrameModel::SkewGated60Hz
+            && ((step + 1) % progress_interval == 0 || step == last_step)
+        {
+            let sample_metrics: Vec<_> = peers.iter().map(|slot| slot.session.metrics()).collect();
+            progress_samples.push(ProgressSample {
+                step,
+                current_frames: peers
+                    .iter()
+                    .map(|slot| slot.session.current_frame().as_i32())
+                    .collect(),
+                confirmed_frames: step_confirmed.clone(),
+                confirmation_lag: sample_metrics
+                    .iter()
+                    .map(|metrics| metrics.confirmation_lag_current)
+                    .collect(),
+                wait_recommendations: sample_metrics
+                    .iter()
+                    .map(|metrics| metrics.wait_recommendations)
+                    .collect(),
+                rollback_count: sample_metrics
+                    .iter()
+                    .map(|metrics| metrics.rollback_count)
+                    .collect(),
+                resimulated_frames: sample_metrics
+                    .iter()
+                    .map(|metrics| metrics.resimulated_frames)
+                    .collect(),
+                prediction_miss_count: sample_metrics
+                    .iter()
+                    .map(|metrics| metrics.prediction_miss_count)
+                    .collect(),
+                frame_opportunities: frame_opportunities.clone(),
+                wait_frames_obeyed: wait_frames_obeyed.clone(),
+            });
         }
 
         // Sample link-specific wire counters only after the fixed-order peer
@@ -2227,6 +2340,21 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
         spectator_applied_frames,
         spectator_max_frame,
         spectator_final_hosts,
+        progress_samples: if schedule.schema_version >= 15 {
+            progress_samples.clone()
+        } else {
+            Vec::new()
+        },
+        frame_opportunities: if schedule.schema_version >= 15 {
+            frame_opportunities.clone()
+        } else {
+            Vec::new()
+        },
+        wait_frames_obeyed: if schedule.schema_version >= 15 {
+            wait_frames_obeyed.clone()
+        } else {
+            Vec::new()
+        },
         net: TraceNetStats::from(net.stats()),
     };
     fold_trace(&mut trace_hash, &final_trace_summary, &mut trace_scratch);
@@ -2246,6 +2374,9 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
         link_stats_by_link,
         load_game_state_observations,
         metrics,
+        progress_samples,
+        frame_opportunities,
+        wait_frames_obeyed,
         peer_wire,
         confirmed_at_heal,
         confirmed_after_recovery,
@@ -2266,6 +2397,15 @@ mod tests {
     #[cfg(feature = "hot-join")]
     use crate::simulation::harness::oracle::OracleFailure;
     use fortress_rollback::network::codec;
+
+    #[test]
+    fn skew_gate_counts_exact_fast_slow_and_frozen_clocks() {
+        let last_step = 225_000;
+        assert_eq!(skew_gated_target(last_step, 16, 0), 216_000);
+        assert_eq!(skew_gated_target(last_step, 16, 1_000), 216_216);
+        assert_eq!(skew_gated_target(last_step, 16, -1_000), 215_784);
+        assert_eq!(skew_gated_target(last_step, 16, -1_000_000), 0);
+    }
 
     #[test]
     fn schema_v10_rebind_addresses_are_deterministic_and_disjoint() {

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -154,13 +154,13 @@ pub enum ScenarioMix {
 pub const SCHEDULE_SCHEMA_VERSION: u32 = 15;
 /// Hard execution bound for one materialized harness schedule.
 ///
-/// This admits the 225,001-step, one-hour H-SKEW experiment at 16 ms cadence
+/// This admits the 240,001-step, one-hour H-SKEW experiment at 15 ms cadence
 /// while preventing an untrusted corpus entry from turning the runner's
 /// `0..steps` loop into an effectively unbounded job.
 pub const MAX_SIMULATION_STEPS: u32 = 250_000;
-/// Skew-gated schedules must expose at most one 60 Hz opportunity per peer per
-/// outer step, preserving peer/network interleaving and bounding total work.
-const MAX_SKEW_GATED_OPPORTUNITIES_PER_STEP: u128 = 1;
+/// A 60 Hz target sampled at integer milliseconds can advance twice only when
+/// a peer's local clock jumps by at least 17 ms between outer steps.
+const MAX_SKEW_GATED_LOCAL_MS_PER_STEP: u128 = 16;
 /// Maximum virtual time advanced by one harness step.
 pub const MAX_SIMULATION_STEP_DT_MS: u64 = 1_000;
 /// Maximum delay accepted on any materialized simulated link.
@@ -981,12 +981,10 @@ pub fn validate_schedule(schedule: &Schedule) -> Result<(), String> {
             .max()
             .unwrap_or(0);
         let rate = u128::try_from(i64::from(1_000_000) + i64::from(fastest_ppm)).unwrap_or(0);
-        let opportunity_numerator = u128::from(schedule.config.step_dt_ms)
-            .saturating_mul(60)
-            .saturating_mul(rate);
-        let opportunity_denominator = 1_000_u128.saturating_mul(1_000_000);
-        if opportunity_numerator
-            > opportunity_denominator.saturating_mul(MAX_SKEW_GATED_OPPORTUNITIES_PER_STEP)
+        let local_millis_numerator = u128::from(schedule.config.step_dt_ms).saturating_mul(rate);
+        let local_millis_denominator = 1_000_000_u128;
+        if local_millis_numerator
+            > local_millis_denominator.saturating_mul(MAX_SKEW_GATED_LOCAL_MS_PER_STEP)
         {
             return Err(format!(
                 "SkewGated60Hz requires at most one frame opportunity per peer per outer step; \
@@ -2423,6 +2421,15 @@ mod tests {
         coarse_gated_cadence.config.frame_model = FrameModel::SkewGated60Hz;
         coarse_gated_cadence.config.step_dt_ms = 17;
         cases.push((coarse_gated_cadence, "at most one frame opportunity"));
+
+        let mut rounded_two_opportunity_boundary = valid.clone();
+        rounded_two_opportunity_boundary.config.frame_model = FrameModel::SkewGated60Hz;
+        rounded_two_opportunity_boundary.config.step_dt_ms = 16;
+        rounded_two_opportunity_boundary.config.clock_skew_ppm = vec![1_000];
+        cases.push((
+            rounded_two_opportunity_boundary,
+            "at most one frame opportunity",
+        ));
 
         let mut implicit_exact_peer_is_fastest = valid.clone();
         implicit_exact_peer_is_fastest.config.frame_model = FrameModel::SkewGated60Hz;

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -85,8 +85,10 @@ pub enum AppModel {
 /// How the harness turns virtual wall-clock time into frame opportunities.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FrameModel {
-    /// Preserve the historical harness behavior: every live peer gets exactly
-    /// one frame opportunity per outer simulation step.
+    /// Preserve the historical harness cadence: every peer accrues exactly one
+    /// opportunity per outer step. Dead, stalled, or synchronizing peers
+    /// consume that opportunity without advancing, so they never catch up in a
+    /// burst after becoming runnable.
     #[default]
     Lockstep,
     /// Gate each peer at 60 Hz using its own rate-skewed clock. This is the
@@ -154,9 +156,10 @@ pub enum ScenarioMix {
 pub const SCHEDULE_SCHEMA_VERSION: u32 = 15;
 /// Hard execution bound for one materialized harness schedule.
 ///
-/// This admits the 240,001-step, one-hour H-SKEW experiment at 15 ms cadence
-/// while preventing an untrusted corpus entry from turning the runner's
-/// `0..steps` loop into an effectively unbounded job.
+/// This admits the H-SKEW experiment's 240,001 sampled steps at 15 ms cadence:
+/// step 0 starts at the epoch and the last driven step starts exactly one hour
+/// later at 3,600,000 ms. The bound also prevents an untrusted corpus entry
+/// from turning the runner's `0..steps` loop into an effectively unbounded job.
 pub const MAX_SIMULATION_STEPS: u32 = 250_000;
 /// A 60 Hz target sampled at integer milliseconds can advance twice only when
 /// a peer's local clock jumps by at least 17 ms between outer steps.

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -82,6 +82,19 @@ pub enum AppModel {
     Obey,
 }
 
+/// How the harness turns virtual wall-clock time into frame opportunities.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FrameModel {
+    /// Preserve the historical harness behavior: every live peer gets exactly
+    /// one frame opportunity per outer simulation step.
+    #[default]
+    Lockstep,
+    /// Gate each peer at 60 Hz using its own rate-skewed clock. This is the
+    /// model required to exercise H-SKEW's frame-production drift. Validation
+    /// admits only cadences that yield at most one opportunity per outer step.
+    SkewGated60Hz,
+}
+
 /// Which storyline vocabulary the deterministic generator may use.
 ///
 /// `NetworkOnly` is the default so every pre-existing generated seed and every
@@ -136,13 +149,18 @@ pub enum ScenarioMix {
 ///   materialized directed links.
 /// - `14`: adds deterministic token-bucket bandwidth and bounded queueing on
 ///   materialized directed links.
-pub const SCHEDULE_SCHEMA_VERSION: u32 = 14;
+/// - `15`: adds [`FrameModel::SkewGated60Hz`], which makes per-peer clock skew
+///   control frame-production cadence instead of timestamps alone.
+pub const SCHEDULE_SCHEMA_VERSION: u32 = 15;
 /// Hard execution bound for one materialized harness schedule.
 ///
-/// This is 20× the 5,000-step nightly cells and 10× the longest current
-/// deterministic stress run, while preventing an untrusted corpus entry from
-/// turning the runner's `0..steps` loop into an effectively unbounded job.
-pub const MAX_SIMULATION_STEPS: u32 = 100_000;
+/// This admits the 225,001-step, one-hour H-SKEW experiment at 16 ms cadence
+/// while preventing an untrusted corpus entry from turning the runner's
+/// `0..steps` loop into an effectively unbounded job.
+pub const MAX_SIMULATION_STEPS: u32 = 250_000;
+/// Skew-gated schedules must expose at most one 60 Hz opportunity per peer per
+/// outer step, preserving peer/network interleaving and bounding total work.
+const MAX_SKEW_GATED_OPPORTUNITIES_PER_STEP: u128 = 1;
 /// Maximum virtual time advanced by one harness step.
 pub const MAX_SIMULATION_STEP_DT_MS: u64 = 1_000;
 /// Maximum delay accepted on any materialized simulated link.
@@ -204,6 +222,9 @@ pub struct SimConfig {
     /// used) keeps pre-existing corpus artifacts replayable without a bump.
     #[serde(default)]
     pub app_model: AppModel,
+    /// Frame-production model. `Lockstep` preserves every schema <=14 run.
+    #[serde(default)]
+    pub frame_model: FrameModel,
     /// Per-peer clock-rate skew in parts-per-million (peer `i` reads
     /// `clock_skew_ppm[i]`; a missing/short entry means 0 = no skew). The
     /// peer's local clock runs `ppm` faster (positive) or slower (negative)
@@ -261,6 +282,7 @@ impl SimConfig {
             disconnect_behavior: DropPolicy::default(),
             save_mode: SavePolicy::default(),
             app_model: AppModel::default(),
+            frame_model: FrameModel::default(),
             clock_skew_ppm: Vec::new(),
             starve_events: Vec::new(),
             event_queue_size: None,
@@ -526,7 +548,9 @@ fn event_required_schema(event: &ScheduleEvent) -> u32 {
 }
 
 fn required_schema_version(schedule: &Schedule) -> u32 {
-    let mut required = if schedule.config.noise == BackgroundNoise::ReliableFifo {
+    let mut required = if schedule.config.frame_model == FrameModel::SkewGated60Hz {
+        15
+    } else if schedule.config.noise == BackgroundNoise::ReliableFifo {
         9
     } else {
         1
@@ -938,6 +962,36 @@ pub fn validate_schedule(schedule: &Schedule) -> Result<(), String> {
             return Err(format!(
                 "clock_skew_ppm must be >= -1_000_000 (-100% = a frozen clock); a \
                  lower value would run time backwards (got {ppm})"
+            ));
+        }
+        if schedule.config.frame_model == FrameModel::SkewGated60Hz && ppm > 1_000_000 {
+            return Err(format!(
+                "clock_skew_ppm must be <= 1_000_000 (+100%) under SkewGated60Hz; \
+                 larger values would exceed the bounded frame-work model (got {ppm})"
+            ));
+        }
+    }
+    if schedule.config.frame_model == FrameModel::SkewGated60Hz {
+        let fastest_ppm = schedule
+            .config
+            .clock_skew_ppm
+            .iter()
+            .copied()
+            .chain((schedule.config.clock_skew_ppm.len() < n).then_some(0))
+            .max()
+            .unwrap_or(0);
+        let rate = u128::try_from(i64::from(1_000_000) + i64::from(fastest_ppm)).unwrap_or(0);
+        let opportunity_numerator = u128::from(schedule.config.step_dt_ms)
+            .saturating_mul(60)
+            .saturating_mul(rate);
+        let opportunity_denominator = 1_000_u128.saturating_mul(1_000_000);
+        if opportunity_numerator
+            > opportunity_denominator.saturating_mul(MAX_SKEW_GATED_OPPORTUNITIES_PER_STEP)
+        {
+            return Err(format!(
+                "SkewGated60Hz requires at most one frame opportunity per peer per outer step; \
+                 step_dt_ms={} and fastest clock skew {fastest_ppm} ppm exceed that bound",
+                schedule.config.step_dt_ms
             ));
         }
     }
@@ -1798,6 +1852,18 @@ mod tests {
     }
 
     #[test]
+    fn schema_v15_floor_applies_to_skew_gated_frame_model() {
+        let mut schedule = generate(7, SimConfig::smoke(2));
+        schedule.config.frame_model = FrameModel::SkewGated60Hz;
+        schedule.schema_version = 14;
+        assert!(validate_schedule(&schedule)
+            .expect_err("schema v14 cannot claim skew-gated frame semantics")
+            .contains("requiring schema_version 15"));
+        schedule.schema_version = 15;
+        assert_eq!(validate_schedule(&schedule), Ok(()));
+    }
+
+    #[test]
     fn bandwidth_policy_validates_rate_burst_and_memory_bound() {
         let mut schedule = generate(7, SimConfig::smoke(2));
         schedule.initial_links[0].2.bandwidth = Some(crate::common::sim_net::BandwidthPolicy {
@@ -2348,6 +2414,25 @@ mod tests {
         too_many_skews.config.clock_skew_ppm = vec![0; 4];
         cases.push((too_many_skews, "entries for a 3-peer mesh"));
 
+        let mut too_fast_gated_clock = valid.clone();
+        too_fast_gated_clock.config.frame_model = FrameModel::SkewGated60Hz;
+        too_fast_gated_clock.config.clock_skew_ppm = vec![1_000_001];
+        cases.push((too_fast_gated_clock, "must be <= 1_000_000"));
+
+        let mut coarse_gated_cadence = valid.clone();
+        coarse_gated_cadence.config.frame_model = FrameModel::SkewGated60Hz;
+        coarse_gated_cadence.config.step_dt_ms = 17;
+        cases.push((coarse_gated_cadence, "at most one frame opportunity"));
+
+        let mut implicit_exact_peer_is_fastest = valid.clone();
+        implicit_exact_peer_is_fastest.config.frame_model = FrameModel::SkewGated60Hz;
+        implicit_exact_peer_is_fastest.config.step_dt_ms = 33;
+        implicit_exact_peer_is_fastest.config.clock_skew_ppm = vec![-500_000];
+        cases.push((
+            implicit_exact_peer_is_fastest,
+            "at most one frame opportunity",
+        ));
+
         let mut bad_starved_peer = valid.clone();
         bad_starved_peer.config.starve_events = vec![9];
         cases.push((bad_starved_peer, "starve_events peer 9 out of range"));
@@ -2468,7 +2553,7 @@ mod tests {
         let cases: [(Mutation, &str); 7] = [
             (
                 |schedule| schedule.config.steps = MAX_SIMULATION_STEPS + 1,
-                "2..=100000 steps",
+                "materialized simulation schedules need 2..=",
             ),
             (
                 |schedule| schedule.config.max_prediction = MAX_FRAME_DELAY + 1,
@@ -2785,9 +2870,9 @@ mod tests {
 
     /// A corpus artifact predating the `#[serde(default)]` config axes (its
     /// `config` object lacks those fields) must deserialize to their defaults —
-    /// including `save_mode = EveryFrame`, `app_model = Ignore` (open-loop), and
-    /// `clock_skew_ppm = []` (no skew) — so old schedules replay bit-identically.
-    /// This pins the "no schema bump" claim. Each field is asserted
+    /// including `save_mode = EveryFrame`, `app_model = Ignore` (open-loop),
+    /// `frame_model = Lockstep`, and `clock_skew_ppm = []` (no skew) — so old
+    /// schedules replay bit-identically. Each field is asserted
     /// present-and-removed so the test can't pass vacuously (a full config also
     /// deserializes fine).
     #[test]
@@ -2809,6 +2894,10 @@ mod tests {
         assert!(
             config.remove("app_model").is_some(),
             "config must serialize an `app_model` field for this test to remove"
+        );
+        assert!(
+            config.remove("frame_model").is_some(),
+            "config must serialize a `frame_model` field for this test to remove"
         );
         assert!(
             config.remove("clock_skew_ppm").is_some(),
@@ -2841,6 +2930,11 @@ mod tests {
             back.config.app_model,
             AppModel::Ignore,
             "a pre-axis config (no app_model) must default to Ignore"
+        );
+        assert_eq!(
+            back.config.frame_model,
+            FrameModel::Lockstep,
+            "a pre-axis config (no frame_model) must default to Lockstep"
         );
         assert!(
             back.config.clock_skew_ppm.is_empty(),

--- a/tests/simulation/harness/shrink.rs
+++ b/tests/simulation/harness/shrink.rs
@@ -650,6 +650,17 @@ where
         }
     }
 
+    // Collapse the frame-production model before simplifying its clock rates;
+    // a failure that does not require rate-gated production should replay on
+    // the historical lockstep model.
+    if current.config.frame_model != super::schedule::FrameModel::Lockstep {
+        let mut candidate = current.clone();
+        candidate.config.frame_model = super::schedule::FrameModel::Lockstep;
+        if evaluator.confirm(&candidate, &current_options).is_some() {
+            current = candidate;
+        }
+    }
+
     // Simplify individual clock-rate entries before attempting the global
     // collapse. A failure may require one skewed peer while every other entry
     // is irrelevant.
@@ -758,7 +769,7 @@ mod tests {
     use crate::simulation::harness::oracle::{OracleFailure, Verdict};
     use crate::simulation::harness::run;
     use crate::simulation::harness::schedule::{
-        BackgroundNoise, SimConfig, SCHEDULE_SCHEMA_VERSION,
+        BackgroundNoise, FrameModel, SimConfig, SCHEDULE_SCHEMA_VERSION,
     };
 
     fn clean_schedule(n_players: usize, steps: u32) -> Schedule {
@@ -836,6 +847,9 @@ mod tests {
             link_stats_by_link: BTreeMap::new(),
             load_game_state_observations: Vec::new(),
             metrics: vec![fortress_rollback::SessionMetrics::default(); n],
+            progress_samples: Vec::new(),
+            frame_opportunities: Vec::new(),
+            wait_frames_obeyed: Vec::new(),
             peer_wire: vec![super::super::PeerWireTotals::default(); n],
             confirmed_at_heal: Vec::new(),
             confirmed_after_recovery: Vec::new(),
@@ -1574,6 +1588,55 @@ mod tests {
         assert_eq!(cadence_result.schedule.config.input_delay, 0);
         assert_eq!(cadence_result.schedule.config.max_prediction, 8);
         assert_eq!(cadence_result.schedule.config.desync_interval, 30);
+    }
+
+    #[test]
+    fn frame_model_shrinking_collapses_or_retains_the_required_gate() {
+        let mut collapsible = clean_schedule(2, 2);
+        collapsible.config.frame_model = FrameModel::SkewGated60Hz;
+        let collapsed = shrink_failure(
+            &collapsible,
+            &RunOptions::default(),
+            "StateDivergence",
+            ShrinkConfig {
+                max_runs: 40,
+                max_duration: Duration::from_secs(10),
+            },
+            |candidate, _| synthetic_report(candidate, vec![state_failure(1)], 0xC011_A95E),
+            |_, _, _| {},
+        )
+        .expect("failure persists without the frame gate");
+        assert_eq!(collapsed.schedule.config.frame_model, FrameModel::Lockstep);
+
+        let mut required = clean_schedule(2, 2);
+        required.config.frame_model = FrameModel::SkewGated60Hz;
+        required.config.clock_skew_ppm = vec![1_000, 2_000];
+        let retained = shrink_failure(
+            &required,
+            &RunOptions::default(),
+            "StateDivergence",
+            ShrinkConfig {
+                max_runs: 60,
+                max_duration: Duration::from_secs(10),
+            },
+            |candidate, _| {
+                let failures = if candidate.config.frame_model == FrameModel::SkewGated60Hz
+                    && candidate.config.clock_skew_ppm.first() == Some(&1_000)
+                {
+                    vec![state_failure(1)]
+                } else {
+                    Vec::new()
+                };
+                synthetic_report(candidate, failures, 0x6A7E)
+            },
+            |_, _, _| {},
+        )
+        .expect("failure requires the frame gate and first peer skew");
+        assert_eq!(
+            retained.schedule.config.frame_model,
+            FrameModel::SkewGated60Hz
+        );
+        assert_eq!(retained.schedule.config.clock_skew_ppm, vec![1_000, 0]);
     }
 
     #[test]

--- a/tests/simulation/harness/shrink.rs
+++ b/tests/simulation/harness/shrink.rs
@@ -1610,6 +1610,7 @@ mod tests {
 
         let mut required = clean_schedule(2, 2);
         required.config.frame_model = FrameModel::SkewGated60Hz;
+        required.config.step_dt_ms = 15;
         required.config.clock_skew_ppm = vec![1_000, 2_000];
         let retained = shrink_failure(
             &required,


### PR DESCRIPTION
## Summary

- add schema-v15 deterministic 60 Hz frame gating driven by each peer's skewed clock
- execute and nightly-gate a matched one-hour H-SKEW experiment with bounded lag, correction duty, and work-amplification evidence
- preserve schema <=14 lockstep behavior while bounding gated schedules to one opportunity per peer per outer step
- carry progress/cost evidence through trace identity, failure artifacts, replay validation, and shrinking

## Findings

At +0.1% skew, the fast peer receives exactly 216 extra opportunities per virtual hour and obeys 213 correction frames with zero stalls. Confirmation lag stays flat at 4–5 frames. The experiment also exposes a still-open cost issue: aggregate simulation work rises 13.3% and resimulation rises 28.3% versus the exact-clock control. Nightly ceilings prevent this from worsening while W-TIME follow-up investigates it.

## Validation

- `cargo nextest run --features tokio,json --no-capture` — 2,760 passed, 72 skipped
- `cargo nextest run --test simulation --no-capture` — 287 passed, 25 skipped
- release hour-equivalent H-SKEW control + skew + replay — passed
- `cargo clippy --workspace --all-targets --features tokio,json -- -D warnings` — passed
- `actionlint .github/workflows/ci-simulation-nightly.yml` — passed
- agent preflight — passed earlier; final rerun reached a pre-existing long-running doc-claims sort and was stopped after all preceding checks passed
- local adversarial review loop — final verdict: zero issues
- Cursor round 1 finding fixed in `e74baa2`; exact-head re-review requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the deterministic harness frame loop and trace/artifact identity (schema bumps), but production rollback paths are untouched and legacy lockstep schedules stay default-compatible.
> 
> **Overview**
> Adds **schema v15** simulation support so each peer can accrue **60 Hz frame opportunities from its own skewed clock** (`FrameModel::SkewGated60Hz`), while **lockstep remains the default** for older schedules. The harness now tracks **frame opportunities**, **obeyed wait frames**, and up to **12 progress samples**, folds them into trace identity for schema ≥15, and bumps **failure artifacts to schema v3** with the same fields plus stricter replay checks.
> 
> **H-SKEW** is exercised with new fleet tests: a short deterministic skew-gated probe and an **ignored hour-equivalent** run (+0.1% → 216 extra opportunities/hour) that asserts bounded lag, correction duty, and work/resimulation ceilings. **Nightly CI** now runs that experiment alongside the sharded fleet. Schedule limits rise (**250k steps**, skew-gated cadence validation); shrink can collapse `SkewGated60Hz` when unnecessary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c53ff7fd531a506a708c983e8e47f8a8f97f38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->