### PR TITLE
Harden scheduled simulation fleet and CI pin contracts

### DIFF
--- a/.github/workflows/ci-release-state.yml
+++ b/.github/workflows/ci-release-state.yml
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pinned Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13.5"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pinned Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13.5"
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -75,7 +75,7 @@ jobs:
         uses: ./.github/actions/install-pinned-release
 
       - name: Install pinned Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13.5"
           cache: pip

--- a/.github/workflows/sync-issue-template.yml
+++ b/.github/workflows/sync-issue-template.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 

--- a/scripts/tests/test_ci_rust_workflow.py
+++ b/scripts/tests/test_ci_rust_workflow.py
@@ -375,7 +375,7 @@ def test_godot_browser_job_pins_its_toolchain() -> None:
     )
     assert (
         rust_step["uses"]
-        == "dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88"
+        == "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c"
     )
     assert rust_step["with"]["toolchain"] == "nightly-2026-07-08"
     assert set(str(rust_step["with"]["components"]).split(",")) == {
@@ -396,7 +396,7 @@ def test_godot_browser_job_pins_its_toolchain() -> None:
     assert emsdk_step["with"]["actions-cache-folder"] == "emsdk-cache"
 
     node_step = next(step for step in steps if step.get("name") == "Install Node.js")
-    assert node_step["uses"] == "actions/setup-node@v6"
+    assert node_step["uses"] == "actions/setup-node@v7"
     assert str(node_step["with"]["node-version"]) == "24"
     assert node_step["with"]["package-manager-cache"] is False
 

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -143,7 +143,7 @@ def test_prepare_uses_exact_python_and_hash_locked_test_dependencies() -> None:
     text = PREPARE.read_text(encoding="utf-8")
     requirements = RELEASE_REQUIREMENTS.read_text(encoding="utf-8")
 
-    assert "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1" in text
+    assert "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" in text
     assert 'python-version: "3.13.5"' in text
     assert "--require-hashes" in text
     assert "--only-binary=:all:" in text
@@ -162,7 +162,7 @@ def test_required_release_workflows_pin_python_runtime() -> None:
         text = workflow.read_text(encoding="utf-8")
         assert (
             text.count(
-                "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1"
+                "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
             )
             == 1
         )

--- a/tests/simulation/fleet.rs
+++ b/tests/simulation/fleet.rs
@@ -90,29 +90,13 @@ fn nightly_schedule(seed: u64, n_players: usize, noise: BackgroundNoise) -> Sche
     }
 
     if noise == BackgroundNoise::ReliableFifo {
-        let retired = schedule
-            .events
-            .iter()
-            .filter_map(|(_, event)| match event {
-                ScheduleEvent::PeerKill { peer }
-                | ScheduleEvent::GracefulRemove { target: peer, .. }
-                | ScheduleEvent::LegacyDisconnect { target: peer, .. }
-                | ScheduleEvent::SpectatorHostKill { host: peer } => Some(*peer),
-                _ => None,
-            })
-            .collect::<BTreeSet<_>>();
-        let mut eligible = (0..n_players)
-            .filter(|peer| !retired.contains(peer))
-            .collect::<Vec<_>>();
-        if eligible.len() < 2 {
-            // Two-player retirement stories have no pair that remains live;
-            // their generated lifecycle event occurs after the early HOL
-            // window below, so both initial endpoints remain meaningful.
-            // This branch is structural rather than silently skipping the
-            // reliable-FIFO assertion.
-            eligible.clear();
-            eligible.extend(0..n_players);
-        }
+        // Generated lifecycle events cannot start before step 100. Keep the
+        // planted HOL window wholly before that boundary so its endpoints are
+        // still driven even when the lifecycle row later freezes or retires
+        // one of them.
+        let start = 40 + u32::try_from((seed / 17) % 20).expect("HOL start fits u32");
+        let window = 20 + u32::try_from((seed / 31) % 20).expect("HOL window fits u32");
+        let eligible = (0..n_players).collect::<Vec<_>>();
         let from_index =
             usize::try_from(seed % u64::try_from(eligible.len()).expect("endpoint count fits u64"))
                 .expect("peer index fits usize");
@@ -123,8 +107,6 @@ fn nightly_schedule(seed: u64, n_players: usize, noise: BackgroundNoise) -> Sche
         )
         .expect("peer offset fits usize");
         let to = eligible[(from_index + peer_offset) % eligible.len()];
-        let start = 100 + u32::try_from((seed / 17) % 150).expect("HOL start fits u32");
-        let window = 20 + u32::try_from((seed / 31) % 40).expect("HOL window fits u32");
         let fifo = schedule
             .initial_links
             .iter()
@@ -161,6 +143,19 @@ fn nightly_schedule(seed: u64, n_players: usize, noise: BackgroundNoise) -> Sche
     schedule
 }
 
+fn nightly_run_options(schedule: &Schedule) -> RunOptions {
+    if schedule.config.noise == BackgroundNoise::Clean {
+        return RunOptions::default();
+    }
+    let run_duration = Duration::from_millis(
+        u64::from(schedule.config.steps).saturating_mul(schedule.config.step_dt_ms),
+    );
+    RunOptions {
+        disconnect_timeout: Some(run_duration.saturating_add(Duration::from_secs(1))),
+        ..RunOptions::default()
+    }
+}
+
 /// Runs one disjoint shard of the long simulation fleet. The explicit tier
 /// gate prevents a manually selected ignored test from silently running a
 /// costly workload with an accidental/default seed base.
@@ -184,7 +179,7 @@ fn run_nightly_shard(shard: u64) {
         let n_players = 2 + usize::try_from(seed % 15).expect("seed modulo 15 fits usize");
         let noise = nightly_noise(seed);
         let schedule = nightly_schedule(seed, n_players, noise);
-        let report = run(&schedule, &RunOptions::default());
+        let report = run(&schedule, &nightly_run_options(&schedule));
         report.expect_pass(&schedule);
         if noise == BackgroundNoise::ReliableFifo {
             assert!(
@@ -373,6 +368,64 @@ fn non_clean_nightly_lifecycle_rewrites_only_retirement_stories() {
             );
         }
     }
+}
+
+#[test]
+fn nightly_reliable_fifo_hol_sender_remains_driven() {
+    const CI_FAILURE_SEED: u64 = 29_718_845_598_175;
+    let schedule = nightly_schedule(CI_FAILURE_SEED, 12, BackgroundNoise::ReliableFifo);
+    let (hol_start, hol_end, hol_sender) = schedule
+        .events
+        .iter()
+        .find_map(|(start, event)| match event {
+            ScheduleEvent::SetLink { from, to, policy } if !policy.retransmit_delay.is_zero() => {
+                let end = schedule.events.iter().find_map(|(end, restore)| {
+                    matches!(
+                        restore,
+                        ScheduleEvent::SetLink {
+                            from: restore_from,
+                            to: restore_to,
+                            policy,
+                        } if restore_from == from
+                            && restore_to == to
+                            && policy.retransmit_delay.is_zero()
+                    )
+                    .then_some(*end)
+                })?;
+                Some((*start, end, *from))
+            },
+            _ => None,
+        })
+        .expect("reliable-FIFO nightly row must plant one HOL window");
+    assert!(
+        hol_end <= 100,
+        "HOL premise must finish before generated lifecycle events can begin"
+    );
+    assert!(
+        !schedule.events.iter().any(|(start, event)| matches!(
+            event,
+            ScheduleEvent::PeerStall { peer, steps }
+                if *peer == hol_sender
+                    && *start < hol_end
+                    && start.saturating_add(*steps) > hol_start
+        )),
+        "HOL sender {hol_sender} is frozen throughout the planted premise"
+    );
+}
+
+#[test]
+fn non_clean_nightly_disconnect_timeout_outlasts_modeled_run() {
+    let schedule = nightly_schedule(30_068_604_101_890, 12, BackgroundNoise::Rough);
+    let options = nightly_run_options(&schedule);
+    let modeled = Duration::from_millis(
+        u64::from(schedule.config.steps).saturating_mul(schedule.config.step_dt_ms),
+    );
+    assert!(options
+        .disconnect_timeout
+        .is_some_and(|timeout| timeout > modeled));
+
+    let clean = nightly_schedule(1, 3, BackgroundNoise::Clean);
+    assert_eq!(nightly_run_options(&clean), RunOptions::default());
 }
 
 #[test]
@@ -4331,6 +4384,22 @@ fn diagnose_repro() {
     use super::harness::diagnose;
     let schedule = generate(1, SimConfig::smoke(4));
     diagnose(&schedule);
+}
+
+#[test]
+#[ignore = "long release-mode regression for historical scheduled CI failures"]
+fn nightly_ci_2026_07_failure_seeds_hold_invariants() {
+    for (seed, noise) in [
+        (29_718_845_598_175, BackgroundNoise::ReliableFifo),
+        (30_068_604_101_890, BackgroundNoise::Rough),
+    ] {
+        let schedule = nightly_schedule(seed, 12, noise);
+        let report = run(&schedule, &nightly_run_options(&schedule));
+        report.expect_pass(&schedule);
+        if noise == BackgroundNoise::ReliableFifo {
+            assert!(report.net_stats.retransmit_delayed > 0);
+        }
+    }
 }
 
 /// Budget probe: measures the wall-clock cost of the largest supported mesh

--- a/tests/simulation/harness/mod.rs
+++ b/tests/simulation/harness/mod.rs
@@ -47,6 +47,7 @@ use std::marker::PhantomData;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicI32, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Input contract used by the deterministic simulation harness.
 ///
@@ -232,6 +233,12 @@ pub struct RunOptions {
     /// `None` preserves legacy traces and the built-in limit of 256.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub receive_message_limit: Option<usize>,
+    /// Override the session disconnect timeout for focused harness tiers.
+    /// `None` preserves the production default. Long-running transport-only
+    /// fleets use this to keep random loss from implicitly introducing a
+    /// terminal membership change; explicit lifecycle events remain effective.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disconnect_timeout: Option<Duration>,
     /// Corrupt `(peer, from_frame)`'s simulated **state** from that frame on
     /// (a real divergence: state, checksums, and downstream frames all split).
     pub corrupt_state_from: Option<(usize, i32)>,
@@ -1749,6 +1756,7 @@ fn rebound_peer_addr(peer: usize) -> SocketAddr {
 #[cfg(feature = "hot-join")]
 struct HotJoinRuntime<'a, I: SimInput> {
     schedule: &'a Schedule,
+    options: &'a RunOptions,
     clock: &'a TestClock,
     net: &'a SimNet<Message>,
     addrs: &'a [SocketAddr],
@@ -1811,6 +1819,9 @@ fn start_hot_join_for_slot<I: SimInput>(slot: usize, step: u32, ctx: &mut HotJoi
         .with_disconnect_behavior(ctx.schedule.config.disconnect_behavior.into())
         .with_protocol_config(protocol_config)
         .with_violation_observer(observer as Arc<_>);
+    if let Some(timeout) = ctx.options.disconnect_timeout {
+        builder = builder.with_disconnect_timeout(timeout);
+    }
     if let Some(size) = ctx.schedule.config.event_queue_size {
         builder = builder.with_event_queue_size(size).unwrap_or_else(|error| {
             panic!(
@@ -2146,6 +2157,12 @@ pub(super) fn validate_run_options(
         ));
     }
     if options
+        .disconnect_timeout
+        .is_some_and(|timeout| timeout.is_zero())
+    {
+        return Err("disconnect_timeout must be non-zero".to_owned());
+    }
+    if options
         .probe_confirmed_at
         .is_some_and(|probe| probe >= schedule.config.steps)
     {
@@ -2353,6 +2370,9 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                 .with_disconnect_behavior(schedule.config.disconnect_behavior.into())
                 .with_protocol_config(protocol_config)
                 .with_violation_observer(Arc::clone(&observer) as Arc<_>);
+            if let Some(timeout) = options.disconnect_timeout {
+                builder = builder.with_disconnect_timeout(timeout);
+            }
             #[cfg(feature = "hot-join")]
             if hot_join_host_enabled[i] {
                 builder = builder.with_hot_join(true);
@@ -2442,6 +2462,9 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                 .expect("valid player count")
                 .with_protocol_config(protocol_config)
                 .with_violation_observer(Arc::clone(&observer) as Arc<_>);
+            if let Some(timeout) = options.disconnect_timeout {
+                builder = builder.with_disconnect_timeout(timeout);
+            }
             if let Some(size) = schedule.config.event_queue_size {
                 builder = builder.with_event_queue_size(size).unwrap_or_else(|error| {
                     panic!(
@@ -2787,6 +2810,7 @@ fn run_inner<I: SimInput>(schedule: &Schedule, options: &RunOptions, diagnose: b
                     // after reactivation.
                     let mut ctx = HotJoinRuntime {
                         schedule,
+                        options,
                         clock: &clock,
                         net: &net,
                         addrs: &addrs,
@@ -3665,6 +3689,28 @@ mod tests {
     }
 
     #[test]
+    fn disconnect_timeout_override_is_nonzero_and_serializable() {
+        let schedule = schedule::generate(1, schedule::SimConfig::smoke(2));
+        let invalid = RunOptions {
+            disconnect_timeout: Some(Duration::ZERO),
+            ..RunOptions::default()
+        };
+        assert_eq!(
+            validate_run_options(&schedule, &invalid),
+            Err("disconnect_timeout must be non-zero".to_owned())
+        );
+
+        let options = RunOptions {
+            disconnect_timeout: Some(Duration::from_secs(90)),
+            ..RunOptions::default()
+        };
+        validate_run_options(&schedule, &options).expect("positive timeout is valid");
+        let encoded = serde_json::to_vec(&options).expect("run options serialize");
+        let replay: RunOptions = serde_json::from_slice(&encoded).expect("run options deserialize");
+        assert_eq!(replay, options);
+    }
+
+    #[test]
     fn cpu_feedback_actuator_has_exact_poll_boundaries() {
         let policy = CpuFeedbackPolicy {
             simulated_frame_cost_us: 1,
@@ -4275,10 +4321,12 @@ mod tests {
             .collect();
         let dead = vec![false; n];
         let mut oracle = Oracle::new(n);
+        let options = RunOptions::default();
 
         {
             let mut ctx = HotJoinRuntime {
                 schedule: &schedule,
+                options: &options,
                 clock: &clock,
                 net: &net,
                 addrs: &addrs,

--- a/tests/simulation/harness/shrink.rs
+++ b/tests/simulation/harness/shrink.rs
@@ -173,6 +173,7 @@ fn remap_options(options: &RunOptions, removed: usize, steps: u32) -> RunOptions
         .and_then(|(from, to)| Some((remap_index(from, removed)?, remap_index(to, removed)?)));
     RunOptions {
         receive_message_limit: options.receive_message_limit,
+        disconnect_timeout: options.disconnect_timeout,
         corrupt_state_from: remap_peer_frame(options.corrupt_state_from, removed),
         corrupt_checksum_from: remap_peer_frame(options.corrupt_checksum_from, removed),
         probe_confirmed_at: options.probe_confirmed_at.filter(|probe| *probe < steps),
@@ -1130,6 +1131,7 @@ mod tests {
         schedule.heal_at = 20;
         let options = RunOptions {
             receive_message_limit: Some(512),
+            disconnect_timeout: Some(Duration::from_secs(90)),
             corrupt_state_from: Some((3, 8)),
             corrupt_checksum_from: Some((1, 9)),
             probe_confirmed_at: Some(19),
@@ -1158,6 +1160,7 @@ mod tests {
         assert_eq!(mapped.corrupt_checksum_from, None);
         assert_eq!(mapped.probe_confirmed_at, Some(19));
         assert_eq!(mapped.receive_message_limit, Some(512));
+        assert_eq!(mapped.disconnect_timeout, Some(Duration::from_secs(90)));
         assert_eq!(mapped.pending_output_probe_link, Some((2, 0)));
         assert_eq!(mapped.receipt_range_probe_target, Some(1));
         assert_eq!(


### PR DESCRIPTION
## Summary

- plant Reliable FIFO HOL windows before generated lifecycle faults so the sender remains active
- serialize and propagate a test-only disconnect-timeout override through peers, spectators, hot-join replacements, artifacts, and shrinking
- keep non-clean nightly transport rows free of implicit terminal membership changes while retaining production timeouts for clean lifecycle coverage
- pin both July 2026 scheduled CI failure seeds as an ignored long regression
- synchronize workflow contract tests and version comments with the action pins already merged by #261

This repairs the two failures that reset A8's scheduled-history gate; it does not promote A8 before seven consecutive scheduled `main` runs exist. The CI-pin follow-up repairs a pre-existing `main` mismatch exposed by this PR's Documentation run and does not change workflow behavior.

## Incident evidence

- scheduled run 29718845598, seed `29718845598175`: the planted peer-7 HOL link overlapped a peer-7 stall, so no retransmission could occur
- scheduled run 30068604101, seed `30068604101890`: Rough loss caused an implicit timeout and expected fail-closed membership split inside the transport-only green tier
- both exact seeds now pass the full oracle; the Reliable FIFO seed records positive `retransmit_delayed` evidence
- Documentation run 30186497038: three assertions still expected the pre-#261 `setup-python` and `rust-toolchain` pins; the complete contract audit also found and corrected the stale `setup-node@v6` assertion

## Review readiness

- Build/tests: PASS — 2,878 default tests and 222 doctests
- Script tests: PASS — all 1,968 tests
- Strict Clippy: PASS — default and `hot-join` configurations, warnings denied
- Exact historical seeds: PASS — ignored focused regression, 31.96s debug
- Workflow lint: PASS — actionlint on all workflows
- Agent preflight: PASS — all checks, including release automation and CI toolchain contracts
- Zero-panic/determinism: PASS — test-only simulation change; no production paths modified
- Error handling: PASS — zero timeout rejected and covered
- Tests breadth: PASS — premise, clean/non-clean split, serde, shrinker, hot-join propagation, exact seeds, exact action pins
- Design log: N/A — no production architecture or public behavior change
- CHANGELOG: N/A — test/CI contract repair only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulation tests/harness and CI pin assertions; production session APIs are only invoked via existing builder hooks in tests.
> 
> **Overview**
> **Simulation fleet** fixes two scheduled CI failures by reshaping **Reliable FIFO** head-of-line (HOL) injection and how long nightly transport runs wait before disconnect.
> 
> HOL windows are planted **before step 100** (lifecycle faults cannot start earlier), so the chosen sender stays active instead of overlapping stalls/kills. A test-only **`RunOptions::disconnect_timeout`** is threaded through session, spectator, and hot-join builders (plus shrink remapping) so **non-clean** nightly rows use a timeout longer than the modeled run—avoiding implicit membership splits from random loss while **clean** rows keep default options.
> 
> New unit tests lock the HOL premise, timeout behavior, serde/shrink propagation, and an ignored long regression over the two July 2026 failure seeds.
> 
> **CI contracts** align workflow YAML and Python contract tests with pins already on `main`: `actions/setup-python` v7 SHA, `dtolnay/rust-toolchain` and `actions/setup-node@v7` expectations—no intended workflow behavior change beyond those pin comments/versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa68bef60420a418273e085c5c8e3176a617e7fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->