### PR TITLE
Add bounded control-loop simulation evidence

### DIFF
--- a/tests/common/sim_net.rs
+++ b/tests/common/sim_net.rs
@@ -142,6 +142,17 @@ pub struct SimLinkStats {
     pub bandwidth_max_queue_delay_ns: u64,
 }
 
+/// Read-only instantaneous bandwidth-queue state for one directed link.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct SimBandwidthState {
+    /// Bytes whose shaped departure remains in the future.
+    pub queued_bytes: u64,
+    /// Datagrams whose shaped departure remains in the future.
+    pub queued_datagrams: u64,
+    /// Virtual nanoseconds until the final queued departure.
+    pub drain_delay_ns: u64,
+}
+
 impl SimLinkStats {
     /// Merges another source-address generation of the same logical link.
     pub fn merge(&mut self, other: Self) {
@@ -1574,6 +1585,31 @@ impl<M: Clone> SimNet<M> {
             .map(|(&key, link)| (key, link.stats))
             .collect()
     }
+
+    /// Snapshot of live bandwidth queues without advancing or mutating them.
+    #[must_use]
+    pub fn bandwidth_states(&self) -> BTreeMap<(SocketAddr, SocketAddr), SimBandwidthState> {
+        let state = self.lock();
+        let now = state.now();
+        state
+            .links
+            .iter()
+            .map(|(&key, link)| {
+                let mut snapshot = SimBandwidthState::default();
+                for &(departure, bytes) in &link.bandwidth_reservations {
+                    if departure <= now {
+                        continue;
+                    }
+                    snapshot.queued_bytes = snapshot.queued_bytes.saturating_add(bytes);
+                    snapshot.queued_datagrams = snapshot.queued_datagrams.saturating_add(1);
+                    let delay_ns =
+                        u64::try_from(departure.duration_since(now).as_nanos()).unwrap_or(u64::MAX);
+                    snapshot.drain_delay_ns = snapshot.drain_delay_ns.max(delay_ns);
+                }
+                (key, snapshot)
+            })
+            .collect()
+    }
 }
 
 /// Why a simulated socket cannot move to a requested address.
@@ -2616,6 +2652,56 @@ mod tests {
         assert_eq!(link.bandwidth_tail_dropped_bytes, 100);
         assert_eq!(link.bandwidth_max_queue_bytes, 200);
         assert_eq!(link.bandwidth_max_queue_delay_ns, 200_000_000);
+    }
+
+    #[test]
+    fn bandwidth_state_snapshot_tracks_drain_without_mutation() {
+        let (clock, offset) = manual_clock();
+        let net = SimNet::new_size_aware(7, clock, sized_payload_metadata);
+        let sender = net.attach(addr(1));
+        let _receiver = net.attach(addr(2));
+        net.set_default_policy(LinkPolicy {
+            bandwidth: Some(BandwidthPolicy {
+                rate_bytes_per_second: 1_000,
+                burst_bytes: 100,
+                queue_capacity_bytes: 200,
+            }),
+            ..LinkPolicy::clean()
+        });
+
+        for id in 1..=3 {
+            sender.send_payload(
+                addr(2),
+                SizedPayload {
+                    id,
+                    encoded_len: 100,
+                    is_input: false,
+                },
+            );
+        }
+
+        let initial = SimBandwidthState {
+            queued_bytes: 200,
+            queued_datagrams: 2,
+            drain_delay_ns: 200_000_000,
+        };
+        assert_eq!(net.bandwidth_states()[&(addr(1), addr(2))], initial);
+        assert_eq!(net.bandwidth_states()[&(addr(1), addr(2))], initial);
+
+        offset.store(100, AtomicOrdering::Relaxed);
+        assert_eq!(
+            net.bandwidth_states()[&(addr(1), addr(2))],
+            SimBandwidthState {
+                queued_bytes: 100,
+                queued_datagrams: 1,
+                drain_delay_ns: 100_000_000,
+            }
+        );
+        offset.store(200, AtomicOrdering::Relaxed);
+        assert_eq!(
+            net.bandwidth_states()[&(addr(1), addr(2))],
+            SimBandwidthState::default()
+        );
     }
 
     #[test]

--- a/tests/simulation/census.rs
+++ b/tests/simulation/census.rs
@@ -1,7 +1,7 @@
 //! Premise-asserted simulation census rows for specific distributed failure modes.
 
 use super::harness::schedule::{
-    BackgroundNoise, DropPolicy, SavePolicy, Schedule, ScheduleEvent, SimConfig,
+    AppModel, BackgroundNoise, DropPolicy, SavePolicy, Schedule, ScheduleEvent, SimConfig,
     SCHEDULE_SCHEMA_VERSION,
 };
 use super::harness::{
@@ -674,6 +674,8 @@ fn constrained_uplink_builds_queue_then_tail_drops_and_recovers() {
     let replay = run(&schedule, &RunOptions::default());
     first.expect_pass(&schedule);
     assert_eq!(first.trace_hash, replay.trace_hash);
+    assert_eq!(first.progress_samples, replay.progress_samples);
+    assert!(!first.progress_samples.is_empty());
     assert_eq!(first.net_stats, replay.net_stats);
     assert_eq!(first.link_stats_by_link, replay.link_stats_by_link);
     assert_eq!(first.recovered_within_b, Some(true));
@@ -693,6 +695,31 @@ fn constrained_uplink_builds_queue_then_tail_drops_and_recovers() {
     assert_eq!(stats.dropped_by_policy, 0, "{stats:?}");
     assert_eq!(stats.dropped_blocked, 0, "{stats:?}");
     assert!(first.final_confirmed.iter().all(|frame| *frame > 400));
+    assert!(
+        first
+            .progress_samples
+            .iter()
+            .flat_map(|sample| &sample.link_queues)
+            .any(|queue| queue.from == 0
+                && queue.to == 1
+                && queue.queued_bytes > 0
+                && queue.queued_datagrams > 0
+                && queue.drain_delay_ns > 0),
+        "the bounded series must observe live queue growth on 0->1: {:?}",
+        first.progress_samples
+    );
+    assert!(
+        first
+            .progress_samples
+            .last()
+            .is_some_and(|sample| sample
+                .link_queues
+                .iter()
+                .all(|queue| queue.queued_bytes == 0
+                    && queue.queued_datagrams == 0
+                    && queue.drain_delay_ns == 0)),
+        "the final bounded sample must prove every bandwidth queue drained"
+    );
     assert_eq!(
         control
             .metrics
@@ -722,6 +749,105 @@ fn constrained_uplink_builds_queue_then_tail_drops_and_recovers() {
             assert_eq!(stats.bandwidth_tail_drops, 0, "link={link:?}");
         }
     }
+}
+
+/// H-BLOAT matched treatment: compare an app that ignores one-way
+/// queue-induced wait recommendations with one that obeys them, using the live
+/// queue series plus cumulative maxima as recovery evidence. The harness keeps
+/// polling while it skips simulation advances, so this row covers pacing
+/// feedback, not an application that also suspends network service.
+#[test]
+fn h_bloat_obedience_reduces_work_without_changing_sampled_queue() {
+    let mut ignore = bandwidth_queue_schedule(true);
+    ignore.config.app_model = AppModel::Ignore;
+    let mut obey = ignore.clone();
+    obey.config.app_model = AppModel::Obey;
+
+    let ignore_report = run(&ignore, &RunOptions::default());
+    let obey_report = run(&obey, &RunOptions::default());
+    let replay = run(&obey, &RunOptions::default());
+    ignore_report.expect_pass(&ignore);
+    obey_report.expect_pass(&obey);
+    assert_eq!(obey_report.trace_hash, replay.trace_hash);
+    assert_eq!(obey_report.progress_samples, replay.progress_samples);
+
+    let queue_series = |report: &RunReport| {
+        report
+            .progress_samples
+            .iter()
+            .map(|sample| {
+                let queue = sample
+                    .link_queues
+                    .iter()
+                    .find(|queue| queue.from == 0 && queue.to == 1)
+                    .expect("complete directed-link queue sample");
+                (sample.step, queue.queued_bytes, queue.drain_delay_ns)
+            })
+            .collect::<Vec<_>>()
+    };
+    let ignore_queue = queue_series(&ignore_report);
+    let obey_queue = queue_series(&obey_report);
+    let total_work = |report: &RunReport| {
+        report
+            .metrics
+            .iter()
+            .map(|metrics| metrics.frames_advanced)
+            .sum::<u64>()
+    };
+    assert!(ignore_queue.iter().any(|(_, bytes, _)| *bytes > 0));
+    assert!(obey_queue.iter().any(|(_, bytes, _)| *bytes > 0));
+    assert!(obey_report
+        .wait_frames_obeyed
+        .iter()
+        .any(|skips| *skips > 0));
+    assert_eq!(
+        ignore_queue, obey_queue,
+        "obeying must not change the bounded queue/drain samples"
+    );
+    assert_eq!(
+        ignore_report.net_stats.bandwidth_admitted_bytes,
+        obey_report.net_stats.bandwidth_admitted_bytes
+    );
+    assert_eq!(
+        ignore_report.net_stats.bandwidth_tail_dropped_bytes,
+        obey_report.net_stats.bandwidth_tail_dropped_bytes
+    );
+    assert_eq!(
+        ignore_report.net_stats.bandwidth_max_queue_bytes,
+        obey_report.net_stats.bandwidth_max_queue_bytes
+    );
+    assert_eq!(
+        ignore_report.net_stats.bandwidth_max_queue_delay_ns,
+        obey_report.net_stats.bandwidth_max_queue_delay_ns
+    );
+    let ignore_work = total_work(&ignore_report);
+    let obey_work = total_work(&obey_report);
+    assert!(
+        obey_work.saturating_mul(100) <= ignore_work.saturating_mul(75),
+        "obeying should reduce stress-work by at least 25%: \
+         ignore={ignore_work}, obey={obey_work}"
+    );
+    let resimulation = |report: &RunReport| {
+        report
+            .metrics
+            .iter()
+            .map(|metrics| metrics.resimulated_frames)
+            .sum::<u64>()
+    };
+    let ignore_resimulation = resimulation(&ignore_report);
+    let obey_resimulation = resimulation(&obey_report);
+    assert!(
+        obey_resimulation.saturating_mul(100) <= ignore_resimulation.saturating_mul(50),
+        "obeying should halve resimulation in this matched stress row: \
+         ignore={ignore_resimulation}, obey={obey_resimulation}"
+    );
+    assert!(obey_report
+        .progress_samples
+        .last()
+        .is_some_and(|sample| sample
+            .link_queues
+            .iter()
+            .all(|queue| queue.queued_bytes == 0)));
 }
 
 #[test]

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -2537,6 +2537,40 @@ fn app_model_obey_wait_recommendation_stays_consistent() {
         );
 
         let obey_again = run(&obey, &RunOptions::default());
+        assert!(!obey_report.progress_samples.is_empty(), "n={n}");
+        assert!(obey_report.progress_samples.len() <= 12, "n={n}");
+        assert_eq!(
+            obey_report.progress_samples, obey_again.progress_samples,
+            "bounded control-loop samples must replay exactly (n={n})"
+        );
+        for sample in &obey_report.progress_samples {
+            assert_eq!(sample.endpoints.len(), n * (n - 1), "n={n}");
+            assert_eq!(sample.link_queues.len(), n * (n - 1), "n={n}");
+            assert!(
+                sample
+                    .endpoints
+                    .windows(2)
+                    .all(|pair| (pair[0].from, pair[0].to) < (pair[1].from, pair[1].to)),
+                "endpoint samples must use stable directed-link order (n={n})"
+            );
+            assert!(
+                sample
+                    .link_queues
+                    .iter()
+                    .all(|queue| queue.queued_bytes == 0
+                        && queue.queued_datagrams == 0
+                        && queue.drain_delay_ns == 0),
+                "delay-only links must not report bandwidth debt (n={n})"
+            );
+        }
+        assert!(
+            obey_report
+                .progress_samples
+                .iter()
+                .flat_map(|sample| &sample.endpoints)
+                .any(|endpoint| endpoint.ping_ms > 0),
+            "the control-loop series must observe measured RTT (n={n})"
+        );
         assert_eq!(
             obey_report.trace_hash, obey_again.trace_hash,
             "an Obey run must reproduce its exact trace (n={n})"
@@ -2547,6 +2581,146 @@ fn app_model_obey_wait_recommendation_stays_consistent() {
              actually happen (n={n})"
         );
     }
+}
+
+/// H-OSC symmetric control: identical 100 ms one-way links do not activate
+/// the discrete sleep controller in the deterministic equal-rate workload.
+/// This falsifies the original perfectly-symmetric mutual-sleep premise; a
+/// perturbation/jitter treatment is still required to test oscillation after
+/// the loop is actually activated.
+#[test]
+fn symmetric_delay_does_not_create_mutual_sleep_h_osc() {
+    for n in [2usize, 4] {
+        let mut schedule = wait_rec_schedule(n, AppModel::Obey);
+        schedule.config.steps = 900;
+        for (_, _, policy) in &mut schedule.initial_links {
+            policy.base_delay = Duration::from_millis(100);
+        }
+        schedule.events.clear();
+        schedule.heal_at = schedule.config.steps;
+
+        let first = run(&schedule, &RunOptions::default());
+        let replay = run(&schedule, &RunOptions::default());
+        first.expect_pass(&schedule);
+        assert_eq!(first.trace_hash, replay.trace_hash, "n={n}");
+        assert_eq!(first.progress_samples, replay.progress_samples, "n={n}");
+        assert!(!first.progress_samples.is_empty(), "n={n}");
+        assert_eq!(first.wait_frames_obeyed, vec![0; n], "n={n}");
+        assert!(
+            first
+                .metrics
+                .iter()
+                .all(|metrics| metrics.wait_recommendations == 0),
+            "perfectly symmetric delay must not manufacture a peer lead: {:?}",
+            first.metrics
+        );
+        assert!(
+            first.progress_samples.last().is_some_and(|sample| sample
+                .endpoints
+                .iter()
+                .all(|endpoint| (190..=230).contains(&endpoint.ping_ms))),
+            "every endpoint must observe the intended ≈200 ms RTT (n={n}): {:?}",
+            first.progress_samples
+        );
+    }
+}
+
+/// H-ASYM matched experiment: a 10/200 ms one-way split has the same 210 ms
+/// RTT as its symmetric control. It creates a measurable throughput/stall
+/// asymmetry, but the reported advantages stay below the sleep dead band and
+/// falsify the predicted one-sided `WaitRecommendation` mechanism.
+#[test]
+fn h_asym_biases_throughput_without_wait_recommendations() {
+    let build = |asymmetric: bool| {
+        let mut schedule = wait_rec_schedule(2, AppModel::Obey);
+        for (from, to, policy) in &mut schedule.initial_links {
+            policy.base_delay = if asymmetric {
+                if from < to {
+                    Duration::from_millis(10)
+                } else {
+                    Duration::from_millis(200)
+                }
+            } else {
+                Duration::from_millis(105)
+            };
+        }
+        schedule.events.clear();
+        schedule.heal_at = schedule.config.steps;
+        schedule
+    };
+    let symmetric = build(false);
+    let asymmetric = build(true);
+    let symmetric_report = run(&symmetric, &RunOptions::default());
+    let asymmetric_report = run(&asymmetric, &RunOptions::default());
+    let replay = run(&asymmetric, &RunOptions::default());
+    symmetric_report.expect_pass(&symmetric);
+    asymmetric_report.expect_pass(&asymmetric);
+    assert_eq!(asymmetric_report.trace_hash, replay.trace_hash);
+    assert_eq!(asymmetric_report.progress_samples, replay.progress_samples);
+    assert_eq!(symmetric_report.wait_frames_obeyed, vec![0, 0]);
+    assert_eq!(asymmetric_report.wait_frames_obeyed, vec![0, 0]);
+    assert!(symmetric_report
+        .metrics
+        .iter()
+        .all(|metrics| metrics.wait_recommendations == 0));
+    assert!(asymmetric_report
+        .metrics
+        .iter()
+        .all(|metrics| metrics.wait_recommendations == 0));
+    assert_eq!(
+        symmetric_report.metrics[0].visual_frames,
+        symmetric_report.metrics[1].visual_frames
+    );
+    assert_eq!(
+        symmetric_report.metrics[0].stall_count,
+        symmetric_report.metrics[1].stall_count
+    );
+    assert!(
+        asymmetric_report.metrics[1].visual_frames > asymmetric_report.metrics[0].visual_frames
+    );
+    assert!(asymmetric_report.metrics[0].stall_count > asymmetric_report.metrics[1].stall_count);
+    let final_sample = asymmetric_report
+        .progress_samples
+        .last()
+        .expect("matched asymmetric run records bounded samples");
+    let symmetric_final = symmetric_report
+        .progress_samples
+        .last()
+        .expect("matched symmetric control records bounded samples");
+    assert_eq!(
+        final_sample.current_frames[1] - final_sample.current_frames[0],
+        7,
+        "10/200 ms paths should produce the measured seven-frame throughput split"
+    );
+    assert_eq!(
+        symmetric_final
+            .endpoints
+            .iter()
+            .map(|endpoint| endpoint.ping_ms)
+            .collect::<Vec<_>>(),
+        final_sample
+            .endpoints
+            .iter()
+            .map(|endpoint| endpoint.ping_ms)
+            .collect::<Vec<_>>(),
+        "control and treatment must observe the same RTT"
+    );
+    assert!(
+        final_sample
+            .endpoints
+            .iter()
+            .all(|endpoint| (210..=240).contains(&endpoint.ping_ms)),
+        "both treatment endpoints must observe the matched ≈210 ms RTT"
+    );
+    assert_eq!(
+        final_sample
+            .endpoints
+            .iter()
+            .map(|endpoint| endpoint.remote_frame_advantage)
+            .collect::<Vec<_>>(),
+        vec![-1, 1],
+        "the latest wire gauges stay below the three-frame recommendation dead band"
+    );
 }
 
 /// Builds a clock-skew schedule: an `n`-mesh over clean links with a small
@@ -2752,6 +2926,27 @@ fn skew_gated_frame_model_exercises_rate_drift_deterministically() {
     assert!(!skewed_report.progress_samples.is_empty());
     assert!(skewed_report.progress_samples.len() <= 12);
     assert_ne!(exact_report.trace_hash, skewed_report.trace_hash);
+}
+
+#[test]
+fn schema_v15_skew_progress_preserves_legacy_trace_shape() {
+    let mut schedule = skew_gated_schedule(1_200, 1_000, AppModel::Obey);
+    schedule.schema_version = 15;
+    schedule.config.step_dt_ms = 8;
+
+    let first = run(&schedule, &RunOptions::default());
+    let replay = run(&schedule, &RunOptions::default());
+    first.expect_pass(&schedule);
+    assert_eq!(first.trace_hash, replay.trace_hash);
+    assert!(!first.progress_samples.is_empty());
+    assert!(first
+        .progress_samples
+        .iter()
+        .all(|sample| sample.endpoints.is_empty() && sample.link_queues.is_empty()));
+    let encoded = serde_json::to_string(&first.progress_samples)
+        .expect("legacy progress samples serialize deterministically");
+    assert!(!encoded.contains("endpoints"));
+    assert!(!encoded.contains("link_queues"));
 }
 
 /// H-SKEW hour-equivalent experiment: +0.1% produces exactly 216 additional

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -11,7 +11,7 @@ use super::harness::schedule::{
 };
 use super::harness::{
     oracle::{OracleFailure, ViolationAllowlistEntry, ViolationSignature, POST_HEAL_MIN_ADVANCE},
-    run, RunOptions,
+    run, RunOptions, RunReport,
 };
 use crate::common::sim_net::LinkPolicy;
 use fortress_rollback::{telemetry::ViolationSeverity, SessionState};
@@ -2822,6 +2822,18 @@ fn h_skew_hour_equivalent_measures_lag_correction_and_cost() {
         "H-SKEW resimulation amplification must not exceed 40%: \
          exact={exact_resimulation}, skewed={skewed_resimulation}"
     );
+    assert!(
+        skewed_total_work.saturating_mul(100) >= exact_total_work.saturating_mul(110),
+        "the open H-SKEW-COST finding must remain directly observable until a \
+         reviewed controller fix deliberately flips this assertion: \
+         exact={exact_total_work}, skewed={skewed_total_work}"
+    );
+    assert!(
+        skewed_resimulation.saturating_mul(100) >= exact_resimulation.saturating_mul(120),
+        "the open H-SKEW-COST resimulation finding must remain directly observable until a \
+         reviewed controller fix deliberately flips this assertion: \
+         exact={exact_resimulation}, skewed={skewed_resimulation}"
+    );
 
     assert_eq!(skewed_report.wait_frames_obeyed[1], 0);
     assert!(
@@ -2874,6 +2886,103 @@ fn h_skew_hour_equivalent_measures_lag_correction_and_cost() {
             max.saturating_sub(min) <= 1,
             "steady-state lag must stay flat rather than creep (peer={peer}, \
              samples={steady_samples:?})"
+        );
+    }
+}
+
+/// H-SKEW cost-amplification diagnostic: repeat a ten-minute-equivalent matched
+/// exact/skew experiment at several scheduler resolutions. A real clock-drift
+/// cost should remain comparable as the deterministic outer-loop cadence gets
+/// finer; a large cadence-dependent swing instead identifies sampling/phase
+/// aliasing in the harness as a confounder.
+#[test]
+#[ignore = "H-SKEW scheduler-resolution cost matrix; run manually"]
+#[allow(clippy::print_stdout, clippy::disallowed_macros)]
+fn h_skew_cost_amplification_across_scheduler_resolutions() {
+    const DURATION_MS: u32 = 600_000;
+
+    for step_dt_ms in [5_u32, 8, 10, 15] {
+        let steps = DURATION_MS / step_dt_ms + 1;
+        let mut exact = skew_gated_schedule(steps, 0, AppModel::Obey);
+        exact.config.step_dt_ms = u64::from(step_dt_ms);
+        let exact_report = run(&exact, &RunOptions::default());
+        exact_report.expect_pass(&exact);
+
+        let total_work = |report: &RunReport| {
+            report
+                .metrics
+                .iter()
+                .map(|metrics| metrics.frames_advanced)
+                .fold(0_u64, u64::saturating_add)
+        };
+        let resimulation = |report: &RunReport| {
+            report
+                .metrics
+                .iter()
+                .map(|metrics| metrics.resimulated_frames)
+                .fold(0_u64, u64::saturating_add)
+        };
+        assert_eq!(exact_report.frame_opportunities, vec![36_000, 36_000]);
+        let exact_work = total_work(&exact_report);
+        let exact_resimulation = resimulation(&exact_report);
+        let mut work_by_orientation = [0_u64; 2];
+        let mut resimulation_by_orientation = [0_u64; 2];
+
+        for fast_peer in 0..2 {
+            let mut skewed = skew_gated_schedule(steps, 0, AppModel::Obey);
+            skewed.config.step_dt_ms = u64::from(step_dt_ms);
+            skewed.config.clock_skew_ppm = vec![0, 0];
+            skewed.config.clock_skew_ppm[fast_peer] = 1_000;
+            let skewed_report = run(&skewed, &RunOptions::default());
+            skewed_report.expect_pass(&skewed);
+
+            let skewed_work = total_work(&skewed_report);
+            let skewed_resimulation = resimulation(&skewed_report);
+            work_by_orientation[fast_peer] = skewed_work;
+            resimulation_by_orientation[fast_peer] = skewed_resimulation;
+            println!(
+                "H-SKEW-COST step_dt_ms={step_dt_ms} fast_peer={fast_peer} \
+                 exact_opportunities={:?} skewed_opportunities={:?} \
+                 exact_work={exact_work} skewed_work={skewed_work} \
+                 exact_resimulation={exact_resimulation} \
+                 skewed_resimulation={skewed_resimulation} skips={:?}",
+                exact_report.frame_opportunities,
+                skewed_report.frame_opportunities,
+                skewed_report.wait_frames_obeyed
+            );
+
+            let mut expected_opportunities = vec![36_000, 36_000];
+            expected_opportunities[fast_peer] = 36_036;
+            assert_eq!(skewed_report.frame_opportunities, expected_opportunities);
+            assert!(
+                skewed_work.saturating_mul(100) >= exact_work.saturating_mul(108),
+                "the measured total-work excess must persist at {step_dt_ms} ms: \
+                 exact={exact_work}, skewed={skewed_work}"
+            );
+            assert!(
+                skewed_resimulation.saturating_mul(100) >= exact_resimulation.saturating_mul(115),
+                "the measured resimulation excess must persist at {step_dt_ms} ms: \
+                 exact={exact_resimulation}, skewed={skewed_resimulation}"
+            );
+            for peer in 0..2 {
+                if peer == fast_peer {
+                    assert!(
+                        (30..=42).contains(&skewed_report.wait_frames_obeyed[peer]),
+                        "correction duty must track the 36-frame drift at {step_dt_ms} ms: {:?}",
+                        skewed_report.wait_frames_obeyed
+                    );
+                } else {
+                    assert_eq!(skewed_report.wait_frames_obeyed[peer], 0);
+                }
+            }
+        }
+        assert_eq!(
+            work_by_orientation[0], work_by_orientation[1],
+            "fixed peer drive order must not explain H-SKEW total-work cost at {step_dt_ms} ms"
+        );
+        assert_eq!(
+            resimulation_by_orientation[0], resimulation_by_orientation[1],
+            "fixed peer drive order must not explain H-SKEW resimulation cost at {step_dt_ms} ms"
         );
     }
 }

--- a/tests/simulation/harness/artifact.rs
+++ b/tests/simulation/harness/artifact.rs
@@ -270,6 +270,56 @@ impl FailureArtifact {
                     sample.step
                 ));
             }
+            let directed_links = n.saturating_mul(n.saturating_sub(1));
+            for (name, len) in [
+                ("endpoints", sample.endpoints.len()),
+                ("link_queues", sample.link_queues.len()),
+            ] {
+                let expected = if self.schedule.schema_version >= 16 {
+                    directed_links
+                } else {
+                    0
+                };
+                if len != expected {
+                    return Err(format!(
+                        "artifact progress sample at step {} has {len} {name} entries \
+                         (expected {expected} for schedule schema {})",
+                        sample.step, self.schedule.schema_version
+                    ));
+                }
+            }
+            for (index, endpoint) in sample.endpoints.iter().enumerate() {
+                let expected_from = index / n.saturating_sub(1);
+                let expected_offset = index % n.saturating_sub(1);
+                let expected_to = if expected_offset >= expected_from {
+                    expected_offset.saturating_add(1)
+                } else {
+                    expected_offset
+                };
+                if (endpoint.from, endpoint.to) != (expected_from, expected_to) {
+                    return Err(format!(
+                        "artifact progress endpoint {index} is {}->{} (expected \
+                         {expected_from}->{expected_to})",
+                        endpoint.from, endpoint.to
+                    ));
+                }
+            }
+            for (index, queue) in sample.link_queues.iter().enumerate() {
+                let expected_from = index / n.saturating_sub(1);
+                let expected_offset = index % n.saturating_sub(1);
+                let expected_to = if expected_offset >= expected_from {
+                    expected_offset.saturating_add(1)
+                } else {
+                    expected_offset
+                };
+                if (queue.from, queue.to) != (expected_from, expected_to) {
+                    return Err(format!(
+                        "artifact progress link queue {index} is {}->{} (expected \
+                         {expected_from}->{expected_to})",
+                        queue.from, queue.to
+                    ));
+                }
+            }
         }
         let expected_tail_len = usize::try_from(self.schedule.config.steps)
             .unwrap_or(usize::MAX)
@@ -562,7 +612,8 @@ mod tests {
         BackgroundNoise, ScheduleEvent, SimConfig, SCHEDULE_SCHEMA_VERSION,
     };
     use crate::simulation::harness::{
-        run, RunOptions, TraceGameState, TraceNetStats, TraceSessionState, TRACE_TAIL_CAPACITY,
+        run, EndpointControlSample, LinkQueueSample, ProgressSample, RunOptions, TraceGameState,
+        TraceNetStats, TraceSessionState, TRACE_TAIL_CAPACITY,
     };
 
     fn temp_artifact_root(label: &str) -> PathBuf {
@@ -777,6 +828,81 @@ mod tests {
             error.contains("unsupported failure artifact schema 2"),
             "wrong diagnostic: {error}"
         );
+    }
+
+    #[test]
+    fn progress_control_samples_validate_order_and_preserve_legacy_defaults() {
+        let sample = ProgressSample {
+            step: 1,
+            current_frames: vec![1, 1],
+            confirmed_frames: vec![0, 0],
+            confirmation_lag: vec![1, 1],
+            wait_recommendations: vec![0, 0],
+            rollback_count: vec![0, 0],
+            resimulated_frames: vec![0, 0],
+            prediction_miss_count: vec![0, 0],
+            frame_opportunities: vec![1, 1],
+            wait_frames_obeyed: vec![0, 0],
+            endpoints: vec![
+                EndpointControlSample {
+                    from: 0,
+                    to: 1,
+                    ping_ms: 10,
+                    remote_frame_advantage: 1,
+                    pending_output_len: 2,
+                },
+                EndpointControlSample {
+                    from: 1,
+                    to: 0,
+                    ping_ms: 10,
+                    remote_frame_advantage: -1,
+                    pending_output_len: 2,
+                },
+            ],
+            link_queues: vec![
+                LinkQueueSample {
+                    from: 0,
+                    to: 1,
+                    queued_bytes: 100,
+                    queued_datagrams: 1,
+                    drain_delay_ns: 1_000,
+                },
+                LinkQueueSample {
+                    from: 1,
+                    to: 0,
+                    queued_bytes: 0,
+                    queued_datagrams: 0,
+                    drain_delay_ns: 0,
+                },
+            ],
+        };
+        let mut artifact = sample_artifact();
+        artifact.progress_samples.push(sample.clone());
+        assert!(artifact.validate().is_ok());
+
+        let mut incomplete = artifact.clone();
+        let _ = incomplete.progress_samples[0].endpoints.pop();
+        assert!(incomplete.validate().is_err());
+        let mut stripped_endpoints = artifact.clone();
+        stripped_endpoints.progress_samples[0].endpoints.clear();
+        assert!(stripped_endpoints.validate().is_err());
+        let mut stripped_queues = artifact.clone();
+        stripped_queues.progress_samples[0].link_queues.clear();
+        assert!(stripped_queues.validate().is_err());
+        let mut misordered = artifact.clone();
+        misordered.progress_samples[0].link_queues.swap(0, 1);
+        assert!(misordered.validate().is_err());
+
+        let mut value = serde_json::to_value(sample).expect("progress sample serializes");
+        let object = value
+            .as_object_mut()
+            .expect("progress sample serializes as an object");
+        assert!(object.remove("endpoints").is_some());
+        assert!(object.remove("link_queues").is_some());
+        let legacy: ProgressSample =
+            serde_json::from_value(value).expect("legacy progress sample uses defaults");
+        assert!(legacy.endpoints.is_empty());
+        assert!(legacy.link_queues.is_empty());
     }
 
     #[test]

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -243,6 +243,32 @@ pub struct ProgressSample {
     pub prediction_miss_count: Vec<u64>,
     pub frame_opportunities: Vec<u64>,
     pub wait_frames_obeyed: Vec<u64>,
+    /// Per-directed-endpoint control-loop gauges in `(from, to)` order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub endpoints: Vec<EndpointControlSample>,
+    /// Per-directed-link live bandwidth queues in `(from, to)` order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub link_queues: Vec<LinkQueueSample>,
+}
+
+/// Instantaneous protocol gauges for one directed endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EndpointControlSample {
+    pub from: usize,
+    pub to: usize,
+    pub ping_ms: u128,
+    pub remote_frame_advantage: i32,
+    pub pending_output_len: u64,
+}
+
+/// Instantaneous bandwidth-queue gauges for one directed simulated link.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkQueueSample {
+    pub from: usize,
+    pub to: usize,
+    pub queued_bytes: u64,
+    pub queued_datagrams: u64,
+    pub drain_delay_ns: u64,
 }
 
 /// Maximum number of final simulation steps retained in a failure artifact.
@@ -713,6 +739,81 @@ fn collect_peer_wire_by_link<I: SimInput>(
         }
     }
     by_link
+}
+
+fn collect_endpoint_control_samples<I: SimInput>(
+    peers: &[PeerSlot<I>],
+    n_players: usize,
+) -> Vec<EndpointControlSample> {
+    let mut samples = Vec::with_capacity(n_players.saturating_mul(n_players.saturating_sub(1)));
+    for (from, slot) in peers.iter().enumerate() {
+        for to in 0..n_players {
+            if from == to {
+                continue;
+            }
+            let metrics = slot
+                .session
+                .peer_metrics(PlayerHandle::new(to))
+                .unwrap_or_default();
+            samples.push(EndpointControlSample {
+                from,
+                to,
+                ping_ms: metrics.ping_ms,
+                remote_frame_advantage: metrics.remote_frame_advantage,
+                pending_output_len: metrics.pending_output_len,
+            });
+        }
+    }
+    samples
+}
+
+fn collect_link_queue_samples<I: SimInput>(
+    net: &SimNet<Message>,
+    peers: &[PeerSlot<I>],
+    canonical_addrs: &[SocketAddr],
+) -> Vec<LinkQueueSample> {
+    let peer_by_addr: BTreeMap<SocketAddr, usize> = peers
+        .iter()
+        .enumerate()
+        .flat_map(|(peer, slot)| {
+            slot.source_addrs
+                .iter()
+                .copied()
+                .map(move |addr| (addr, peer))
+        })
+        .collect();
+    let mut by_link: BTreeMap<(usize, usize), LinkQueueSample> = BTreeMap::new();
+    for from in 0..canonical_addrs.len() {
+        for to in 0..canonical_addrs.len() {
+            if from != to {
+                by_link.insert(
+                    (from, to),
+                    LinkQueueSample {
+                        from,
+                        to,
+                        queued_bytes: 0,
+                        queued_datagrams: 0,
+                        drain_delay_ns: 0,
+                    },
+                );
+            }
+        }
+    }
+    for ((from_addr, to_addr), state) in net.bandwidth_states() {
+        let (Some(&from), Some(&to)) = (peer_by_addr.get(&from_addr), peer_by_addr.get(&to_addr))
+        else {
+            continue;
+        };
+        let Some(sample) = by_link.get_mut(&(from, to)) else {
+            continue;
+        };
+        sample.queued_bytes = sample.queued_bytes.saturating_add(state.queued_bytes);
+        sample.queued_datagrams = sample
+            .queued_datagrams
+            .saturating_add(state.queued_datagrams);
+        sample.drain_delay_ns = sample.drain_delay_ns.max(state.drain_delay_ns);
+    }
+    by_link.into_values().collect()
 }
 
 impl RunReport {
@@ -1627,6 +1728,21 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
     let app_model = schedule.config.app_model;
     let mut wait_skip: Vec<u32> = vec![0; n];
     let frame_model = schedule.config.frame_model;
+    let sample_control_loop = (schedule.schema_version >= 15
+        && frame_model == FrameModel::SkewGated60Hz)
+        || (schedule.schema_version >= 16
+            && (app_model == AppModel::Obey
+                || schedule
+                    .initial_links
+                    .iter()
+                    .any(|(_, _, policy)| policy.bandwidth.is_some())
+                || schedule.events.iter().any(|(_, event)| {
+                    matches!(
+                        event,
+                        ScheduleEvent::SetLink { policy, .. } if policy.bandwidth.is_some()
+                    )
+                })));
+    let sample_control_gauges = schedule.schema_version >= 16;
     let mut frame_opportunities = vec![0_u64; n];
     let mut skew_targets_seen = vec![0_u64; n];
     let mut wait_frames_obeyed = vec![0_u64; n];
@@ -2049,9 +2165,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
             }
         }
 
-        if frame_model == FrameModel::SkewGated60Hz
-            && ((step + 1) % progress_interval == 0 || step == last_step)
-        {
+        if sample_control_loop && ((step + 1) % progress_interval == 0 || step == last_step) {
             let sample_metrics: Vec<_> = peers.iter().map(|slot| slot.session.metrics()).collect();
             progress_samples.push(ProgressSample {
                 step,
@@ -2082,6 +2196,16 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                     .collect(),
                 frame_opportunities: frame_opportunities.clone(),
                 wait_frames_obeyed: wait_frames_obeyed.clone(),
+                endpoints: if sample_control_gauges {
+                    collect_endpoint_control_samples(&peers, n)
+                } else {
+                    Vec::new()
+                },
+                link_queues: if sample_control_gauges {
+                    collect_link_queue_samples(&net, &peers, &addrs)
+                } else {
+                    Vec::new()
+                },
             });
         }
 

--- a/tests/simulation/harness/schedule.rs
+++ b/tests/simulation/harness/schedule.rs
@@ -153,7 +153,9 @@ pub enum ScenarioMix {
 ///   materialized directed links.
 /// - `15`: adds [`FrameModel::SkewGated60Hz`], which makes per-peer clock skew
 ///   control frame-production cadence instead of timestamps alone.
-pub const SCHEDULE_SCHEMA_VERSION: u32 = 15;
+/// - `16`: adds bounded directed-endpoint and live bandwidth-queue samples to
+///   control-loop experiments. Schema 15 retains its original trace identity.
+pub const SCHEDULE_SCHEMA_VERSION: u32 = 16;
 /// Hard execution bound for one materialized harness schedule.
 ///
 /// This admits the H-SKEW experiment's 240,001 sampled steps at 15 ms cadence:


### PR DESCRIPTION
## What

- quantify H-SKEW rollback cost across mirrored peer orientation and four scheduler cadences
- add schema-v16 bounded endpoint RTT/advantage/backlog and live bandwidth queue/drain samples
- preserve schema-v15 serialized trace identity and artifact replay compatibility
- execute matched H-OSC, H-BLOAT, and H-ASYM experiments with direct evidence

## Why

Several open PLAN hypotheses could only be discussed through aggregate counters. This adds at most 12 deterministic directed-link samples per run, allowing matched causal experiments without unbounded traces.

The resulting evidence:

- perfectly symmetric 100 ms H-OSC controls are inert (zero recommendations/skips), so perturbation-driven A10 remains
- the N=2/4-byte H-BLOAT row shows identical bounded queue samples/cumulative maxima while obedience cuts work 42.7%; scale and between-cut behavior remain open
- 10/200 ms H-ASYM confirms a seven-frame throughput and 18-vs-11 stall split, but falsifies the predicted wait-recommendation mechanism at this bound

## Impact

Test/simulation infrastructure only. No production API, wire format, changelog-relevant behavior, or runtime behavior changes.

## Validation

- agent preflight: PASS
- strict workspace clippy with tokio,json: PASS
- full nextest: 2,743 passed, 73 skipped
- focused schema compatibility, artifact validation, H-OSC, H-BLOAT, H-ASYM, SimNet drain tests: PASS
- ignored release H-SKEW hour and cadence/orientation probes: PASS
- adversarial sub-agent review: zero issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test/simulation harness and SimNet telemetry; no production runtime or wire-format behavior is modified.
> 
> **Overview**
> Adds **schema v16** simulation harness support: up to ~12 deterministic `ProgressSample` rows per run now optionally carry per-directed **endpoint** gauges (RTT, remote frame advantage, pending output) and **live bandwidth queue** snapshots (queued bytes/datagrams, drain delay). **Schema 15** keeps empty gauge vectors and unchanged serialized trace shape; artifact validation enforces directed-link ordering and counts only for v16+.
> 
> `SimNet` exposes read-only `SimBandwidthState` via `bandwidth_states()` without advancing virtual time or mutating queues.
> 
> Matched census/fleet tests use the new series for causal evidence: **H-BLOAT** (obey vs ignore wait recommendations with identical queue samples), **H-OSC** (symmetric delay does not trigger mutual sleep), **H-ASYM** (throughput bias without wait recommendations), tighter **bandwidth-queue** census assertions, and additional **H-SKEW** cost observability (lower-bound assertions on hour test; ignored cadence matrix probe).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df35e189e982aa28d0981e917519afa6f9ace358. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->