### PR TITLE
Document D12 frame-domain boundary

### DIFF
--- a/src/network/codec.rs
+++ b/src/network/codec.rs
@@ -397,6 +397,12 @@ fn read_i32(bytes: &[u8], cursor: &mut usize, field: &'static str) -> CodecResul
     Ok(i32::from_le_bytes(read_array(bytes, cursor, field)?))
 }
 
+/// Reads one wire frame using the complete public [`Frame`] value domain.
+///
+/// Every non-negative `i32` through `i32::MAX` is valid. `Frame::NULL` is
+/// additionally accepted only for fields whose protocol semantics explicitly
+/// allow the sentinel. There is deliberately no smaller "sane" upper bound:
+/// imposing one here would reject frame values that the public type supports.
 fn read_frame(
     bytes: &[u8],
     cursor: &mut usize,
@@ -3112,6 +3118,43 @@ mod tests {
             let bytes = encode(&message).unwrap();
             let result = decode_message(&bytes);
             assert_eq!(result, Ok((message, bytes.len())));
+        }
+    }
+
+    #[test]
+    fn decode_message_accepts_maximum_frame_for_all_d12_fields() {
+        let maximum = Frame::new(i32::MAX);
+        let messages = [
+            Message {
+                header: MessageHeader::new(0xABCD),
+                body: MessageBody::Input(Input {
+                    peer_connect_status: vec![ConnectionStatus {
+                        disconnected: false,
+                        last_frame: maximum,
+                        epoch: 0,
+                    }],
+                    ..Input::default()
+                }),
+            },
+            Message {
+                header: MessageHeader::new(0xABCD),
+                body: MessageBody::FloorReply(FloorReply {
+                    round_seq: 1,
+                    floors: vec![maximum],
+                }),
+            },
+            Message {
+                header: MessageHeader::new(0xABCD),
+                body: MessageBody::ChecksumReport(ChecksumReport {
+                    checksum: 7,
+                    frame: maximum,
+                }),
+            },
+        ];
+
+        for message in messages {
+            let bytes = encode(&message).unwrap();
+            assert_eq!(decode_message(&bytes), Ok((message, bytes.len())));
         }
     }
 

--- a/src/network/messages.rs
+++ b/src/network/messages.rs
@@ -14,6 +14,9 @@ pub struct ConnectionStatus {
     /// Whether this peer has disconnected.
     pub disconnected: bool,
     /// The last frame received from this peer.
+    ///
+    /// The bounded wire decoder accepts [`Frame::NULL`] or any non-negative
+    /// frame through `i32::MAX`, matching [`Frame`]'s complete value domain.
     pub last_frame: Frame,
     /// Per-slot connection-status **generation**, incremented by the owning peer
     /// on every `connected <-> disconnected` transition (a drop or a
@@ -197,6 +200,10 @@ pub(crate) struct QualityReply {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub(crate) struct ChecksumReport {
     pub checksum: u128,
+    /// The confirmed frame whose state produced `checksum`.
+    ///
+    /// The bounded wire decoder accepts every non-negative [`Frame`] through
+    /// `i32::MAX`; unlike status and floor fields, the null sentinel is invalid.
     pub frame: Frame,
 }
 
@@ -255,6 +262,9 @@ pub(crate) struct FloorReply {
     /// The originating [`FloorRequest::round_seq`], echoed verbatim.
     pub round_seq: u32,
     /// The relay's per-slot pessimistic floors at reply time (handle-indexed).
+    ///
+    /// Each bounded wire value may be [`Frame::NULL`] or any non-negative frame
+    /// through `i32::MAX`, matching [`Frame`]'s complete value domain.
     pub floors: Vec<Frame>,
 }
 


### PR DESCRIPTION
## Summary

- document the exact bounded-wire domain for D12 frame fields
- pin `i32::MAX` compatibility across connection status, floor replies, and checksum reports
- retain the existing rejection of invalid negative frames without introducing a narrower protocol cap

## Why

`Frame` deliberately supports the complete non-negative `i32` range. D12 had already closed the negative-domain validation gap, but its upper-bound disposition remained implicit. An arbitrary smaller cap would reject values supported by the public type and change protocol compatibility.

## Impact

This is a test and documentation clarification only. It changes no wire bytes, production branches, allocation bounds, public API, or deterministic behavior.

## Validation

- negative-control mutation proved the new regression is load-bearing
- `cargo nextest run --no-capture` — 2,875 passed
- `cargo nextest run --features hot-join --no-capture` — 3,131 passed
- `cargo test --doc -- --nocapture` — 160 passed
- Clippy, rustdoc, rustfmt, markdownlint, and `git diff --check`
- `python3 scripts/ci/agent-preflight.py --auto-fix`
- main-thread adversarial review found no high- or critical-severity issue

## Changelog

No changelog entry: no public or user-observable behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes with no modifications to decode logic or wire compatibility.
> 
> **Overview**
> Clarifies the **D12** bounded-wire contract for frame fields: decoders accept the full public [`Frame`] domain (non-negative values through `i32::MAX`, plus [`Frame::NULL`] only where semantics allow), with **no** narrower protocol cap in `read_frame`.
> 
> Docs on `read_frame` and on `ConnectionStatus::last_frame`, `ChecksumReport::frame`, and `FloorReply::floors` spell out that rule and note that checksum frames reject the null sentinel.
> 
> Adds **`decode_message_accepts_maximum_frame_for_all_d12_fields`**, which round-trips `i32::MAX` through Input connect status, floor replies, and checksum reports via `decode_message`. **No wire format, decode branches, or public API behavior change**—only documentation and a regression test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 576855c235f49d59851fe0232268d51a2c368165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->