### PR TITLE
Confirm H-SKEW phase mechanism

### DIFF
--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -11,11 +11,15 @@ use super::harness::schedule::{
 };
 use super::harness::{
     oracle::{OracleFailure, ViolationAllowlistEntry, ViolationSignature, POST_HEAL_MIN_ADVANCE},
-    run, RunOptions, RunReport, TraceSessionState,
+    phase_control_progress_interval, phase_control_sample_capacity, run, RunOptions, RunReport,
+    TraceSessionState,
 };
 use crate::common::sim_net::{BandwidthPolicy, LinkPolicy};
 use fortress_rollback::{telemetry::ViolationSeverity, SessionState};
-use std::{collections::BTreeSet, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    time::Duration,
+};
 
 /// Fixed PR-smoke seed set. Nightly fleets derive disjoint seeds from the CI
 /// run id; the PR set stays fixed so PR failures reproduce verbatim.
@@ -3127,6 +3131,33 @@ fn skew_gated_frame_model_exercises_rate_drift_deterministically() {
     assert_ne!(exact_report.trace_hash, skewed_report.trace_hash);
 }
 
+/// Phase-resolved control sampling is opt-in: ordinary fleet runs retain the
+/// compact 12-sample trace, while a focused H-SKEW probe can preserve the
+/// intermediate frame-advantage transitions that explain a correction cycle.
+#[test]
+fn phase_resolved_skew_samples_are_bounded_and_deterministic() {
+    let mut schedule = skew_gated_schedule(1_200, 1_000_000, AppModel::Obey);
+    schedule.config.step_dt_ms = 8;
+    let options = RunOptions {
+        phase_resolved_control_samples: true,
+        ..RunOptions::default()
+    };
+
+    let first = run(&schedule, &options);
+    first.expect_pass(&schedule);
+    let replay = run(&schedule, &options);
+
+    assert_eq!(first.trace_hash, replay.trace_hash);
+    assert_eq!(first.progress_samples, replay.progress_samples);
+    assert!(first.progress_samples.len() > 12);
+    assert!(first.progress_samples.len() <= phase_control_sample_capacity(2));
+    assert!(first.progress_samples.iter().all(|sample| {
+        sample.frames_ahead.len() == 2
+            && sample.endpoints.is_empty()
+            && sample.link_queues.is_empty()
+    }));
+}
+
 #[test]
 fn schema_v15_skew_progress_preserves_legacy_trace_shape() {
     let mut schedule = skew_gated_schedule(1_200, 1_000, AppModel::Obey);
@@ -3160,16 +3191,23 @@ fn h_skew_hour_equivalent_measures_lag_correction_and_cost() {
     let mut skewed = skew_gated_schedule(240_001, 1_000, AppModel::Obey);
     skewed.config.step_dt_ms = 15;
 
-    let exact_report = run(&exact, &RunOptions::default());
+    let phase_options = RunOptions {
+        phase_resolved_control_samples: true,
+        ..RunOptions::default()
+    };
+    let exact_report = run(&exact, &phase_options);
     exact_report.expect_pass(&exact);
-    let skewed_report = run(&skewed, &RunOptions::default());
+    let skewed_report = run(&skewed, &phase_options);
     skewed_report.expect_pass(&skewed);
-    let replay = run(&skewed, &RunOptions::default());
+    let replay = run(&skewed, &phase_options);
 
     assert_eq!(exact_report.frame_opportunities, vec![216_000, 216_000]);
     assert_eq!(skewed_report.frame_opportunities, vec![216_216, 216_000]);
     assert_eq!(skewed_report.trace_hash, replay.trace_hash);
     assert_eq!(skewed_report.progress_samples, replay.progress_samples);
+    assert!(exact_report.progress_samples.len() > 2_000);
+    assert!(skewed_report.progress_samples.len() > exact_report.progress_samples.len());
+    assert!(skewed_report.progress_samples.len() < phase_control_sample_capacity(2));
     let exact_total_work = exact_report
         .metrics
         .iter()
@@ -3194,7 +3232,7 @@ fn h_skew_hour_equivalent_measures_lag_correction_and_cost() {
         "H-SKEW exact_opportunities={:?} exact_metrics={:?} \
          skewed_opportunities={:?} wait_frames_obeyed={:?} \
          skewed_metrics={:?} exact_total_work={} skewed_total_work={} \
-         exact_resimulation={} skewed_resimulation={} samples={:?}",
+         exact_resimulation={} skewed_resimulation={} sample_counts=({}, {})",
         exact_report.frame_opportunities,
         exact_report.metrics,
         skewed_report.frame_opportunities,
@@ -3204,7 +3242,8 @@ fn h_skew_hour_equivalent_measures_lag_correction_and_cost() {
         skewed_total_work,
         exact_resimulation,
         skewed_resimulation,
-        skewed_report.progress_samples
+        exact_report.progress_samples.len(),
+        skewed_report.progress_samples.len()
     );
     assert!(
         skewed_total_work.saturating_mul(100) <= exact_total_work.saturating_mul(120),
@@ -3264,24 +3303,147 @@ fn h_skew_hour_equivalent_measures_lag_correction_and_cost() {
         "steady-state confirmation lag must remain inside max_prediction: {:?}",
         final_sample.confirmation_lag
     );
-    let steady_samples = &skewed_report.progress_samples[6..];
     for peer in 0..2 {
-        let min = steady_samples
-            .iter()
-            .map(|sample| sample.confirmation_lag[peer])
-            .min()
-            .expect("steady-state sample set is non-empty");
-        let max = steady_samples
-            .iter()
-            .map(|sample| sample.confirmation_lag[peer])
-            .max()
-            .expect("steady-state sample set is non-empty");
+        let lag_range = |start: u32, end: u32| {
+            let samples = skewed_report
+                .progress_samples
+                .iter()
+                .filter(|sample| (start..end).contains(&sample.step));
+            let minimum = samples
+                .clone()
+                .map(|sample| sample.confirmation_lag[peer])
+                .min()
+                .expect("steady-state phase has samples");
+            let maximum = samples
+                .map(|sample| sample.confirmation_lag[peer])
+                .max()
+                .expect("steady-state phase has samples");
+            (minimum, maximum)
+        };
+        let third_quarter = lag_range(
+            skewed.config.steps / 2,
+            skewed.config.steps.saturating_mul(3) / 4,
+        );
+        let fourth_quarter = lag_range(
+            skewed.config.steps.saturating_mul(3) / 4,
+            skewed.config.steps,
+        );
+        assert_eq!(
+            third_quarter, fourth_quarter,
+            "phase-resolved lag range must repeat rather than creep (peer={peer})"
+        );
         assert!(
-            max.saturating_sub(min) <= 1,
-            "steady-state lag must stay flat rather than creep (peer={peer}, \
-             samples={steady_samples:?})"
+            fourth_quarter.1 <= skewed.config.max_prediction as u64,
+            "steady-state lag must stay within max_prediction (peer={peer}, \
+             range={fourth_quarter:?})"
         );
     }
+
+    let progress_interval = phase_control_progress_interval(skewed.config.steps, 2);
+    let exact_periodic: BTreeMap<_, _> = exact_report
+        .progress_samples
+        .iter()
+        .filter(|sample| (sample.step + 1) % progress_interval == 0)
+        .map(|sample| (sample.step, sample))
+        .collect();
+    let skewed_periodic: Vec<_> = skewed_report
+        .progress_samples
+        .iter()
+        .filter(|sample| (sample.step + 1) % progress_interval == 0)
+        .collect();
+    let mut interval_counts = [0_u64; 4];
+    let mut exact_resimulation_by_phase = [0_u64; 4];
+    let mut skewed_resimulation_by_phase = [0_u64; 4];
+    let mut skewed_rollbacks_by_phase = [0_u64; 4];
+    let mut wait_transitions_by_phase = [0_u64; 4];
+    let mut recommendation_transitions_by_phase = [0_u64; 4];
+    let fast_phase_range = skewed_report
+        .progress_samples
+        .iter()
+        .map(|sample| sample.frames_ahead[0])
+        .fold((i32::MAX, i32::MIN), |(minimum, maximum), value| {
+            (minimum.min(value), maximum.max(value))
+        });
+    for pair in skewed_report.progress_samples.windows(2) {
+        let previous = &pair[0];
+        let current = &pair[1];
+        let phase = usize::try_from(current.frames_ahead[0].clamp(0, 3)).unwrap_or(0);
+        wait_transitions_by_phase[phase] = wait_transitions_by_phase[phase].saturating_add(
+            current.wait_frames_obeyed[0].saturating_sub(previous.wait_frames_obeyed[0]),
+        );
+        recommendation_transitions_by_phase[phase] = recommendation_transitions_by_phase[phase]
+            .saturating_add(
+                current.wait_recommendations[0].saturating_sub(previous.wait_recommendations[0]),
+            );
+    }
+    for pair in skewed_periodic.windows(2) {
+        let previous = pair[0];
+        let current = pair[1];
+        let Some(exact_previous) = exact_periodic.get(&previous.step) else {
+            continue;
+        };
+        let Some(exact_current) = exact_periodic.get(&current.step) else {
+            continue;
+        };
+        let phase = usize::try_from(current.frames_ahead[0].clamp(0, 3)).unwrap_or(0);
+        interval_counts[phase] = interval_counts[phase].saturating_add(1);
+        exact_resimulation_by_phase[phase] = exact_resimulation_by_phase[phase].saturating_add(
+            exact_current.resimulated_frames[0]
+                .saturating_sub(exact_previous.resimulated_frames[0]),
+        );
+        skewed_resimulation_by_phase[phase] = skewed_resimulation_by_phase[phase].saturating_add(
+            current.resimulated_frames[0].saturating_sub(previous.resimulated_frames[0]),
+        );
+        skewed_rollbacks_by_phase[phase] = skewed_rollbacks_by_phase[phase]
+            .saturating_add(current.rollback_count[0].saturating_sub(previous.rollback_count[0]));
+    }
+    println!(
+        "H-SKEW-PHASE intervals={interval_counts:?} \
+         exact_fast_resim={exact_resimulation_by_phase:?} \
+         skewed_fast_resim={skewed_resimulation_by_phase:?} \
+         skewed_fast_rollbacks={skewed_rollbacks_by_phase:?} \
+         wait_transitions={wait_transitions_by_phase:?} \
+         recommendation_transitions={recommendation_transitions_by_phase:?}"
+    );
+    assert!(
+        interval_counts.iter().all(|count| *count > 0),
+        "every 0→3 controller phase must be observed: {interval_counts:?}"
+    );
+    assert_eq!(
+        fast_phase_range,
+        (0, 3),
+        "phase bucketing must not clamp an unobserved controller value"
+    );
+    assert_eq!(
+        wait_transitions_by_phase,
+        [0, 0, 0, 213],
+        "all obeyed waits must occur at the three-frame dead-band boundary"
+    );
+    assert_eq!(
+        recommendation_transitions_by_phase,
+        [0, 0, 0, 71],
+        "all recommendations must fire at the three-frame dead-band boundary"
+    );
+    for phase in 1..4 {
+        assert!(
+            skewed_resimulation_by_phase[phase]
+                .saturating_mul(skewed_rollbacks_by_phase[phase - 1])
+                > skewed_resimulation_by_phase[phase - 1]
+                    .saturating_mul(skewed_rollbacks_by_phase[phase]),
+            "fast-peer rollback depth must rise monotonically through the 0→3 \
+             controller phases: resimulation={skewed_resimulation_by_phase:?}, \
+             rollbacks={skewed_rollbacks_by_phase:?}"
+        );
+    }
+    assert!(
+        skewed_resimulation_by_phase[0].saturating_mul(100)
+            <= exact_resimulation_by_phase[0].saturating_mul(160),
+        "phase zero should stay near the exact-clock baseline"
+    );
+    assert!(
+        skewed_resimulation_by_phase[2] >= exact_resimulation_by_phase[2].saturating_mul(3),
+        "the pre-correction phase must carry the measured rollback amplification"
+    );
 }
 
 /// H-SKEW cost-amplification diagnostic: repeat a ten-minute-equivalent matched

--- a/tests/simulation/harness/artifact.rs
+++ b/tests/simulation/harness/artifact.rs
@@ -3,7 +3,8 @@
 use super::oracle::OracleFailure;
 use super::schedule::{validate_schedule, Schedule};
 use super::{
-    ProgressSample, RunReport, TraceSnapshot, TRACE_STEP_EVENT_CAPACITY, TRACE_TAIL_CAPACITY,
+    phase_control_sample_capacity, ProgressSample, RunReport, TraceSnapshot,
+    TRACE_STEP_EVENT_CAPACITY, TRACE_TAIL_CAPACITY,
 };
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
@@ -239,10 +240,15 @@ impl FailureArtifact {
                 return Err(format!("artifact has {len} {name} entries for {n} peers"));
             }
         }
-        if self.progress_samples.len() > 12 {
+        let maximum_progress_samples = if self.replay_options.phase_resolved_control_samples {
+            phase_control_sample_capacity(n)
+        } else {
+            12
+        };
+        if self.progress_samples.len() > maximum_progress_samples {
             return Err(format!(
-                "artifact has {} progress samples (maximum 12)",
-                self.progress_samples.len()
+                "artifact has {} progress samples (maximum {maximum_progress_samples})",
+                self.progress_samples.len(),
             ));
         }
         for sample in &self.progress_samples {
@@ -264,6 +270,19 @@ impl FailureArtifact {
                     ));
                 }
             }
+            let expected_frames_ahead = if self.replay_options.phase_resolved_control_samples {
+                n
+            } else {
+                0
+            };
+            if sample.frames_ahead.len() != expected_frames_ahead {
+                return Err(format!(
+                    "artifact progress sample at step {} has {} frames_ahead entries \
+                     (expected {expected_frames_ahead})",
+                    sample.step,
+                    sample.frames_ahead.len()
+                ));
+            }
             if sample.step >= self.schedule.config.steps {
                 return Err(format!(
                     "artifact progress sample step {} is outside embedded schedule",
@@ -275,7 +294,9 @@ impl FailureArtifact {
                 ("endpoints", sample.endpoints.len()),
                 ("link_queues", sample.link_queues.len()),
             ] {
-                let expected = if self.schedule.schema_version >= 16 {
+                let expected = if self.schedule.schema_version >= 16
+                    && !self.replay_options.phase_resolved_control_samples
+                {
                     directed_links
                 } else {
                     0
@@ -843,6 +864,7 @@ mod tests {
             prediction_miss_count: vec![0, 0],
             frame_opportunities: vec![1, 1],
             wait_frames_obeyed: vec![0, 0],
+            frames_ahead: Vec::new(),
             endpoints: vec![
                 EndpointControlSample {
                     from: 0,
@@ -892,6 +914,26 @@ mod tests {
         let mut misordered = artifact.clone();
         misordered.progress_samples[0].link_queues.swap(0, 1);
         assert!(misordered.validate().is_err());
+
+        let mut phase_resolved = artifact.clone();
+        phase_resolved.replay_options.phase_resolved_control_samples = true;
+        phase_resolved.schedule.config.frame_model =
+            super::super::schedule::FrameModel::SkewGated60Hz;
+        phase_resolved.progress_samples[0].frames_ahead = vec![2, -2];
+        phase_resolved.progress_samples[0].endpoints.clear();
+        phase_resolved.progress_samples[0].link_queues.clear();
+        assert!(phase_resolved.validate().is_ok());
+        let mut over_capacity = phase_resolved.clone();
+        over_capacity.progress_samples.resize(
+            phase_control_sample_capacity(2) + 1,
+            phase_resolved.progress_samples[0].clone(),
+        );
+        assert!(over_capacity.validate().is_err());
+        let mut missing_phase_signal = phase_resolved;
+        missing_phase_signal.progress_samples[0]
+            .frames_ahead
+            .clear();
+        assert!(missing_phase_signal.validate().is_err());
 
         let mut value = serde_json::to_value(sample).expect("progress sample serializes");
         let object = value

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -179,6 +179,15 @@ pub struct RunOptions {
     /// for one directed `(from, to)` link after every simulation step.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_output_probe_link: Option<(usize, usize)>,
+    /// Preserve a bounded, phase-resolved controller time series instead of
+    /// the ordinary twelve-or-fewer progress samples. The denser series is
+    /// intended for focused clock-skew/control-loop experiments and records
+    /// new opportunity-lead high-water marks and obeyed waits plus evenly spaced
+    /// samples carrying the frame-advantage gauge. It is valid only for
+    /// schema-v16-or-newer
+    /// [`FrameModel::SkewGated60Hz`] schedules.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub phase_resolved_control_samples: bool,
     /// Corrupt the configured spectator's first input fingerprint in each
     /// displayed frame at or after this frame. Negative controls only need one
     /// planted spectator-only mismatch to prove the §6.2(d) oracle compares
@@ -247,6 +256,10 @@ pub struct ProgressSample {
     pub prediction_miss_count: Vec<u64>,
     pub frame_opportunities: Vec<u64>,
     pub wait_frames_obeyed: Vec<u64>,
+    /// Session-level maximum remote frame advantage, indexed by peer. Present
+    /// only for opt-in phase-resolved controller samples.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub frames_ahead: Vec<i32>,
     /// Per-directed-endpoint control-loop gauges in `(from, to)` order.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub endpoints: Vec<EndpointControlSample>,
@@ -273,6 +286,33 @@ pub struct LinkQueueSample {
     pub queued_bytes: u64,
     pub queued_datagrams: u64,
     pub drain_delay_ns: u64,
+}
+
+/// Maximum number of phase-resolved samples retained for a two-player run.
+pub const MAX_PHASE_CONTROL_SAMPLES: usize = 4_096;
+/// Total peer-vector cells available to a phase-resolved series. Scaling the
+/// sample cap by player count prevents a 16-player artifact from multiplying
+/// the two-player memory budget by eight.
+const MAX_PHASE_CONTROL_SAMPLE_PLAYER_CELLS: usize = 8_192;
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+pub(super) fn phase_control_sample_capacity(n_players: usize) -> usize {
+    MAX_PHASE_CONTROL_SAMPLES.min(
+        MAX_PHASE_CONTROL_SAMPLE_PLAYER_CELLS
+            .checked_div(n_players.max(1))
+            .unwrap_or(1)
+            .max(1),
+    )
+}
+
+pub(super) fn phase_control_progress_interval(steps: u32, n_players: usize) -> u32 {
+    let sample_target = u32::try_from(phase_control_sample_capacity(n_players) / 2)
+        .unwrap_or(u32::MAX)
+        .max(1);
+    steps.div_ceil(sample_target).max(1)
 }
 
 /// Maximum number of final simulation steps retained in a failure artifact.
@@ -1568,6 +1608,15 @@ pub(super) fn validate_run_options(
             schedule.config.steps
         ));
     }
+    if options.phase_resolved_control_samples
+        && (schedule.schema_version < 16
+            || schedule.config.frame_model != FrameModel::SkewGated60Hz)
+    {
+        return Err(
+            "phase_resolved_control_samples requires a schema-v16-or-newer SkewGated60Hz schedule"
+                .to_owned(),
+        );
+    }
     let Some((from, to)) = options.pending_output_probe_link else {
         return Ok(());
     };
@@ -1812,12 +1861,20 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                         ScheduleEvent::SetLink { policy, .. } if policy.bandwidth.is_some()
                     )
                 })));
-    let sample_control_gauges = schedule.schema_version >= 16;
+    let phase_resolved_control_samples = options.phase_resolved_control_samples;
+    let sample_control_gauges = schedule.schema_version >= 16 && !phase_resolved_control_samples;
     let mut frame_opportunities = vec![0_u64; n];
     let mut skew_targets_seen = vec![0_u64; n];
     let mut wait_frames_obeyed = vec![0_u64; n];
     let mut local_input_ordinals = vec![0_u32; n];
-    let mut progress_samples = Vec::new();
+    let phase_sample_capacity = phase_control_sample_capacity(n);
+    let mut progress_samples = VecDeque::with_capacity(if phase_resolved_control_samples {
+        phase_sample_capacity
+    } else {
+        12
+    });
+    let mut last_phase_opportunity_lead = Vec::new();
+    let mut last_phase_wait_frames_obeyed = Vec::new();
     let mut first_running_step = if collect_receive_timing {
         vec![None; n]
     } else {
@@ -1828,7 +1885,11 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
     } else {
         Vec::new()
     };
-    let progress_interval = schedule.config.steps.div_ceil(12).max(1);
+    let progress_interval = if phase_resolved_control_samples {
+        phase_control_progress_interval(schedule.config.steps, n)
+    } else {
+        schedule.config.steps.div_ceil(12).max(1)
+    };
     // Peers whose app model never drains the session event queue (models a
     // wedged event consumer). Their bounded `event_queue` fills and the session
     // trims oldest events, firing the D9 `events_discarded_*` telemetry. Because
@@ -2271,9 +2332,44 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
             }
         }
 
-        if sample_control_loop && ((step + 1) % progress_interval == 0 || step == last_step) {
+        let phase_changed = if phase_resolved_control_samples {
+            let minimum_opportunities = frame_opportunities.iter().copied().min().unwrap_or(0);
+            let opportunity_lead_increased = last_phase_opportunity_lead.len() != n
+                || frame_opportunities
+                    .iter()
+                    .enumerate()
+                    .any(|(peer, &value)| {
+                        last_phase_opportunity_lead
+                            .get(peer)
+                            .is_none_or(|previous| {
+                                value.saturating_sub(minimum_opportunities) > *previous
+                            })
+                    });
+            let waits_changed = last_phase_wait_frames_obeyed != wait_frames_obeyed;
+            let changed = opportunity_lead_increased || waits_changed;
+            if changed {
+                if last_phase_opportunity_lead.len() != n {
+                    last_phase_opportunity_lead.resize(n, 0);
+                }
+                for (high_water, value) in last_phase_opportunity_lead
+                    .iter_mut()
+                    .zip(&frame_opportunities)
+                {
+                    *high_water = (*high_water).max(value.saturating_sub(minimum_opportunities));
+                }
+                last_phase_wait_frames_obeyed.clone_from(&wait_frames_obeyed);
+            }
+            changed
+        } else {
+            false
+        };
+        let periodic_sample_due = (step + 1) % progress_interval == 0 || step == last_step;
+        if sample_control_loop && (periodic_sample_due || phase_changed) {
             let sample_metrics: Vec<_> = peers.iter().map(|slot| slot.session.metrics()).collect();
-            progress_samples.push(ProgressSample {
+            if progress_samples.len() == phase_sample_capacity {
+                let _ = progress_samples.pop_front();
+            }
+            progress_samples.push_back(ProgressSample {
                 step,
                 current_frames: peers
                     .iter()
@@ -2302,6 +2398,14 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                     .collect(),
                 frame_opportunities: frame_opportunities.clone(),
                 wait_frames_obeyed: wait_frames_obeyed.clone(),
+                frames_ahead: if phase_resolved_control_samples {
+                    peers
+                        .iter()
+                        .map(|slot| slot.session.frames_ahead())
+                        .collect()
+                } else {
+                    Vec::new()
+                },
                 endpoints: if sample_control_gauges {
                     collect_endpoint_control_samples(&peers, n)
                 } else {
@@ -2569,6 +2673,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
     let reported_first_synchronized_step = options
         .receive_message_limit
         .map_or_else(Vec::new, |_| first_synchronized_step);
+    let progress_samples: Vec<_> = progress_samples.into();
     let final_trace_summary = TraceFinalSummary {
         failure_classes: verdict.failures.iter().map(OracleFailure::class).collect(),
         final_confirmed: final_confirmed.clone(),
@@ -3305,6 +3410,24 @@ mod tests {
             .push((120, schedule::ScheduleEvent::PeerKill { peer: 1 }));
         retiring.events.sort_by_key(|(step, _)| *step);
         assert!(validate_run_options(&retiring, &options).is_err());
+    }
+
+    #[test]
+    fn phase_resolved_control_samples_require_current_skew_schedule() {
+        let mut schedule = schedule::generate(7, schedule::SimConfig::smoke(2));
+        let options = RunOptions {
+            phase_resolved_control_samples: true,
+            ..RunOptions::default()
+        };
+        assert!(validate_run_options(&schedule, &options).is_err());
+
+        schedule.config.frame_model = schedule::FrameModel::SkewGated60Hz;
+        assert!(validate_run_options(&schedule, &options).is_ok());
+        assert_eq!(phase_control_sample_capacity(2), 4_096);
+        assert_eq!(phase_control_sample_capacity(16), 512);
+
+        schedule.schema_version = 15;
+        assert!(validate_run_options(&schedule, &options).is_err());
     }
 
     #[test]

--- a/tests/simulation/harness/shrink.rs
+++ b/tests/simulation/harness/shrink.rs
@@ -157,6 +157,7 @@ fn remap_options(options: &RunOptions, removed: usize, steps: u32) -> RunOptions
         corrupt_checksum_from: remap_peer_frame(options.corrupt_checksum_from, removed),
         probe_confirmed_at: options.probe_confirmed_at.filter(|probe| *probe < steps),
         pending_output_probe_link,
+        phase_resolved_control_samples: options.phase_resolved_control_samples,
         corrupt_spectator_input_from: options.corrupt_spectator_input_from,
         corrupt_spectator_status_from: options.corrupt_spectator_status_from,
     }
@@ -1007,6 +1008,7 @@ mod tests {
             corrupt_checksum_from: Some((1, 9)),
             probe_confirmed_at: Some(19),
             pending_output_probe_link: Some((3, 0)),
+            phase_resolved_control_samples: false,
             corrupt_spectator_input_from: Some(11),
             corrupt_spectator_status_from: Some(12),
         };


### PR DESCRIPTION
## Summary

- add an opt-in, bounded phase-resolved sampling mode for skew-gated simulation runs
- preserve the controller's `frames_ahead` signal in deterministic failure artifacts without changing legacy trace identity
- convert the one-hour H-SKEW cost inference into a phase-resolved verdict

## Why

The existing one-hour experiment retained only 12 samples. Aggregate histograms suggested that the fast peer paid deeper rollbacks while traversing the 0→3-frame wait-recommendation dead band, but they could not prove the temporal relationship.

The new 2,457-sample skew trace places all 71 recommendations and 213 obeyed waits at phase 3. Mean fast-peer rollback depth rises monotonically across phases 0→3 (approximately 1.43, 2.37, 3.33, and 3.94 frames). This confirms the mechanism for the deliberately always-changing stress input without changing production time-sync policy.

## Validation

- `cargo clippy --workspace --all-targets --features tokio,json`
- default nextest suite: 2,842 passed, 73 skipped
- hot-join nextest suite: 3,098 passed, 74 skipped
- release one-hour H-SKEW probe with exact replay: passed
- `python3 scripts/ci/agent-preflight.py --auto-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulation harness telemetry, artifact validation, and tests; production rollback/time-sync code is untouched and legacy 12-sample traces are unchanged by default.
> 
> **Overview**
> Adds an **opt-in** `RunOptions::phase_resolved_control_samples` mode for schema-v16+ `SkewGated60Hz` runs. Default fleet behavior stays on the compact ≤12-sample progress trace; when enabled, the harness records a **bounded** time series (up to ~4k samples for two players, scaled by peer count) that includes **`frames_ahead`** on each sample and extra samples on opportunity-lead / obeyed-wait transitions, without the schema-16 endpoint/link gauge payload.
> 
> **Failure artifacts** validate the larger sample cap, require per-peer `frames_ahead` when the flag is set, and skip endpoint/link fields for phase-resolved replays. Shrinker remapping preserves the new option.
> 
> **Tests:** a focused bounded/determinism probe; the hour-equivalent H-SKEW experiment now runs with phase sampling and asserts phase-bucketed lag stability, that waits/recommendations fire only at the three-frame dead band, and monotonic rollback depth across controller phases 0→3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd080badcacb616fabed2049c087a32c876667b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->