### PR TITLE
Add bounded long-run network soak

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -76,8 +76,9 @@ slow-timeout = { period = "60s", terminate-after = 3 } # 180s: above the 165s ma
 
 # Nightly network profile - used ONLY by ci-network-nightly.yml via
 # `--profile ci-network-nightly --run-ignored ignored-only`. The ignored tests
-# are the extreme-chaos scenarios (peer timeouts up to 240s) and the long
-# endurance sessions (peer timeouts up to 600s for the 5000-frame stress test).
+# are the extreme-chaos scenarios (peer timeouts up to 240s), the long
+# endurance sessions (peer timeouts up to 600s for the 5000-frame stress test),
+# and the 4,000,000-frame deterministic soak selected by ci-network-nightly.yml.
 # Their nextest budget MUST exceed those internal timeouts + harness overhead
 # on every matrix OS, otherwise nextest would SIGKILL them before their own
 # timeout fires. 960s (period 60s, terminate-after 16) covers the macOS-scaled

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -93,6 +93,13 @@ filter = 'test(network::multi_process::)'
 test-group = "network-multi-process"
 slow-timeout = { period = "60s", terminate-after = 16 } # 960s: covers the 930s macOS-scaled endurance ceiling
 
+# The deterministic 4,000,000-frame soak measured 203.47s locally in release
+# mode. A 600s ceiling leaves shared-runner/OS headroom while remaining far
+# below the 240-minute workflow bound.
+[[profile.ci-network-nightly.overrides]]
+filter = 'test(network::soak::four_million_frame_soak_preserves_bounds_replay_and_lifecycle)'
+slow-timeout = { period = "60s", terminate-after = 10 }
+
 [profile.ci-network-nightly.junit]
 path = "target/nextest/ci-network-nightly/junit.xml"
 

--- a/.github/workflows/ci-network-nightly.yml
+++ b/.github/workflows/ci-network-nightly.yml
@@ -165,7 +165,9 @@ jobs:
           SCCACHE_IDLE_TIMEOUT: "0"
 
       - name: Run ignored extreme real-UDP tests and deterministic soak (nextest)
-        run: cargo nextest run --profile ci-network-nightly --release --run-ignored ignored-only -E 'test(multi_process) or test(network::soak::four_million_frame_soak_preserves_bounds_replay_and_lifecycle)' --test network --features hot-join --no-capture
+        run: |
+          cargo nextest run --profile ci-network-nightly --release --run-ignored ignored-only -E 'test(multi_process)' --test network --features hot-join --no-capture
+          cargo nextest run --profile ci-network-nightly --release --run-ignored ignored-only -E 'test(network::soak::four_million_frame_soak_preserves_bounds_replay_and_lifecycle)' --test network --features hot-join --no-capture
         env:
           # Nightly tier: stand the per-PR smoke-tier guard down so the ignored
           # loss-bearing real-UDP scenarios are allowed to run (the spawn_peer

--- a/.github/workflows/ci-network-nightly.yml
+++ b/.github/workflows/ci-network-nightly.yml
@@ -164,8 +164,8 @@ jobs:
           SCCACHE_STARTUP_NOTIFY_TIMEOUT: "60"
           SCCACHE_IDLE_TIMEOUT: "0"
 
-      - name: Run ignored extreme real-UDP network tests (nextest)
-        run: cargo nextest run --profile ci-network-nightly --release --run-ignored ignored-only -E 'test(multi_process)' --test network
+      - name: Run ignored extreme real-UDP tests and deterministic soak (nextest)
+        run: cargo nextest run --profile ci-network-nightly --release --run-ignored ignored-only -E 'test(multi_process) or test(network::soak::four_million_frame_soak_preserves_bounds_replay_and_lifecycle)' --test network --features hot-join --no-capture
         env:
           # Nightly tier: stand the per-PR smoke-tier guard down so the ignored
           # loss-bearing real-UDP scenarios are allowed to run (the spawn_peer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pre-existing:** repeated two-player hot-joins under packet loss no longer strand the joiner one input frame behind. A serving host now defers pre-commit input packets and reliably backfills the activation frame before accepting the new generation's stream; an uncaptured N-player serve whose saved-state frame moves during an honest rollback repair aborts immediately and retries at a fresh frame instead of emitting an Error on every poll until timeout.
+
 ## [0.10.0] - 2026-07-12
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,6 +413,18 @@ pub mod __internal {
     pub fn message_metadata(message: &crate::Message) -> (usize, crate::MessageKind) {
         (message.encoded_len(), message.kind())
     }
+
+    /// Returns `(event_queue_len, event_queue_limit, local_checksum_history_len)`.
+    ///
+    /// This unstable hook exists for long-running integration tests that audit
+    /// the crate's bounded-allocation contracts without exposing mutable
+    /// internals to applications.
+    #[must_use]
+    pub fn p2p_container_lengths<T: crate::Config>(
+        session: &crate::P2PSession<T>,
+    ) -> (usize, usize, usize) {
+        session.container_lengths_for_tests()
+    }
 }
 
 // #############

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -3238,6 +3238,7 @@ impl<T: Config> P2PSession<T> {
             return false;
         };
         if let Some(endpoint) = self.player_reg.remotes.get_mut(&serve.addr) {
+            endpoint.set_defer_input_processing(false);
             endpoint.clear_pending_output();
         }
         true
@@ -3393,6 +3394,15 @@ impl<T: Config> P2PSession<T> {
             if !self.player_reg.remotes.contains_key(&addr) {
                 continue;
             }
+            // The joiner applies the snapshot before the host consumes its
+            // snapshot ack. Under loss/jitter, a real Input(F) can overtake
+            // that ack. Defer Input processing until Phase 3 reactivates the
+            // session-level slot; otherwise the protocol consumes and acks F
+            // while `local_connect_status` is still disconnected, and the
+            // session then rejects F+1 forever as a sequence gap.
+            if let Some(endpoint) = self.player_reg.remotes.get_mut(&addr) {
+                endpoint.set_defer_input_processing(true);
+            }
             // Cache the serve. The actual send is Phase 2's job — it is the SOLE
             // snapshot-send site, so the serve we open here is transmitted exactly
             // once this poll (Phase 2 runs immediately below) and once per poll
@@ -3532,6 +3542,16 @@ impl<T: Config> P2PSession<T> {
             } else {
                 std::cmp::min(self.disconnect_frame, activation_frame)
             };
+            // A freshly synchronized/rearmed endpoint can open and commit a
+            // serve before an organic `advance_frame` ever queued the host's
+            // input at F. Reuse the N-peer activation-window backfill to make
+            // the reliable stream begin at F in both the empty-queue and
+            // persisted-gap cases. Without this, the joiner consumes F+1
+            // first and rejects the entire stream as out of sequence.
+            self.backfill_joiner_pending_inputs(&addr, activation_frame);
+            if let Some(endpoint) = self.player_reg.remotes.get_mut(&addr) {
+                endpoint.set_defer_input_processing(false);
+            }
             // Join complete: retire the serve and the reservation, resume solo+peer
             // advancing (the host unpauses once `joining` is empty).
             self.hot_join.joining.remove(&handle);
@@ -4026,17 +4046,21 @@ impl<T: Config> P2PSession<T> {
                     },
                 }
             } else {
-                // The pause holds last_saved fixed, so this indicates the serve
-                // opened against a moving frame counter — fail loudly and let
-                // Phase 4 abort rather than serve a wrong F.
+                // A late input can legitimately trigger a rollback repair after
+                // the serve opens but before capture, moving `last_saved` off S.
+                // No snapshot bytes exist yet, so abort immediately and let the
+                // R3 retry choose a fresh later frame. Waiting for Phase 4 only
+                // repeats an Error every poll for an honest loss/reorder race.
                 report_violation!(
-                    ViolationSeverity::Error,
+                    ViolationSeverity::Warning,
                     ViolationKind::FrameSync,
-                    "N-peer hot-join serve for slot {}: last_saved_frame {} moved off the pinned snapshot frame {} while paused",
+                    "N-peer hot-join serve for slot {} aborted before capture: last_saved_frame {} moved off the pinned snapshot frame {} during rollback repair",
                     serve.handle,
                     self.sync_layer.last_saved_frame(),
                     serve.snapshot_frame
                 );
+                self.abort_npeer_serve(serve);
+                return;
             }
         }
 
@@ -7823,6 +7847,15 @@ impl<T: Config> P2PSession<T> {
     /// ```
     pub fn metrics(&self) -> SessionMetrics {
         self.metrics
+    }
+
+    /// Returns current bounded-container lengths for integration diagnostics.
+    pub(crate) fn container_lengths_for_tests(&self) -> (usize, usize, usize) {
+        (
+            self.event_queue.len(),
+            self.max_event_queue_size,
+            self.local_checksum_history.len(),
+        )
     }
 
     /// Returns the confirmed inputs for all players at a specific frame.
@@ -11957,19 +11990,6 @@ impl<T: Config> P2PSession<T> {
                         return;
                     };
 
-                    if let Some(checksum) = cell.checksum() {
-                        for remote in self.player_reg.remotes.values_mut() {
-                            remote.send_checksum_report(frame_to_send, checksum);
-                        }
-                        self.last_sent_checksum_frame = frame_to_send;
-                        // collect locally for later comparison
-                        self.local_checksum_history.insert(frame_to_send, checksum);
-                        // Record the peak history length (the momentary overshoot
-                        // before the size-cap prune below is the true high-water).
-                        self.metrics
-                            .observe_checksum_history_len(self.local_checksum_history.len());
-                    }
-
                     // Retention is deliberately governed by the configured
                     // scheduled-frame window, not peer `last_verified_frame`
                     // cursors. Those cursors advance only on a match, so using
@@ -11979,11 +11999,23 @@ impl<T: Config> P2PSession<T> {
                     // the schedule still advanced and older evidence must remain
                     // bounded, though the history may contain fewer than the cap.
                     let max_history = self.protocol_config.max_checksum_history;
-                    if self.local_checksum_history.len() > max_history {
+                    if self.local_checksum_history.len() >= max_history {
                         let oldest_frame_to_keep =
                             checksum_history_oldest_frame(frame_to_send, max_history, interval);
                         self.local_checksum_history
                             .retain(|&frame, _| frame >= oldest_frame_to_keep);
+                    }
+
+                    if let Some(checksum) = cell.checksum() {
+                        for remote in self.player_reg.remotes.values_mut() {
+                            remote.send_checksum_report(frame_to_send, checksum);
+                        }
+                        self.last_sent_checksum_frame = frame_to_send;
+                        // Pre-pruning above keeps the configured cap as a hard
+                        // allocation bound, including the insertion high-water.
+                        self.local_checksum_history.insert(frame_to_send, checksum);
+                        self.metrics
+                            .observe_checksum_history_len(self.local_checksum_history.len());
                     }
                 }
             },
@@ -14624,6 +14656,37 @@ mod tests {
             vec![Frame::new(2)],
             "scheduled frame 3 with a cap of 2 must prune frames older than 2"
         );
+
+        // Refill the cap and harvest a real checksum. Pruning must happen
+        // before insertion: the configured cap is an allocation bound, not
+        // merely the final length after a one-entry overshoot.
+        session.local_checksum_history.insert(Frame::new(3), 3);
+        let request = session.sync_layer.save_current_state();
+        if let FortressRequest::SaveGameState { cell, frame } = request {
+            assert_eq!(frame, Frame::new(4));
+            assert!(cell.save(frame, Some(0u8), Some(4)));
+        }
+        session.sync_layer.advance_frame();
+        session
+            .sync_layer
+            .set_last_confirmed_frame(Frame::new(4), session.save_mode);
+        session.last_sent_checksum_frame = Frame::new(3);
+
+        session.check_checksum_send_interval();
+
+        assert_eq!(
+            session.metrics().checksum_history_high_water,
+            2,
+            "checksum insertion must never allocate above max_checksum_history"
+        );
+        assert_eq!(
+            session
+                .local_checksum_history
+                .keys()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![Frame::new(3), Frame::new(4)]
+        );
     }
 
     #[test]
@@ -15162,8 +15225,26 @@ mod tests {
             "an endpoint requesting the reserved slot it owns must open a serve"
         );
         assert!(
+            host.player_reg
+                .remotes
+                .get(&addr_b)
+                .expect("addr_b endpoint exists")
+                .defers_input_processing(),
+            "an open serve must defer pre-commit Input packets"
+        );
+        assert!(
             !host.hot_join.joining.contains_key(&PlayerHandle::new(1)),
             "the spoofed handle 1 must never be served"
+        );
+        assert!(host.abort_hot_join_serve(PlayerHandle::new(2)));
+        assert!(
+            !host
+                .player_reg
+                .remotes
+                .get(&addr_b)
+                .expect("addr_b endpoint exists")
+                .defers_input_processing(),
+            "serve abort must restore ordinary Input processing"
         );
     }
 

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -16,4 +16,6 @@ mod network {
     pub mod peer_metrics;
     pub mod protocol_version;
     pub mod resilience;
+    #[cfg(feature = "hot-join")]
+    pub mod soak;
 }

--- a/tests/network/soak.rs
+++ b/tests/network/soak.rs
@@ -1,0 +1,498 @@
+//! Long-running deterministic boundedness soak.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use crate::common::sim_net::{LinkPolicy, SimNet};
+use crate::common::stubs::{GameStub, StubConfig, StubInput};
+use crate::common::test_clock::TestClock;
+use fortress_rollback::telemetry::{CollectingObserver, ViolationSeverity};
+use fortress_rollback::{
+    __internal::p2p_container_lengths, DesyncDetection, DisconnectBehavior, FortressError, Message,
+    P2PSession, PeerMetrics, PlayerHandle, PlayerType, ProtocolConfig, SessionBuilder,
+    SessionState, SpectatorSession,
+};
+use std::collections::BTreeSet;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+const TARGET_CONFIRMED_FRAMES: i32 = 4_000_000;
+const CHECKPOINT_FRAMES: i32 = 50_000;
+const WARMUP_FRAMES: i32 = 1_000_000;
+const VIRTUAL_HOUR_FRAMES: i32 = 216_000;
+const HOT_JOIN_INTERVAL_FRAMES: i32 = 100_000;
+const POLL_INTERVAL: Duration = Duration::from_millis(16);
+const MAX_STEPS_PER_TARGET_FRAME: i64 = 8;
+const MAX_CHECKSUM_HISTORY: usize = 32;
+const PENDING_OUTPUT_LIMIT: u64 = 128;
+
+fn target_confirmed_frames() -> i32 {
+    std::env::var("FORTRESS_SOAK_TARGET_FRAMES")
+        .ok()
+        .and_then(|value| value.parse::<i32>().ok())
+        .filter(|target| *target >= CHECKPOINT_FRAMES)
+        .unwrap_or(TARGET_CONFIRMED_FRAMES)
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ContainerHighWater {
+    event_queue: usize,
+    checksum_history: usize,
+    pending_checksums: u64,
+    pending_output: u64,
+}
+
+impl ContainerHighWater {
+    fn observe_session(&mut self, session: &P2PSession<StubConfig>, n_players: usize) {
+        let (event_len, event_limit, checksum_len) = p2p_container_lengths(session);
+        assert!(
+            event_len <= event_limit,
+            "event queue exceeded its configured bound: {event_len} > {event_limit}"
+        );
+        assert!(
+            checksum_len <= MAX_CHECKSUM_HISTORY,
+            "checksum history exceeded its configured bound: {checksum_len} > {MAX_CHECKSUM_HISTORY}"
+        );
+        let session_metrics = session.metrics();
+        let event_high =
+            usize::try_from(session_metrics.event_queue_high_water).unwrap_or(usize::MAX);
+        let checksum_high =
+            usize::try_from(session_metrics.checksum_history_high_water).unwrap_or(usize::MAX);
+        assert!(
+            event_high <= event_limit,
+            "event-queue high-water mark exceeded its configured bound: {event_high} > {event_limit}"
+        );
+        assert!(
+            checksum_high <= MAX_CHECKSUM_HISTORY,
+            "checksum-history high-water mark exceeded its configured bound: {checksum_high} > {MAX_CHECKSUM_HISTORY}"
+        );
+        self.event_queue = self.event_queue.max(event_high);
+        self.checksum_history = self.checksum_history.max(checksum_high);
+
+        for peer in 0..n_players {
+            let handle = PlayerHandle::new(peer);
+            let Ok(metrics) = session.peer_metrics(handle) else {
+                continue;
+            };
+            self.observe_peer(&metrics);
+        }
+    }
+
+    fn observe_peer(&mut self, metrics: &PeerMetrics) {
+        self.observe_pending(metrics.pending_output_len, metrics.pending_checksums_len);
+    }
+
+    fn observe_pending(&mut self, pending_output_len: u64, pending_checksums_len: u64) {
+        assert!(
+            pending_output_len <= PENDING_OUTPUT_LIMIT,
+            "pending output exceeded its configured bound: {} > {PENDING_OUTPUT_LIMIT}",
+            pending_output_len
+        );
+        assert!(
+            pending_checksums_len <= u64::try_from(MAX_CHECKSUM_HISTORY).unwrap_or(u64::MAX),
+            "pending checksum history exceeded its configured bound: {} > {MAX_CHECKSUM_HISTORY}",
+            pending_checksums_len
+        );
+        self.pending_output = self.pending_output.max(pending_output_len);
+        self.pending_checksums = self.pending_checksums.max(pending_checksums_len);
+    }
+}
+
+struct PeerSlot {
+    session: P2PSession<StubConfig>,
+    game: GameStub,
+    observer: Arc<CollectingObserver>,
+}
+
+struct SoakRun {
+    clock: TestClock,
+    net: SimNet<Message>,
+    addrs: Vec<SocketAddr>,
+    spectator_addr: SocketAddr,
+    peers: Vec<PeerSlot>,
+    spectator: SpectatorSession<StubConfig>,
+    spectator_observer: Arc<CollectingObserver>,
+    next_checkpoint: i32,
+    next_hot_join: i32,
+    replay_checked: bool,
+    hot_joins_completed: u32,
+    periodic_hot_join: bool,
+    pending_hot_join: Option<(usize, usize, u64)>,
+    drop_commit_observers: BTreeSet<usize>,
+    high_water: ContainerHighWater,
+    last_high_water_change_frame: i32,
+    rss_last_hour: Option<(i32, u64)>,
+}
+
+fn addr(index: usize) -> SocketAddr {
+    let host = u8::try_from(index.saturating_add(1)).unwrap_or(u8::MAX);
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, host)), 31_000)
+}
+
+fn protocol_config(clock: &TestClock, seed: u64) -> ProtocolConfig {
+    ProtocolConfig {
+        clock: Some(clock.as_protocol_clock()),
+        protocol_rng_seed: Some(seed),
+        max_checksum_history: MAX_CHECKSUM_HISTORY,
+        pending_output_limit: usize::try_from(PENDING_OUTPUT_LIMIT).unwrap_or(128),
+        ..ProtocolConfig::default()
+    }
+}
+
+fn mild_policy() -> LinkPolicy {
+    LinkPolicy {
+        drop_rate: 0.01,
+        dup_rate: 0.002,
+        base_delay: Duration::from_millis(4),
+        jitter: Duration::from_millis(4),
+        burst_rate: 0.000_2,
+        burst_len: 2,
+        ..LinkPolicy::clean()
+    }
+}
+
+impl SoakRun {
+    fn new(n_players: usize, seed: u64, periodic_hot_join: bool) -> Result<Self, FortressError> {
+        let clock = TestClock::new();
+        let net = SimNet::new(seed, clock.as_protocol_clock());
+        net.set_default_policy(mild_policy());
+        let addrs: Vec<_> = (0..n_players).map(addr).collect();
+        let spectator_addr = addr(n_players);
+
+        let mut peers = Vec::with_capacity(n_players);
+        for local in 0..n_players {
+            let observer = Arc::new(CollectingObserver::new());
+            let mut builder = SessionBuilder::<StubConfig>::new()
+                .with_num_players(n_players)?
+                .with_protocol_config(protocol_config(
+                    &clock,
+                    seed.saturating_add(u64::try_from(local).unwrap_or(u64::MAX)),
+                ))
+                .with_desync_detection_mode(DesyncDetection::On { interval: 60 })
+                .with_disconnect_behavior(DisconnectBehavior::ContinueWithout)
+                .with_hot_join(periodic_hot_join && local == n_players.saturating_sub(1))
+                .with_recording(local == 0)
+                .with_violation_observer(Arc::clone(&observer) as Arc<_>);
+            for (peer, &peer_addr) in addrs.iter().enumerate() {
+                let player_type = if peer == local {
+                    PlayerType::Local
+                } else {
+                    PlayerType::Remote(peer_addr)
+                };
+                builder = builder.add_player(player_type, PlayerHandle::new(peer))?;
+            }
+            builder = builder.add_player(
+                PlayerType::Spectator(spectator_addr),
+                PlayerHandle::new(n_players),
+            )?;
+            peers.push(PeerSlot {
+                session: builder.start_p2p_session(net.attach(addrs[local]))?,
+                game: GameStub::new(),
+                observer,
+            });
+        }
+
+        let spectator_observer = Arc::new(CollectingObserver::new());
+        let spectator = SessionBuilder::<StubConfig>::new()
+            .with_num_players(n_players)?
+            .with_protocol_config(protocol_config(&clock, seed ^ 0x5350_4543_5441_544f))
+            .with_violation_observer(Arc::clone(&spectator_observer) as Arc<_>)
+            .start_spectator_session_multi(&addrs, net.attach(spectator_addr))
+            .expect("validated spectator host set starts");
+
+        Ok(Self {
+            clock,
+            net,
+            addrs,
+            spectator_addr,
+            peers,
+            spectator,
+            spectator_observer,
+            next_checkpoint: CHECKPOINT_FRAMES,
+            next_hot_join: HOT_JOIN_INTERVAL_FRAMES,
+            replay_checked: false,
+            hot_joins_completed: 0,
+            periodic_hot_join,
+            pending_hot_join: None,
+            drop_commit_observers: BTreeSet::new(),
+            high_water: ContainerHighWater::default(),
+            last_high_water_change_frame: 0,
+            rss_last_hour: None,
+        })
+    }
+
+    fn min_confirmed(&self) -> i32 {
+        self.peers
+            .iter()
+            .map(|peer| peer.session.confirmed_frame().as_i32())
+            .min()
+            .unwrap_or(-1)
+    }
+
+    fn poll_and_advance(&mut self, step: u64) -> Result<(), FortressError> {
+        for (local, peer) in self.peers.iter_mut().enumerate() {
+            peer.session.poll_remote_clients();
+            for event in peer.session.events() {
+                if self.pending_hot_join.is_some_and(|(slot, _host, _)| {
+                    matches!(event, fortress_rollback::FortressEvent::PeerDropped { handle, .. } if handle == PlayerHandle::new(slot))
+                }) {
+                    self.drop_commit_observers.insert(local);
+                }
+            }
+        }
+        self.spectator.poll_remote_clients();
+        let _: Vec<_> = self.spectator.events().collect();
+
+        for (local, peer) in self.peers.iter_mut().enumerate() {
+            if peer.session.current_state() != SessionState::Running {
+                continue;
+            }
+            let local_word = u32::try_from(local).unwrap_or(u32::MAX);
+            peer.session.add_local_input(
+                PlayerHandle::new(local),
+                StubInput {
+                    inp: u32::try_from(step)
+                        .unwrap_or(u32::MAX)
+                        .wrapping_mul(31)
+                        .wrapping_add(local_word),
+                },
+            )?;
+            match peer.session.advance_frame() {
+                Ok(requests) => peer.game.handle_requests(requests),
+                Err(FortressError::PredictionThreshold | FortressError::NotSynchronized) => {},
+                Err(error) => return Err(error),
+            }
+        }
+        if self.spectator.current_state() == SessionState::Running {
+            match self.spectator.advance_frame() {
+                Ok(_)
+                | Err(FortressError::PredictionThreshold | FortressError::NotSynchronized) => {},
+                Err(error) => return Err(error),
+            }
+        }
+        self.clock.advance(POLL_INTERVAL);
+        if self.pending_hot_join.is_some_and(|(slot, _, _)| {
+            self.drop_commit_observers.len() == self.addrs.len().saturating_sub(1)
+                && !self.drop_commit_observers.contains(&slot)
+        }) {
+            self.start_replacement()?;
+        }
+        Ok(())
+    }
+
+    fn checkpoint(&mut self, confirmed: i32) -> Result<(), FortressError> {
+        let previous_high_water = self.high_water;
+        for peer in &self.peers {
+            self.high_water
+                .observe_session(&peer.session, self.addrs.len());
+            assert!(
+                peer.observer
+                    .violations_at_severity(ViolationSeverity::Error)
+                    .is_empty(),
+                "peer emitted Error+ violations at frame {confirmed}: {:?}",
+                peer.observer.violations()
+            );
+            // The observer is diagnostic instrumentation, not production
+            // session state. Keep it from becoming the only unbounded object
+            // in the boundedness test when warning-level events are expected.
+            peer.observer.clear();
+        }
+        assert!(
+            self.spectator_observer
+                .violations_at_severity(ViolationSeverity::Error)
+                .is_empty(),
+            "spectator emitted Error+ violations at frame {confirmed}: {:?}",
+            self.spectator_observer.violations()
+        );
+        self.spectator_observer.clear();
+
+        if !self.replay_checked {
+            let replay = self.peers[0].session.take_replay()?;
+            replay.validate()?;
+            assert!(
+                !replay.frames.is_empty(),
+                "soak replay must contain confirmed frames"
+            );
+            self.replay_checked = true;
+        }
+
+        if self.high_water != previous_high_water {
+            self.last_high_water_change_frame = confirmed;
+        }
+        self.check_rss(confirmed);
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn check_rss(&mut self, confirmed: i32) {
+        if confirmed < WARMUP_FRAMES {
+            return;
+        }
+        let Some((_, previous_rss)) = self.rss_last_hour else {
+            self.rss_last_hour = read_rss_bytes().map(|rss| (confirmed, rss));
+            return;
+        };
+        let Some((previous_frame, _)) = self.rss_last_hour else {
+            return;
+        };
+        if confirmed.saturating_sub(previous_frame) < VIRTUAL_HOUR_FRAMES {
+            return;
+        }
+        let Some(rss) = read_rss_bytes() else {
+            return;
+        };
+        assert!(
+            u128::from(rss).saturating_mul(100) < u128::from(previous_rss).saturating_mul(105),
+            "RSS grew by at least 5% in one post-warmup virtual hour: {previous_rss} -> {rss} bytes"
+        );
+        self.rss_last_hour = Some((confirmed, rss));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn check_rss(&mut self, _confirmed: i32) {}
+
+    fn maybe_hot_join(&mut self, confirmed: i32, seed: u64) -> Result<(), FortressError> {
+        if !self.periodic_hot_join
+            || confirmed < self.next_hot_join
+            || self.pending_hot_join.is_some()
+        {
+            return Ok(());
+        }
+        let n_players = self.addrs.len();
+        // Drive order makes slot 0 the stable lagging edge and the last slot
+        // the stable leading edge. Keeping one explicit coordinator avoids
+        // teaching every survivor to claim the mutually exclusive serve role.
+        let slot = 0;
+        let host = n_players.saturating_sub(1);
+
+        self.peers[host]
+            .session
+            .remove_player(PlayerHandle::new(slot))?;
+        self.pending_hot_join = Some((slot, host, seed));
+        self.drop_commit_observers.clear();
+        self.next_hot_join = self.next_hot_join.saturating_add(HOT_JOIN_INTERVAL_FRAMES);
+        Ok(())
+    }
+
+    fn start_replacement(&mut self) -> Result<(), FortressError> {
+        let Some((slot, host, seed)) = self.pending_hot_join else {
+            return Ok(());
+        };
+        let n_players = self.addrs.len();
+        self.net.detach(self.addrs[slot]);
+        let observer = Arc::new(CollectingObserver::new());
+        let mut builder = SessionBuilder::<StubConfig>::new()
+            .with_num_players(n_players)?
+            .with_protocol_config(protocol_config(
+                &self.clock,
+                seed.saturating_add(u64::from(self.hot_joins_completed))
+                    .saturating_add(1),
+            ))
+            .with_desync_detection_mode(DesyncDetection::On { interval: 60 })
+            .with_disconnect_behavior(DisconnectBehavior::ContinueWithout)
+            .with_violation_observer(Arc::clone(&observer) as Arc<_>);
+        for (peer, &peer_addr) in self.addrs.iter().enumerate() {
+            let player_type = if peer == slot {
+                PlayerType::Local
+            } else {
+                PlayerType::Remote(peer_addr)
+            };
+            builder = builder.add_player(player_type, PlayerHandle::new(peer))?;
+        }
+        builder = builder.add_player(
+            PlayerType::Spectator(self.spectator_addr),
+            PlayerHandle::new(n_players),
+        )?;
+
+        let session =
+            builder.start_hot_join_session(self.net.attach(self.addrs[slot]), self.addrs[host])?;
+        self.peers[slot] = PeerSlot {
+            session,
+            game: GameStub::new(),
+            observer,
+        };
+        self.hot_joins_completed = self.hot_joins_completed.saturating_add(1);
+        self.pending_hot_join = None;
+        self.drop_commit_observers.clear();
+        Ok(())
+    }
+
+    fn run_to_target(mut self, seed: u64) -> Result<(), FortressError> {
+        let target = target_confirmed_frames();
+        let step_limit = i64::from(target).saturating_mul(MAX_STEPS_PER_TARGET_FRAME);
+        for step in 0..u64::try_from(step_limit).unwrap_or(u64::MAX) {
+            self.poll_and_advance(step)?;
+            let confirmed = self.min_confirmed();
+            self.maybe_hot_join(confirmed, seed)?;
+            while confirmed >= self.next_checkpoint {
+                self.checkpoint(confirmed)?;
+                self.next_checkpoint = self.next_checkpoint.saturating_add(CHECKPOINT_FRAMES);
+            }
+            if confirmed >= target && self.pending_hot_join.is_none() {
+                assert!(self.replay_checked, "the replay checkpoint must run");
+                if target >= WARMUP_FRAMES.saturating_add(VIRTUAL_HOUR_FRAMES) {
+                    assert!(
+                        confirmed.saturating_sub(self.last_high_water_change_frame)
+                            >= VIRTUAL_HOUR_FRAMES,
+                        "bounded-container high-water marks did not plateau for a final virtual hour: last change at {}, final frame {confirmed}, high-water {:?}",
+                        self.last_high_water_change_frame,
+                        self.high_water
+                    );
+                }
+                if self.periodic_hot_join {
+                    let expected = u32::try_from(target / HOT_JOIN_INTERVAL_FRAMES).unwrap_or(0);
+                    assert!(
+                        self.hot_joins_completed >= expected,
+                        "expected at least {expected} periodic hot-joins through the soak, got {}",
+                        self.hot_joins_completed
+                    );
+                }
+                assert!(
+                    self.spectator.current_frame().as_i32() > 0,
+                    "the attached spectator must make progress"
+                );
+                return Ok(());
+            }
+        }
+        let states: Vec<_> = self
+            .peers
+            .iter()
+            .map(|peer| {
+                (
+                    peer.session.current_state(),
+                    peer.session.current_frame().as_i32(),
+                    peer.session.confirmed_frame().as_i32(),
+                    peer.session.diagnostic_connect_status(),
+                    peer.observer
+                        .violations_at_severity(ViolationSeverity::Error),
+                )
+            })
+            .collect();
+        panic!(
+            "soak failed to reach {target} confirmed frames; stopped at {}; peers={states:#?}",
+            self.min_confirmed(),
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_rss_bytes() -> Option<u64> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let resident_pages = statm.split_whitespace().nth(1)?.parse::<u64>().ok()?;
+    Some(resident_pages.saturating_mul(4096))
+}
+
+#[test]
+#[ignore = "4,000,000-frame deterministic release-mode boundedness soak; nightly CI only"]
+fn four_million_frame_soak_preserves_bounds_replay_and_lifecycle() -> Result<(), FortressError> {
+    SoakRun::new(2, 0x50A4_0002, true)?.run_to_target(0x50A4_0002)?;
+    SoakRun::new(4, 0x50A4_0004, false)?.run_to_target(0x50A4_0004)
+}
+
+#[test]
+fn high_water_tracks_each_bounded_container() {
+    let mut high = ContainerHighWater::default();
+    high.observe_pending(7, 3);
+    assert_eq!(high.pending_output, 7);
+    assert_eq!(high.pending_checksums, 3);
+}

--- a/tests/network/soak.rs
+++ b/tests/network/soak.rs
@@ -123,7 +123,7 @@ struct SoakRun {
     drop_commit_observers: BTreeSet<usize>,
     high_water: ContainerHighWater,
     last_high_water_change_frame: i32,
-    rss_baseline: Option<(i32, u64)>,
+    rss_baseline: Option<u64>,
     rss_last_hour: Option<(i32, u64)>,
 }
 
@@ -336,15 +336,12 @@ impl SoakRun {
             return;
         };
         if self.rss_baseline.is_none() {
-            self.rss_baseline = Some((confirmed, rss));
+            self.rss_baseline = Some(rss);
             self.rss_last_hour = Some((confirmed, rss));
             return;
         }
-        let Some((_, previous_rss)) = self.rss_last_hour else {
+        let Some((previous_frame, previous_rss)) = self.rss_last_hour else {
             self.rss_last_hour = Some((confirmed, rss));
-            return;
-        };
-        let Some((previous_frame, _)) = self.rss_last_hour else {
             return;
         };
         if confirmed.saturating_sub(previous_frame) < VIRTUAL_HOUR_FRAMES {
@@ -352,14 +349,16 @@ impl SoakRun {
         }
         assert!(
             rss_growth_within_limit(previous_rss, rss, RSS_HOURLY_GROWTH_PERCENT),
-            "RSS grew by at least 5% in one post-warmup virtual hour: {previous_rss} -> {rss} bytes"
+            "RSS grew by at least {RSS_HOURLY_GROWTH_PERCENT}% in one post-warmup virtual hour: \
+             {previous_rss} -> {rss} bytes"
         );
-        let Some((_, baseline_rss)) = self.rss_baseline else {
+        let Some(baseline_rss) = self.rss_baseline else {
             return;
         };
         assert!(
             rss_growth_within_limit(baseline_rss, rss, RSS_TOTAL_GROWTH_PERCENT),
-            "RSS grew by at least 10% from the first post-warmup sample: {baseline_rss} -> {rss} bytes"
+            "RSS grew by at least {RSS_TOTAL_GROWTH_PERCENT}% from the first post-warmup sample: \
+             {baseline_rss} -> {rss} bytes"
         );
         self.rss_last_hour = Some((confirmed, rss));
     }
@@ -521,5 +520,11 @@ fn high_water_tracks_each_bounded_container() {
 #[test]
 fn rss_growth_gate_rejects_large_cumulative_growth() {
     assert!(rss_growth_within_limit(100, 104, RSS_HOURLY_GROWTH_PERCENT));
+    assert!(!rss_growth_within_limit(
+        100,
+        105,
+        RSS_HOURLY_GROWTH_PERCENT
+    ));
+    assert!(rss_growth_within_limit(100, 109, RSS_TOTAL_GROWTH_PERCENT));
     assert!(!rss_growth_within_limit(100, 110, RSS_TOTAL_GROWTH_PERCENT));
 }

--- a/tests/network/soak.rs
+++ b/tests/network/soak.rs
@@ -25,6 +25,8 @@ const POLL_INTERVAL: Duration = Duration::from_millis(16);
 const MAX_STEPS_PER_TARGET_FRAME: i64 = 8;
 const MAX_CHECKSUM_HISTORY: usize = 32;
 const PENDING_OUTPUT_LIMIT: u64 = 128;
+const RSS_HOURLY_GROWTH_PERCENT: u64 = 5;
+const RSS_TOTAL_GROWTH_PERCENT: u64 = 10;
 
 fn target_confirmed_frames() -> i32 {
     std::env::var("FORTRESS_SOAK_TARGET_FRAMES")
@@ -121,6 +123,7 @@ struct SoakRun {
     drop_commit_observers: BTreeSet<usize>,
     high_water: ContainerHighWater,
     last_high_water_change_frame: i32,
+    rss_baseline: Option<(i32, u64)>,
     rss_last_hour: Option<(i32, u64)>,
 }
 
@@ -217,6 +220,7 @@ impl SoakRun {
             drop_commit_observers: BTreeSet::new(),
             high_water: ContainerHighWater::default(),
             last_high_water_change_frame: 0,
+            rss_baseline: None,
             rss_last_hour: None,
         })
     }
@@ -328,8 +332,16 @@ impl SoakRun {
         if confirmed < WARMUP_FRAMES {
             return;
         }
+        let Some(rss) = read_rss_bytes() else {
+            return;
+        };
+        if self.rss_baseline.is_none() {
+            self.rss_baseline = Some((confirmed, rss));
+            self.rss_last_hour = Some((confirmed, rss));
+            return;
+        }
         let Some((_, previous_rss)) = self.rss_last_hour else {
-            self.rss_last_hour = read_rss_bytes().map(|rss| (confirmed, rss));
+            self.rss_last_hour = Some((confirmed, rss));
             return;
         };
         let Some((previous_frame, _)) = self.rss_last_hour else {
@@ -338,12 +350,16 @@ impl SoakRun {
         if confirmed.saturating_sub(previous_frame) < VIRTUAL_HOUR_FRAMES {
             return;
         }
-        let Some(rss) = read_rss_bytes() else {
+        assert!(
+            rss_growth_within_limit(previous_rss, rss, RSS_HOURLY_GROWTH_PERCENT),
+            "RSS grew by at least 5% in one post-warmup virtual hour: {previous_rss} -> {rss} bytes"
+        );
+        let Some((_, baseline_rss)) = self.rss_baseline else {
             return;
         };
         assert!(
-            u128::from(rss).saturating_mul(100) < u128::from(previous_rss).saturating_mul(105),
-            "RSS grew by at least 5% in one post-warmup virtual hour: {previous_rss} -> {rss} bytes"
+            rss_growth_within_limit(baseline_rss, rss, RSS_TOTAL_GROWTH_PERCENT),
+            "RSS grew by at least 10% from the first post-warmup sample: {baseline_rss} -> {rss} bytes"
         );
         self.rss_last_hour = Some((confirmed, rss));
     }
@@ -482,6 +498,11 @@ fn read_rss_bytes() -> Option<u64> {
     Some(resident_pages.saturating_mul(4096))
 }
 
+fn rss_growth_within_limit(previous: u64, current: u64, growth_percent: u64) -> bool {
+    u128::from(current).saturating_mul(100)
+        < u128::from(previous).saturating_mul(u128::from(100_u64.saturating_add(growth_percent)))
+}
+
 #[test]
 #[ignore = "4,000,000-frame deterministic release-mode boundedness soak; nightly CI only"]
 fn four_million_frame_soak_preserves_bounds_replay_and_lifecycle() -> Result<(), FortressError> {
@@ -495,4 +516,10 @@ fn high_water_tracks_each_bounded_container() {
     high.observe_pending(7, 3);
     assert_eq!(high.pending_output, 7);
     assert_eq!(high.pending_checksums, 3);
+}
+
+#[test]
+fn rss_growth_gate_rejects_large_cumulative_growth() {
+    assert!(rss_growth_within_limit(100, 104, RSS_HOURLY_GROWTH_PERCENT));
+    assert!(!rss_growth_within_limit(100, 110, RSS_TOTAL_GROWTH_PERCENT));
 }


### PR DESCRIPTION
## Summary

- add a deterministic 4,000,000-confirmed-frame nightly soak for 2-player periodic rejoin and 4-player mild-chaos endurance lanes, both with spectators, replay validation, hard container bounds, high-water plateau checks, and Linux RSS gates
- pre-prune local checksum history so its configured cap is also its true allocation high-water
- make repeated hot-join activation loss-safe by deferring pre-commit input processing, backfilling activation frame F, and retrying uncaptured N-player serves after honest rollback repair
- wire the release-mode soak into nightly network CI

## Root cause

The long-run runner exposed three boundary assumptions that shorter tests missed: checksum retention pruned after allocation, a rejoiner's activation input could be consumed or omitted around snapshot commit, and an honest pre-capture rollback could move the saved frame while an N-player serve waited. The fixes preserve fail-closed behavior while making these normal loss/reorder cases recoverable.

An exploratory repeated N=4 generation run also exposed survivor epoch divergence after 20 cycles. That separate D17 remains recorded in PLAN.md for a focused follow-up; the committed soak keeps periodic generation churn in the N=2 lane and runs N=4 as full-duration mild-chaos endurance.

## Validation

- full 4,000,000-frame release soak: passed in 203.47 s
- `cargo clippy --workspace --all-targets --features tokio,json,hot-join -- -D warnings`
- `cargo nextest run --workspace --features tokio,json,hot-join --no-capture`: 3,121 passed, 74 skipped
- `cargo test --doc --features tokio,json,hot-join -- --nocapture`: 169 passed, 54 ignored
- `cargo doc --no-deps --features tokio,json,hot-join`
- `python3 scripts/ci/agent-preflight.py --auto-fix`
- `actionlint .github/workflows/ci-network-nightly.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches P2P hot-join activation and checksum history in core session paths; behavior is narrowed to loss/reorder recovery and bounded retention, with a large new soak as regression coverage.
> 
> **Overview**
> Adds a **nightly-only** deterministic **4,000,000-frame** network soak (2-player periodic hot-join + 4-player mild chaos) that checks replay, bounded containers, high-water plateaus, and Linux RSS growth, plus **`__internal::p2p_container_lengths`** for those audits.
> 
> **Hot-join under loss:** the serving host **defers joiner `Input` processing** until commit, **backfills activation frame F** on reactivation, and **aborts uncaptured N-player serves** when rollback moves `last_saved` off the pinned snapshot (warning + retry instead of per-poll errors).
> 
> **Checksum retention:** `check_checksum_send_interval` **prunes before insert** so `max_checksum_history` is a true allocation cap (with unit coverage).
> 
> **CI:** `ci-network-nightly` runs the soak with `hot-join` and a dedicated **600s** nextest override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27281e0edae91dd12b90ecad439c048b2f5a7aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->