### PR TITLE
Fix repository binding for GitHub Release publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -257,9 +257,10 @@ jobs:
           release_lookup_exit=$?
           set -e
           if [ "$release_lookup_exit" -eq 0 ]; then
-            gh release upload "$TAG" "${assets[@]}" --clobber
+            gh release upload "$TAG" "${assets[@]}" --clobber \
+              --repo "${GITHUB_REPOSITORY}"
             gh release edit "$TAG" --title "$TAG" --notes-file "${RUNNER_TEMP}/release_notes.md" \
-              --draft=false --prerelease=false
+              --draft=false --prerelease=false --repo "${GITHUB_REPOSITORY}"
             exit 0
           fi
 
@@ -270,4 +271,5 @@ jobs:
             exit "$release_lookup_exit"
           fi
           gh release create "$TAG" "${assets[@]}" --title "$TAG" \
-            --notes-file "${RUNNER_TEMP}/release_notes.md" --verify-tag
+            --notes-file "${RUNNER_TEMP}/release_notes.md" --verify-tag \
+            --repo "${GITHUB_REPOSITORY}"

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -403,6 +403,25 @@ def test_publish_workflow_updates_existing_github_release() -> None:
     assert "gh release edit" in text
 
 
+def test_publish_workflow_release_commands_are_repository_explicit() -> None:
+    text = PUBLISH.read_text(encoding="utf-8")
+    release_step = text.split(
+        "- name: Create or update GitHub Release", maxsplit=1
+    )[1]
+    logical_lines = release_step.replace("\\\n", " ").splitlines()
+    release_commands = [
+        line.strip() for line in logical_lines if line.strip().startswith("gh release ")
+    ]
+
+    assert len(release_commands) == 3
+    assert {command.split()[2] for command in release_commands} == {
+        "create",
+        "edit",
+        "upload",
+    }
+    assert all('--repo "${GITHUB_REPOSITORY}"' in command for command in release_commands)
+
+
 def test_version_sync_preserves_check_name_and_runs_full_lock_checker() -> None:
     text = VERSION_SYNC.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- bind every `gh release` mutation to `${GITHUB_REPOSITORY}` explicitly
- prevent `gh release create` from consulting the process working directory
- add a regression contract covering create, edit, and upload retry paths

## Incident

Publish run [29655408224](https://github.com/wallstop/fortress-rollback/actions/runs/29655408224) created the immutable `v0.11.0` tag and successfully reconciled the crates.io package, then failed while creating the GitHub Release because the job's workspace root is not a Git checkout and the command omitted `--repo`.

The publisher is idempotent: after this fix lands, rerunning it will verify the existing tag and exact crates.io checksum before completing the missing GitHub Release.

## Validation

- `actionlint .github/workflows/publish.yml`
- `python -m pytest scripts/tests/test_release_workflows.py -q` (29 passed)
- `python -m pytest scripts/tests -q` (1,968 passed)
- pre-commit hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CI/release workflow change with no application runtime impact; reduces mis-targeted release API calls.
> 
> **Overview**
> Fixes publish jobs that fail at the GitHub Release step when the runner workspace is not a git checkout (helpers live under `trusted/`, artifacts under `candidate/`). **`gh release upload`**, **`edit`**, and **`create`** now all pass **`--repo "${GITHUB_REPOSITORY}"`**, matching the existing tag lookup via **`gh api`**, so the CLI no longer infers the repo from the working directory.
> 
> A regression test in **`test_release_workflows.py`** asserts those three commands in the “Create or update GitHub Release” step each include the explicit repo flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25d88d2f427d4d7ba53436f0a5404cc8bf5013f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->