### PR TITLE
Make release branch protection reproducible

### DIFF
--- a/.agents/skills/publishing/SKILL.md
+++ b/.agents/skills/publishing/SKILL.md
@@ -165,12 +165,12 @@ Fortress Rollback has one reviewed release path:
    digest so the reviewed tree is the tree that will be tagged and published.
    Protect `main` with the repository ruleset in
    `.github/rulesets/main-protection.json`. Its stable **Verify prepared release
-   state** check must remain required with strict up-to-date checking enabled.
-   This is the supported policy for this repository; do not require or recommend
-   a merge queue. The workflow's `merge_group` support is forward-compatible
-   defense in depth, not an enforcement dependency. A release PR combined with
-   another change intentionally fails and must be regenerated from current
-   `main`.
+   state** check must remain required, bound to the GitHub Actions integration,
+   and configured with strict up-to-date checking. This is the supported policy
+   for this repository; do not require or recommend a merge queue. The
+   workflow's `merge_group` support is forward-compatible defense in depth, not
+   an enforcement dependency. A release PR combined with another change
+   intentionally fails and must be regenerated from current `main`.
 3. Merge the prepared PR to `main`.
 4. Dispatch **Release - Publish Crate** from `main` with the exact committed
    version. This is the sole manual publication entrypoint. It checks locks,

--- a/.agents/skills/publishing/SKILL.md
+++ b/.agents/skills/publishing/SKILL.md
@@ -163,12 +163,14 @@ Fortress Rollback has one reviewed release path:
    with Cargo; do not hand-edit locks. The PR also finalizes its release date,
    issue-template version, semantic-version classification, and prepared-source
    digest so the reviewed tree is the tree that will be tagged and published.
-   Protect `main` with the stable required check **Verify prepared release
-   state** and either require GitHub's merge queue (preferred) or enable strict
-   up-to-date required checks. The workflow handles `merge_group` and rebuilds
-   the exact prospective tree from the event's trusted base SHA. A release PR
-   grouped with another change intentionally fails and must be regenerated or
-   queued alone.
+   Protect `main` with the repository ruleset in
+   `.github/rulesets/main-protection.json`. Its stable **Verify prepared release
+   state** check must remain required with strict up-to-date checking enabled.
+   This is the supported policy for this repository; do not require or recommend
+   a merge queue. The workflow's `merge_group` support is forward-compatible
+   defense in depth, not an enforcement dependency. A release PR combined with
+   another change intentionally fails and must be regenerated from current
+   `main`.
 3. Merge the prepared PR to `main`.
 4. Dispatch **Release - Publish Crate** from `main` with the exact committed
    version. This is the sole manual publication entrypoint. It checks locks,
@@ -191,10 +193,14 @@ state fails closed. Every `release/v*` pull request runs the unfiltered release
 state CI guard, so changing an otherwise unrelated tracked path cannot evade
 the full-tree digest check.
 
-Workflow code cannot enable branch protection or a merge queue. Repository
-administrators must keep the required-check/up-to-date policy enabled; without
-one of those GitHub settings, a previously green but stale PR could bypass the
-prospective-tree run by merging outside the queue.
+GitHub does not grant ordinary workflow tokens repository-administration access,
+so workflow code cannot repair its own ruleset. Check drift with
+`python3 scripts/release/main_ruleset.py check --repo wallstop/fortress-rollback`
+and a `GH_TOKEN` that can read repository administration. An administrator can
+repair drift by changing `check` to `apply`; the helper creates or updates only
+the exactly named declarative ruleset and never prints the token. Without the
+required strict check, a previously green but stale PR could bypass the
+prospective-tree run.
 
 Publication must not edit or push the default branch. All release metadata is
 part of the reviewed preparation PR. Retries reconcile the locally packaged

--- a/.github/rulesets/main-protection.json
+++ b/.github/rulesets/main-protection.json
@@ -26,7 +26,8 @@
       "parameters": {
         "required_status_checks": [
           {
-            "context": "Verify prepared release state"
+            "context": "Verify prepared release state",
+            "integration_id": 15368
           }
         ],
         "strict_required_status_checks_policy": true,

--- a/.github/rulesets/main-protection.json
+++ b/.github/rulesets/main-protection.json
@@ -1,0 +1,37 @@
+{
+  "name": "Main Protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {
+            "context": "Verify prepared release state"
+          }
+        ],
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false
+      }
+    }
+  ]
+}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -90,7 +90,7 @@ jobs:
             --only-binary=:all: \
             --requirement scripts/release/requirements.txt \
             --quiet
-          python3 -m pytest scripts/tests/test_workspace_locks.py scripts/tests/test_prepare_release.py scripts/tests/test_release_policy.py scripts/tests/test_release_state.py scripts/tests/test_release_state_ci.py scripts/tests/test_release_checkpoint.py scripts/tests/test_publish_state.py scripts/tests/test_release_branch.py scripts/tests/test_sync_issue_template_versions.py scripts/tests/test_issue_template_versions_wiring.py scripts/tests/test_release_workflows.py --no-header -q
+          python3 -m pytest scripts/tests/test_workspace_locks.py scripts/tests/test_prepare_release.py scripts/tests/test_release_policy.py scripts/tests/test_release_state.py scripts/tests/test_release_state_ci.py scripts/tests/test_release_checkpoint.py scripts/tests/test_publish_state.py scripts/tests/test_release_branch.py scripts/tests/test_main_ruleset.py scripts/tests/test_sync_issue_template_versions.py scripts/tests/test_issue_template_versions_wiring.py scripts/tests/test_release_workflows.py --no-header -q
 
       - name: Plan release version
         id: plan
@@ -203,7 +203,7 @@ jobs:
       - name: Test release tooling after preparation
         run: |
           set -euo pipefail
-          python3 -m pytest scripts/tests/test_workspace_locks.py scripts/tests/test_prepare_release.py scripts/tests/test_release_policy.py scripts/tests/test_release_state.py scripts/tests/test_release_state_ci.py scripts/tests/test_release_checkpoint.py scripts/tests/test_publish_state.py scripts/tests/test_release_branch.py scripts/tests/test_sync_issue_template_versions.py scripts/tests/test_issue_template_versions_wiring.py scripts/tests/test_release_workflows.py --no-header -q
+          python3 -m pytest scripts/tests/test_workspace_locks.py scripts/tests/test_prepare_release.py scripts/tests/test_release_policy.py scripts/tests/test_release_state.py scripts/tests/test_release_state_ci.py scripts/tests/test_release_checkpoint.py scripts/tests/test_publish_state.py scripts/tests/test_release_branch.py scripts/tests/test_main_ruleset.py scripts/tests/test_sync_issue_template_versions.py scripts/tests/test_issue_template_versions_wiring.py scripts/tests/test_release_workflows.py --no-header -q
 
       - name: Validate release package
         run: |

--- a/progress/session-145-release-publish-reliability.md
+++ b/progress/session-145-release-publish-reliability.md
@@ -35,9 +35,10 @@ retry-safe, semver-aware, and self-enforcing, then open a fully reviewed green P
   findings with strict raw-byte parsing and exact restore-prefix regressions.
 - [x] Resolve all four actionable Cursor review threads and make all 14 GitHub
   workflow runs green on implementation commit `1e8cf5fc`.
-- [ ] Repository administrator: require the stable `Verify prepared release
-  state` check on `main` and enable merge queue (preferred) or strict
-  up-to-date required checks; GitHub does not expose this setting to repo code.
+- [x] Apply and verify the active `Main Protection` repository ruleset with the
+  stable `Verify prepared release state` check and strict up-to-date semantics.
+- [x] Check in the declarative ruleset plus a tested drift check/repair helper;
+  merge queues are neither available nor required for this repository.
 
 ## Verification
 

--- a/scripts/ci/agent-preflight.py
+++ b/scripts/ci/agent-preflight.py
@@ -359,6 +359,7 @@ def plan_checks(
                     "scripts/tests/test_release_checkpoint.py",
                     "scripts/tests/test_publish_state.py",
                     "scripts/tests/test_release_branch.py",
+                    "scripts/tests/test_main_ruleset.py",
                     "scripts/tests/test_sync_issue_template_versions.py",
                     "scripts/tests/test_issue_template_versions_wiring.py",
                     "scripts/tests/test_release_workflows.py",

--- a/scripts/ci/agent-preflight.py
+++ b/scripts/ci/agent-preflight.py
@@ -104,6 +104,7 @@ def is_release_automation_surface_file(path: str) -> bool:
         or path
         in {
             ".github/ISSUE_TEMPLATE/bug_report.yml",
+            ".github/rulesets/main-protection.json",
             ".github/workflows/release-prepare.yml",
             ".github/workflows/ci-release-state.yml",
             ".github/workflows/publish.yml",
@@ -122,6 +123,7 @@ def is_release_automation_surface_file(path: str) -> bool:
             "scripts/tests/test_release_workflows.py",
             "scripts/ci/sync-issue-template-versions.py",
             "scripts/tests/test_issue_template_versions_wiring.py",
+            "scripts/tests/test_main_ruleset.py",
             "scripts/tests/test_sync_issue_template_versions.py",
         }
     )

--- a/scripts/release/main_ruleset.py
+++ b/scripts/release/main_ruleset.py
@@ -142,7 +142,9 @@ def _request_json(
 
 def _find_ruleset(repository: str, token: str, name: str) -> int | None:
     document = _request_json(
-        "GET", f"/repos/{repository}/rulesets?per_page=100", token=token
+        "GET",
+        f"/repos/{repository}/rulesets?per_page=100&includes_parents=false",
+        token=token,
     )
     if not isinstance(document, list):
         raise RulesetError("GitHub ruleset listing must be an array")

--- a/scripts/release/main_ruleset.py
+++ b/scripts/release/main_ruleset.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Check or apply the declarative GitHub default-branch ruleset."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = REPO_ROOT / ".github" / "rulesets" / "main-protection.json"
+API_ROOT = "https://api.github.com"
+API_VERSION = "2022-11-28"
+MAX_RESPONSE_BYTES = 1_048_576
+REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+MANAGED_FIELDS = (
+    "name",
+    "target",
+    "enforcement",
+    "bypass_actors",
+    "conditions",
+    "rules",
+)
+
+
+class RulesetError(RuntimeError):
+    """The configured and live repository rulesets cannot be reconciled safely."""
+
+
+def _managed(document: dict[str, Any]) -> dict[str, Any]:
+    """Return only fields controlled by the declarative ruleset."""
+    return {field: document.get(field) for field in MANAGED_FIELDS}
+
+
+def load_config(path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
+    """Load and validate the mandatory release-protection invariants."""
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RulesetError(f"cannot read ruleset config {path}: {error}") from error
+    if not isinstance(document, dict):
+        raise RulesetError("ruleset config must be a JSON object")
+    if document.get("name") != "Main Protection":
+        raise RulesetError("ruleset config must be named 'Main Protection'")
+    if document.get("target") != "branch" or document.get("enforcement") != "active":
+        raise RulesetError("main protection must be an active branch ruleset")
+    if document.get("bypass_actors") != []:
+        raise RulesetError("main protection must not grant bypass actors")
+    conditions = document.get("conditions")
+    if conditions != {
+        "ref_name": {"exclude": [], "include": ["~DEFAULT_BRANCH"]}
+    }:
+        raise RulesetError("main protection must target only the default branch")
+    rules = document.get("rules")
+    if not isinstance(rules, list):
+        raise RulesetError("main protection rules must be an array")
+    if not all(isinstance(rule, dict) for rule in rules):
+        raise RulesetError("every main protection rule must be an object")
+    required_rule_types = [
+        "deletion",
+        "non_fast_forward",
+        "required_linear_history",
+        "required_status_checks",
+    ]
+    rule_types = [rule.get("type") for rule in rules]
+    if rule_types != required_rule_types:
+        raise RulesetError(
+            "main protection must contain exactly the deletion, non-fast-forward, "
+            "linear-history, and release-state status-check rules"
+        )
+    status_rule = rules[-1]
+    required_parameters = {
+        "required_status_checks": [
+            {"context": "Verify prepared release state"}
+        ],
+        "strict_required_status_checks_policy": True,
+        "do_not_enforce_on_create": False,
+    }
+    if status_rule.get("parameters") != required_parameters:
+        raise RulesetError(
+            "release-state status check must be exact, required, and strict"
+        )
+    return _managed(document)
+
+
+def _request_json(
+    method: str,
+    path: str,
+    *,
+    token: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    """Call the GitHub API without ever rendering the credential."""
+    if not token or "\n" in token or "\r" in token:
+        raise RulesetError("a non-empty single-line GitHub token is required")
+    data = None
+    if payload is not None:
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(
+        f"{API_ROOT}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "fortress-rollback-ruleset-sync",
+            "X-GitHub-Api-Version": API_VERSION,
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            raw = response.read(MAX_RESPONSE_BYTES + 1)
+    except urllib.error.HTTPError as error:
+        snippet = error.read(201).decode(errors="replace")[:200]
+        raise RulesetError(
+            f"GitHub returned HTTP {error.code} for {method} {path}: {snippet}"
+        ) from error
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        raise RulesetError(
+            f"GitHub request failed for {method} {path}: {error}"
+        ) from error
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise RulesetError(f"GitHub response for {method} {path} is too large")
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise RulesetError(
+            f"GitHub returned malformed JSON for {method} {path}"
+        ) from error
+
+
+def _find_ruleset(repository: str, token: str, name: str) -> int | None:
+    document = _request_json(
+        "GET", f"/repos/{repository}/rulesets?per_page=100", token=token
+    )
+    if not isinstance(document, list):
+        raise RulesetError("GitHub ruleset listing must be an array")
+    if not all(isinstance(item, dict) for item in document):
+        raise RulesetError("every GitHub ruleset listing entry must be an object")
+    matches = [item for item in document if item.get("name") == name]
+    if len(matches) > 1:
+        raise RulesetError(f"repository has multiple rulesets named {name!r}")
+    if not matches:
+        return None
+    ruleset_id = matches[0].get("id")
+    if not isinstance(ruleset_id, int) or ruleset_id < 1:
+        raise RulesetError("GitHub returned an invalid ruleset ID")
+    return ruleset_id
+
+
+def synchronize(
+    repository: str,
+    token: str,
+    *,
+    config_path: Path = DEFAULT_CONFIG,
+    apply: bool = False,
+) -> str:
+    """Check live state, or create/update it when explicitly requested."""
+    if REPOSITORY.fullmatch(repository) is None:
+        raise RulesetError("repository must use the owner/name form")
+    expected = load_config(config_path)
+    ruleset_id = _find_ruleset(repository, token, expected["name"])
+    collection_path = f"/repos/{repository}/rulesets"
+    if ruleset_id is None:
+        if not apply:
+            raise RulesetError("live Main Protection ruleset is missing")
+        created = _request_json(
+            "POST", collection_path, token=token, payload=expected
+        )
+        if not isinstance(created, dict) or _managed(created) != expected:
+            raise RulesetError("GitHub did not create the requested ruleset")
+        return "created"
+    item_path = f"{collection_path}/{ruleset_id}"
+    live = _request_json("GET", item_path, token=token)
+    if not isinstance(live, dict):
+        raise RulesetError("GitHub ruleset response must be an object")
+    if _managed(live) == expected:
+        return "current"
+    if not apply:
+        raise RulesetError("live Main Protection ruleset differs from config")
+    updated = _request_json(
+        "PUT", item_path, token=token, payload=expected
+    )
+    if not isinstance(updated, dict) or _managed(updated) != expected:
+        raise RulesetError("GitHub did not apply the requested ruleset")
+    return "updated"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("check", "apply"))
+    parser.add_argument("--repo", required=True, dest="repository")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--token-env", default="GH_TOKEN")
+    args = parser.parse_args()
+    token = os.environ.get(args.token_env, "")
+    try:
+        outcome = synchronize(
+            args.repository,
+            token,
+            config_path=args.config,
+            apply=args.mode == "apply",
+        )
+    except RulesetError as error:
+        print(f"main-ruleset: error: {error}", file=sys.stderr)
+        return 1
+    print(f"main_ruleset={outcome}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/main_ruleset.py
+++ b/scripts/release/main_ruleset.py
@@ -78,7 +78,10 @@ def load_config(path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
     status_rule = rules[-1]
     required_parameters = {
         "required_status_checks": [
-            {"context": "Verify prepared release state"}
+            {
+                "context": "Verify prepared release state",
+                "integration_id": 15368,
+            }
         ],
         "strict_required_status_checks_policy": True,
         "do_not_enforce_on_create": False,

--- a/scripts/release/main_ruleset.py
+++ b/scripts/release/main_ruleset.py
@@ -19,6 +19,8 @@ DEFAULT_CONFIG = REPO_ROOT / ".github" / "rulesets" / "main-protection.json"
 API_ROOT = "https://api.github.com"
 API_VERSION = "2022-11-28"
 MAX_RESPONSE_BYTES = 1_048_576
+RULESETS_PER_PAGE = 100
+MAX_RULESET_PAGES = 100
 REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 MANAGED_FIELDS = (
     "name",
@@ -141,16 +143,26 @@ def _request_json(
 
 
 def _find_ruleset(repository: str, token: str, name: str) -> int | None:
-    document = _request_json(
-        "GET",
-        f"/repos/{repository}/rulesets?per_page=100&includes_parents=false",
-        token=token,
-    )
-    if not isinstance(document, list):
-        raise RulesetError("GitHub ruleset listing must be an array")
-    if not all(isinstance(item, dict) for item in document):
-        raise RulesetError("every GitHub ruleset listing entry must be an object")
-    matches = [item for item in document if item.get("name") == name]
+    rulesets: list[dict[str, Any]] = []
+    for page in range(1, MAX_RULESET_PAGES + 1):
+        document = _request_json(
+            "GET",
+            f"/repos/{repository}/rulesets?per_page={RULESETS_PER_PAGE}"
+            f"&page={page}&includes_parents=false",
+            token=token,
+        )
+        if not isinstance(document, list):
+            raise RulesetError("GitHub ruleset listing must be an array")
+        if not all(isinstance(item, dict) for item in document):
+            raise RulesetError("every GitHub ruleset listing entry must be an object")
+        rulesets.extend(document)
+        if len(document) < RULESETS_PER_PAGE:
+            break
+    else:
+        raise RulesetError(
+            f"repository ruleset listing exceeds {MAX_RULESET_PAGES} pages"
+        )
+    matches = [item for item in rulesets if item.get("name") == name]
     if len(matches) > 1:
         raise RulesetError(f"repository has multiple rulesets named {name!r}")
     if not matches:

--- a/scripts/tests/test_agent_preflight.py
+++ b/scripts/tests/test_agent_preflight.py
@@ -36,6 +36,8 @@ CHECK_TRIGGER_CASES: list[tuple[str, str]] = [
     ("workspace-lock-check", "scripts/release/prepare_release.py"),
     ("release-automation-tests", "scripts/release/prepare_release.py"),
     ("release-automation-tests", "scripts/tests/test_release_branch.py"),
+    ("release-automation-tests", "scripts/tests/test_main_ruleset.py"),
+    ("release-automation-tests", ".github/rulesets/main-protection.json"),
     ("release-automation-tests", ".github/workflows/publish.yml"),
     ("release-automation-tests", ".github/workflows/ci-release-state.yml"),
     ("ci-toolchain-contract", ".github/actions/install-pinned-nightly/toolchain"),

--- a/scripts/tests/test_agent_preflight.py
+++ b/scripts/tests/test_agent_preflight.py
@@ -168,6 +168,7 @@ def test_plan_checks_runs_release_state_machine_regressions() -> None:
         "scripts/tests/test_release_checkpoint.py",
         "scripts/tests/test_publish_state.py",
         "scripts/tests/test_release_branch.py",
+        "scripts/tests/test_main_ruleset.py",
         "scripts/tests/test_sync_issue_template_versions.py",
         "scripts/tests/test_issue_template_versions_wiring.py",
         "scripts/tests/test_release_workflows.py",

--- a/scripts/tests/test_main_ruleset.py
+++ b/scripts/tests/test_main_ruleset.py
@@ -90,7 +90,7 @@ def test_check_accepts_matching_live_ruleset(monkeypatch: pytest.MonkeyPatch) ->
     def urlopen(request: object, timeout: int) -> MagicMock:
         calls.append((request.get_method(), request.full_url))
         if request.full_url.endswith(
-            "rulesets?per_page=100&includes_parents=false"
+            "rulesets?per_page=100&page=1&includes_parents=false"
         ):
             return _response([{"id": 16185604, "name": "Main Protection"}])
         return _response(_live_config())
@@ -127,7 +127,7 @@ def test_apply_repairs_drift_with_exact_config(monkeypatch: pytest.MonkeyPatch) 
     def urlopen(request: object, timeout: int) -> MagicMock:
         requests.append(request)
         if request.full_url.endswith(
-            "rulesets?per_page=100&includes_parents=false"
+            "rulesets?per_page=100&page=1&includes_parents=false"
         ):
             return _response([{"id": 16185604, "name": "Main Protection"}])
         if request.get_method() == "GET":
@@ -184,5 +184,31 @@ def test_lookup_explicitly_excludes_inherited_rulesets(
         == "current"
     )
     assert requests[0].full_url.endswith(
-        "/rulesets?per_page=100&includes_parents=false"
+        "/rulesets?per_page=100&page=1&includes_parents=false"
     )
+
+
+def test_lookup_follows_ruleset_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[object] = []
+    first_page = [
+        {"id": index + 1, "name": f"Unrelated {index}"}
+        for index in range(main_ruleset.RULESETS_PER_PAGE)
+    ]
+
+    def urlopen(request: object, timeout: int) -> MagicMock:
+        requests.append(request)
+        if "&page=1&" in request.full_url:
+            return _response(first_page)
+        if "&page=2&" in request.full_url:
+            return _response([{"id": 16185604, "name": "Main Protection"}])
+        return _response(_live_config())
+
+    monkeypatch.setattr(main_ruleset.urllib.request, "urlopen", urlopen)
+
+    assert (
+        main_ruleset.synchronize("wallstop/fortress-rollback", "token")
+        == "current"
+    )
+    assert "&page=1&" in requests[0].full_url
+    assert "&page=2&" in requests[1].full_url
+    assert requests[2].get_method() == "GET"

--- a/scripts/tests/test_main_ruleset.py
+++ b/scripts/tests/test_main_ruleset.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests for declarative GitHub main-branch protection."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "release" / "main_ruleset.py"
+SPEC = importlib.util.spec_from_file_location("main_ruleset", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+main_ruleset = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = main_ruleset
+SPEC.loader.exec_module(main_ruleset)
+
+
+def _response(document: object) -> MagicMock:
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    response.read.return_value = json.dumps(document).encode("utf-8")
+    return response
+
+
+def _live_config(**extra: object) -> dict[str, object]:
+    return {**main_ruleset.load_config(), "id": 16185604, **extra}
+
+
+def test_checked_in_config_requires_exact_strict_release_check() -> None:
+    config = main_ruleset.load_config()
+
+    status_rule = next(
+        rule for rule in config["rules"] if rule["type"] == "required_status_checks"
+    )
+    assert config["conditions"] == {
+        "ref_name": {"exclude": [], "include": ["~DEFAULT_BRANCH"]}
+    }
+    assert status_rule["parameters"] == {
+        "required_status_checks": [
+            {"context": "Verify prepared release state"}
+        ],
+        "strict_required_status_checks_policy": True,
+        "do_not_enforce_on_create": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda config: config["rules"][-1]["parameters"].update(
+                strict_required_status_checks_policy=False
+            ),
+            "exact, required, and strict",
+        ),
+        (
+            lambda config: config.update(bypass_actors=[{"actor_type": "OrganizationAdmin"}]),
+            "bypass actors",
+        ),
+    ],
+)
+def test_config_validation_rejects_weakened_policy(
+    tmp_path: Path,
+    mutation: Callable[[dict[str, object]], object],
+    message: str,
+) -> None:
+    config = main_ruleset.load_config()
+    mutation(config)
+    path = tmp_path / "ruleset.json"
+    path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(main_ruleset.RulesetError, match=message):
+        main_ruleset.load_config(path)
+
+
+def test_check_accepts_matching_live_ruleset(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def urlopen(request: object, timeout: int) -> MagicMock:
+        calls.append((request.get_method(), request.full_url))
+        if request.full_url.endswith("rulesets?per_page=100"):
+            return _response([{"id": 16185604, "name": "Main Protection"}])
+        return _response(_live_config())
+
+    monkeypatch.setattr(main_ruleset.urllib.request, "urlopen", urlopen)
+
+    outcome = main_ruleset.synchronize("wallstop/fortress-rollback", "token")
+
+    assert outcome == "current"
+    assert [method for method, _url in calls] == ["GET", "GET"]
+
+
+def test_check_fails_closed_on_live_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    live = _live_config(enforcement="evaluate")
+    responses = iter(
+        [
+            _response([{"id": 16185604, "name": "Main Protection"}]),
+            _response(live),
+        ]
+    )
+    monkeypatch.setattr(
+        main_ruleset.urllib.request,
+        "urlopen",
+        lambda _request, timeout: next(responses),
+    )
+
+    with pytest.raises(main_ruleset.RulesetError, match="differs from config"):
+        main_ruleset.synchronize("wallstop/fortress-rollback", "token")
+
+
+def test_apply_repairs_drift_with_exact_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[object] = []
+
+    def urlopen(request: object, timeout: int) -> MagicMock:
+        requests.append(request)
+        if request.full_url.endswith("rulesets?per_page=100"):
+            return _response([{"id": 16185604, "name": "Main Protection"}])
+        if request.get_method() == "GET":
+            return _response(_live_config(enforcement="evaluate"))
+        return _response(_live_config())
+
+    monkeypatch.setattr(main_ruleset.urllib.request, "urlopen", urlopen)
+
+    outcome = main_ruleset.synchronize(
+        "wallstop/fortress-rollback", "token", apply=True
+    )
+
+    assert outcome == "updated"
+    put = requests[-1]
+    assert put.get_method() == "PUT"
+    assert json.loads(put.data.decode("utf-8")) == main_ruleset.load_config()
+    assert put.headers["Authorization"] == "Bearer token"
+
+
+def test_apply_creates_missing_ruleset(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[object] = []
+
+    def urlopen(request: object, timeout: int) -> MagicMock:
+        requests.append(request)
+        if request.get_method() == "GET":
+            return _response([])
+        return _response(_live_config())
+
+    monkeypatch.setattr(main_ruleset.urllib.request, "urlopen", urlopen)
+
+    outcome = main_ruleset.synchronize(
+        "wallstop/fortress-rollback", "token", apply=True
+    )
+
+    assert outcome == "created"
+    assert [request.get_method() for request in requests] == ["GET", "POST"]

--- a/scripts/tests/test_main_ruleset.py
+++ b/scripts/tests/test_main_ruleset.py
@@ -89,7 +89,9 @@ def test_check_accepts_matching_live_ruleset(monkeypatch: pytest.MonkeyPatch) ->
 
     def urlopen(request: object, timeout: int) -> MagicMock:
         calls.append((request.get_method(), request.full_url))
-        if request.full_url.endswith("rulesets?per_page=100"):
+        if request.full_url.endswith(
+            "rulesets?per_page=100&includes_parents=false"
+        ):
             return _response([{"id": 16185604, "name": "Main Protection"}])
         return _response(_live_config())
 
@@ -124,7 +126,9 @@ def test_apply_repairs_drift_with_exact_config(monkeypatch: pytest.MonkeyPatch) 
 
     def urlopen(request: object, timeout: int) -> MagicMock:
         requests.append(request)
-        if request.full_url.endswith("rulesets?per_page=100"):
+        if request.full_url.endswith(
+            "rulesets?per_page=100&includes_parents=false"
+        ):
             return _response([{"id": 16185604, "name": "Main Protection"}])
         if request.get_method() == "GET":
             return _response(_live_config(enforcement="evaluate"))
@@ -160,3 +164,25 @@ def test_apply_creates_missing_ruleset(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert outcome == "created"
     assert [request.get_method() for request in requests] == ["GET", "POST"]
+
+
+def test_lookup_explicitly_excludes_inherited_rulesets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[object] = []
+
+    def urlopen(request: object, timeout: int) -> MagicMock:
+        requests.append(request)
+        if len(requests) == 1:
+            return _response([{"id": 16185604, "name": "Main Protection"}])
+        return _response(_live_config())
+
+    monkeypatch.setattr(main_ruleset.urllib.request, "urlopen", urlopen)
+
+    assert (
+        main_ruleset.synchronize("wallstop/fortress-rollback", "token")
+        == "current"
+    )
+    assert requests[0].full_url.endswith(
+        "/rulesets?per_page=100&includes_parents=false"
+    )

--- a/scripts/tests/test_main_ruleset.py
+++ b/scripts/tests/test_main_ruleset.py
@@ -45,7 +45,10 @@ def test_checked_in_config_requires_exact_strict_release_check() -> None:
     }
     assert status_rule["parameters"] == {
         "required_status_checks": [
-            {"context": "Verify prepared release state"}
+            {
+                "context": "Verify prepared release state",
+                "integration_id": 15368,
+            }
         ],
         "strict_required_status_checks_policy": True,
         "do_not_enforce_on_create": False,

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -17,6 +17,7 @@ RELEASE_STATE_CI = REPO_ROOT / ".github" / "workflows" / "ci-release-state.yml"
 CARGO_MANIFEST = REPO_ROOT / "Cargo.toml"
 RELEASE_TOOLCHAIN = REPO_ROOT / ".github" / "actions" / "install-pinned-release" / "toolchain"
 RELEASE_REQUIREMENTS = REPO_ROOT / "scripts" / "release" / "requirements.txt"
+AGENT_PREFLIGHT = REPO_ROOT / "scripts" / "ci" / "agent-preflight.py"
 
 
 def test_prepare_workflow_opens_ci_capable_release_pr() -> None:
@@ -58,6 +59,12 @@ def test_prepare_workflow_uses_canonical_lock_transaction_and_summary() -> None:
         "test_release_workflows.py",
     ):
         assert text.count(test_file) == 2
+    assert (
+        AGENT_PREFLIGHT.read_text(encoding="utf-8").count(
+            '"scripts/tests/test_main_ruleset.py"'
+        )
+        == 1
+    )
     assert "scripts/release/workspace_locks.py sync" in text
     assert "scripts/release/workspace_locks.py check" in text
     assert "git diff --binary -- ." in text

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -52,6 +52,7 @@ def test_prepare_workflow_uses_canonical_lock_transaction_and_summary() -> None:
         "test_release_checkpoint.py",
         "test_publish_state.py",
         "test_release_branch.py",
+        "test_main_ruleset.py",
         "test_sync_issue_template_versions.py",
         "test_issue_template_versions_wiring.py",
         "test_release_workflows.py",
@@ -240,6 +241,15 @@ def test_release_branch_state_check_has_no_path_filter_escape() -> None:
         "github.event.merge_group.head_sha }}" in text
     )
     assert "candidate/scripts/" not in text
+
+
+def test_publishing_guidance_uses_supported_strict_ruleset_policy() -> None:
+    text = PUBLISHING_SKILL.read_text(encoding="utf-8")
+
+    assert ".github/rulesets/main-protection.json" in text
+    assert "do not require or recommend\n   a merge queue" in text
+    assert "main_ruleset.py check --repo wallstop/fortress-rollback" in text
+    assert "merge queue (preferred)" not in text
 
 
 def test_issue_template_sync_is_manual_repair_only() -> None:

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -63,7 +63,7 @@ def test_prepare_workflow_uses_canonical_lock_transaction_and_summary() -> None:
         AGENT_PREFLIGHT.read_text(encoding="utf-8").count(
             '"scripts/tests/test_main_ruleset.py"'
         )
-        == 1
+        == 2
     )
     assert "scripts/release/workspace_locks.py sync" in text
     assert "scripts/release/workspace_locks.py check" in text

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -247,7 +247,8 @@ def test_publishing_guidance_uses_supported_strict_ruleset_policy() -> None:
     text = PUBLISHING_SKILL.read_text(encoding="utf-8")
 
     assert ".github/rulesets/main-protection.json" in text
-    assert "do not require or recommend\n   a merge queue" in text
+    assert "do not require or recommend a merge queue" in text
+    assert "bound to the GitHub Actions integration" in text
     assert "main_ruleset.py check --repo wallstop/fortress-rollback" in text
     assert "merge queue (preferred)" not in text
 


### PR DESCRIPTION
## Summary

- codify the active `Main Protection` ruleset as repository source
- add a credential-safe check/apply helper and adversarial offline tests
- replace unsupported merge-queue guidance with strict required-check policy
- run the ruleset regression suite during release preparation

## Live configuration

The active repository ruleset already matches this change: `Verify prepared release state` is required with strict up-to-date semantics.

## Verification

- 283 release automation tests passed
- changed-file agent preflight passed (276 release tests, all 49 Agent Skills, actionlint, 5,138-file/1,392-link validation, and spelling)
- live `main_ruleset.py check` reports `current`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes govern how `main` can be merged and whether stale green PRs can bypass release-state verification; mistakes could weaken protection or block merges until ruleset is repaired.
> 
> **Overview**
> **Default-branch protection is now defined in-repo** via `.github/rulesets/main-protection.json` (linear history, no force-push/delete, and a strict required **Verify prepared release state** check bound to the GitHub Actions integration).
> 
> A new `scripts/release/main_ruleset.py` helper **checks or applies** that ruleset against the live GitHub API (credential-safe, paginated lookup, fails closed on drift). Publishing guidance **drops merge-queue recommendations** in favor of this ruleset plus strict up-to-date checks, and documents `main_ruleset.py check` / `apply` for administrators.
> 
> Release automation surfaces **wire in** `test_main_ruleset.py` through agent preflight, the release-prepare workflow pytest runs, and offline workflow contract tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ab3bb1d4cd5e8c9e1cafe077abcde7439b7e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->