### PR TITLE
Make rewritten checkpoint fixture self-contained

### DIFF
--- a/scripts/tests/test_release_checkpoint.py
+++ b/scripts/tests/test_release_checkpoint.py
@@ -244,7 +244,10 @@ def test_absent_tag_accepts_previous_checkpoint_older_than_search_bound(
             f"intervening main commit {index}",
         )
     _git(trusted, "cherry-pick", prepared)
-    _git(trusted, "push", "--force", "origin", "main")
+    # This fixture deliberately replaces a long local-bare history. Send a
+    # self-contained pack so receive-pack never depends on an object advertised
+    # from the history being replaced.
+    _git(trusted, "push", "--force", "--no-thin", "origin", "main")
 
     checkpoint = _resolve(trusted, tmp_path)
 


### PR DESCRIPTION
## Summary

- send a self-contained pack when the checkpoint fixture force-replaces a long local bare-repository history
- avoid receive-pack depending on an object advertised from the history being replaced
- eliminate the post-preparation dry-run failure seen in run 29653681047

## Verification

- targeted long-history checkpoint test passed 10 consecutive runs
- all 285 release automation tests passed
- Git documents `git push` as using thin transfer by default and `--no-thin` as the self-contained alternative for this fixture

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to push flags in a release checkpoint fixture; no production release logic is modified.
> 
> **Overview**
> Fixes flaky CI in **`test_absent_tag_accepts_previous_checkpoint_older_than_search_bound`** when the fixture **force-replaces** a long `main` history on the local bare remote.
> 
> The force-push now uses **`--no-thin`** so the pack is **self-contained** and `receive-pack` does not need objects still advertised from the history being overwritten (which caused failures such as run 29653681047). Comments in the test document that intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 761fe9435e4722df597dfadbcae06889fb385acd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->