### PR TITLE
Add deterministic allocation contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "smallvec",
+ "stats_alloc",
  "tokio",
  "tracing",
  "tracing-log",
@@ -1244,6 +1245,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "stats_alloc"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -393,6 +393,8 @@ proptest = "1.11"
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 # Benchmarking
 criterion = { version = "0.8", features = ["html_reports"] }
+# Deterministic allocation contracts run in an isolated integration-test process.
+stats_alloc = "0.1.10"
 # Macro utilities for data-driven tests
 pastey = "0.2"
 

--- a/tests/allocation_contract.rs
+++ b/tests/allocation_contract.rs
@@ -35,7 +35,15 @@ fn measure<T>(operation: impl FnOnce() -> T) -> (T, Stats) {
 
 #[track_caller]
 fn assert_zero_allocations(label: &str, stats: Stats) {
-    assert_eq!(stats, Stats::default(), "{label} allocation stats");
+    assert_eq!(stats.allocations, 0, "{label} allocation stats: {stats:?}");
+    assert_eq!(
+        stats.reallocations, 0,
+        "{label} allocation stats: {stats:?}"
+    );
+    assert_eq!(
+        stats.bytes_allocated, 0,
+        "{label} allocation stats: {stats:?}"
+    );
 }
 
 #[track_caller]
@@ -111,6 +119,16 @@ fn warmed_hot_paths_obey_allocation_contracts() {
         "known-allocation control: {control:?}"
     );
     drop(allocation);
+
+    // The zero-allocation helper deliberately permits deallocation: its
+    // contract is about newly allocated memory, not every allocator event.
+    let deallocation = vec![0_u8; 4_096];
+    let ((), deallocation_control) = measure(|| drop(deallocation));
+    assert_eq!(
+        deallocation_control.deallocations, 1,
+        "known-deallocation control: {deallocation_control:?}"
+    );
+    assert_zero_allocations("known-deallocation control", deallocation_control);
 
     // `encode_into` publicly documents that a caller-provided buffer avoids
     // allocation on the successful path.

--- a/tests/allocation_contract.rs
+++ b/tests/allocation_contract.rs
@@ -1,0 +1,164 @@
+//! Deterministic heap-allocation contracts for documented and warmed hot paths.
+//!
+//! This integration test is intentionally a single test in its own process.
+//! The process-local global allocator therefore cannot observe allocations from
+//! another test, and every measured operation excludes construction and warm-up.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
+#![forbid(unsafe_code)]
+
+use std::alloc::System;
+use std::hint::black_box;
+use std::net::SocketAddr;
+
+use fortress_rollback::network::codec;
+use fortress_rollback::{Config, PlayerHandle, SessionBuilder, SyncTestSession};
+use stats_alloc::{Region, Stats, StatsAlloc, INSTRUMENTED_SYSTEM};
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+struct AllocationConfig;
+
+impl Config for AllocationConfig {
+    type Input = u32;
+    type State = u32;
+    type Address = SocketAddr;
+}
+
+fn measure<T>(operation: impl FnOnce() -> T) -> (T, Stats) {
+    let region = Region::new(GLOBAL);
+    let result = operation();
+    let stats = region.change();
+    (result, stats)
+}
+
+#[track_caller]
+fn assert_zero_allocations(label: &str, stats: Stats) {
+    assert_eq!(stats, Stats::default(), "{label} allocation stats");
+}
+
+#[track_caller]
+fn assert_allocation_ceiling(
+    label: &str,
+    stats: Stats,
+    maximum_operations: usize,
+    maximum_bytes: usize,
+) {
+    let operations = stats.allocations.saturating_add(stats.reallocations);
+    assert!(
+        operations <= maximum_operations,
+        "{label} used {operations} allocation operations (ceiling {maximum_operations}): {stats:?}"
+    );
+    assert!(
+        stats.bytes_allocated <= maximum_bytes,
+        "{label} allocated {} bytes (ceiling {maximum_bytes}): {stats:?}",
+        stats.bytes_allocated
+    );
+}
+
+fn warmed_synctest_frame_stats(num_players: usize) -> Stats {
+    let mut session: SyncTestSession<AllocationConfig> = SessionBuilder::new()
+        .with_num_players(num_players)
+        .expect("configure allocation-contract player count")
+        .with_check_distance(0)
+        .start_synctest_session()
+        .expect("construct allocation-contract sync test");
+
+    for player in 0..num_players {
+        session
+            .add_local_input(
+                PlayerHandle::new(player),
+                u32::try_from(player).expect("allocation-contract handle fits u32"),
+            )
+            .expect("add warm-up input");
+    }
+    black_box(session.advance_frame().expect("advance warm-up frame"));
+
+    let (requests, stats) = measure(|| {
+        for player in 0..num_players {
+            session
+                .add_local_input(
+                    PlayerHandle::new(player),
+                    u32::try_from(player).expect("allocation-contract handle fits u32"),
+                )
+                .expect("add measured input");
+        }
+        black_box(session.advance_frame().expect("advance measured frame"))
+    });
+    black_box(requests);
+    stats
+}
+
+/// Allocation contracts are measured together so the instrumented allocator
+/// cannot observe concurrently running tests in this integration-test process.
+#[test]
+fn warmed_hot_paths_obey_allocation_contracts() {
+    // Counter sensitivity: this must detect one known allocation or every
+    // zero-allocation assertion below would be capable of passing vacuously.
+    let (allocation, control) = measure(|| vec![0_u8; 4_096]);
+    black_box(&allocation);
+    assert_eq!(
+        control.allocations, 1,
+        "known-allocation control: {control:?}"
+    );
+    assert_eq!(
+        control.reallocations, 0,
+        "known-allocation control: {control:?}"
+    );
+    assert_eq!(
+        control.bytes_allocated, 4_096,
+        "known-allocation control: {control:?}"
+    );
+    drop(allocation);
+
+    // `encode_into` publicly documents that a caller-provided buffer avoids
+    // allocation on the successful path.
+    let mut buffer = [0_u8; 64];
+    let (encoded_len, encode_stats) =
+        measure(|| codec::encode_into(black_box(&42_u32), black_box(&mut buffer)));
+    assert_eq!(encoded_len.expect("encode into fixed buffer"), 4);
+    assert_zero_allocations("codec::encode_into", encode_stats);
+
+    // Handle iterators publicly document zero allocation. The collecting
+    // convenience API is allowed one bounded spill above HandleVec's inline
+    // capacity of eight.
+    let session: SyncTestSession<AllocationConfig> = SessionBuilder::new()
+        .with_num_players(16)
+        .expect("configure sixteen-player allocation contract")
+        .start_synctest_session()
+        .expect("construct sixteen-player allocation contract");
+    let (handle_sum, iterator_stats) = measure(|| {
+        black_box(&session)
+            .local_player_handles_iter()
+            .map(PlayerHandle::as_usize)
+            .sum::<usize>()
+    });
+    assert_eq!(handle_sum, 120);
+    assert_zero_allocations("local_player_handles_iter", iterator_stats);
+
+    let (handles, collecting_stats) = measure(|| session.local_player_handles());
+    assert_eq!(handles.len(), 16);
+    assert_allocation_ceiling("sixteen-player HandleVec spill", collecting_stats, 1, 256);
+    drop(handles);
+
+    // The ceilings are based on the red-run observations (1/192 B, 1/192 B,
+    // and 4/800 B). Byte ceilings leave bounded layout headroom while operation
+    // counts stay tight enough to expose new per-player allocation growth.
+    for (players, operation_ceiling, byte_ceiling) in [(2, 1, 256), (4, 1, 256), (16, 4, 1_024)] {
+        let first = warmed_synctest_frame_stats(players);
+        for repetition in 1..3 {
+            assert_eq!(
+                warmed_synctest_frame_stats(players),
+                first,
+                "warmed {players}-player sync-test frame repetition {repetition}"
+            );
+        }
+        assert_allocation_ceiling(
+            &format!("warmed {players}-player sync-test frame"),
+            first,
+            operation_ceiling,
+            byte_ceiling,
+        );
+    }
+}

--- a/tests/allocation_contract.rs
+++ b/tests/allocation_contract.rs
@@ -44,6 +44,16 @@ fn assert_zero_allocations(label: &str, stats: Stats) {
         stats.bytes_allocated, 0,
         "{label} allocation stats: {stats:?}"
     );
+    assert_eq!(
+        stats.bytes_reallocated, 0,
+        "{label} allocation stats: {stats:?}"
+    );
+}
+
+fn allocated_and_grown_bytes(stats: Stats) -> usize {
+    let reallocation_growth = usize::try_from(stats.bytes_reallocated.max(0))
+        .expect("nonnegative reallocation growth fits usize");
+    stats.bytes_allocated.saturating_add(reallocation_growth)
 }
 
 #[track_caller]
@@ -54,14 +64,14 @@ fn assert_allocation_ceiling(
     maximum_bytes: usize,
 ) {
     let operations = stats.allocations.saturating_add(stats.reallocations);
+    let allocated_bytes = allocated_and_grown_bytes(stats);
     assert!(
         operations <= maximum_operations,
         "{label} used {operations} allocation operations (ceiling {maximum_operations}): {stats:?}"
     );
     assert!(
-        stats.bytes_allocated <= maximum_bytes,
-        "{label} allocated {} bytes (ceiling {maximum_bytes}): {stats:?}",
-        stats.bytes_allocated
+        allocated_bytes <= maximum_bytes,
+        "{label} allocated or grew by {allocated_bytes} bytes (ceiling {maximum_bytes}): {stats:?}"
     );
 }
 
@@ -129,6 +139,25 @@ fn warmed_hot_paths_obey_allocation_contracts() {
         "known-deallocation control: {deallocation_control:?}"
     );
     assert_zero_allocations("known-deallocation control", deallocation_control);
+
+    // Synthetic counter sensitivity ensures positive reallocation growth is
+    // charged to the byte ceiling even when no fresh allocation is recorded.
+    let reallocation_control = Stats {
+        reallocations: 1,
+        bytes_reallocated: 4_096,
+        ..Stats::default()
+    };
+    assert_eq!(
+        allocated_and_grown_bytes(reallocation_control),
+        4_096,
+        "known-reallocation-growth control: {reallocation_control:?}"
+    );
+    assert_allocation_ceiling(
+        "known-reallocation-growth control",
+        reallocation_control,
+        1,
+        4_096,
+    );
 
     // `encode_into` publicly documents that a caller-provided buffer avoids
     // allocation on the successful path.


### PR DESCRIPTION
## What

- add a test-scoped counting allocator in one isolated integration-test process
- prove the counter is live with a planted 4 KiB allocation
- pin documented zero-allocation behavior for `codec::encode_into` and player-handle iteration
- establish repeatable operation/byte ceilings for warmed N={2,4,16} sync-test frames and the 16-player `HandleVec` spill

## Why

Issue #264's benchmark half is already operational. The remaining prerequisite for data-backed allocation optimization is a deterministic, non-wall-clock contract that can distinguish documented zero-allocation paths from bounded allocating paths without contamination from concurrent tests.

The initial red run assigned zero ceilings and observed one 192-byte allocation at N=2. The calibrated rows repeat bit-for-bit three times before their ceilings are checked:

| Warmed sync-test frame | Operations | Bytes |
| --- | ---: | ---: |
| N=2 | 1 | 192 |
| N=4 | 1 | 192 |
| N=16 | 4 | 800 |

This measurement-only slice intentionally does not optimize production code yet. It gives the next optimization a permanent red/green oracle. Progresses #264.

## Impact

Test infrastructure and a development dependency only. No production behavior, public API, wire format, or changelog-relevant behavior changes. The existing cross-platform Rust Nextest matrix auto-discovers the test; no duplicate workflow is added.

## Validation

- allocation contract: 10 consecutive debug passes
- release allocation contract: 1 passed
- strict workspace/all-target Clippy with `tokio,json`: passed
- default Nextest: 2,883 passed, 71 skipped
- hot-join Nextest: 3,139 passed, 72 skipped
- full agent preflight: passed, including 286 release-automation tests, 66 CI-toolchain tests, 49 Agent Skills, 1,393 links, workflow lint, allocation bounds, and spelling
- adversarial review: final pass reported zero findings

## Review Readiness

- Build/tests: PASS
- Zero-panic: PASS (no production change; test crate forbids unsafe code)
- Determinism: PASS (single process/test, setup excluded, each scale repeats identically)
- Agent preflight: PASS
- Error handling: PASS
- Tests breadth: PASS (known-allocation control, exact-zero paths, bounded N=2/4/16 rows)
- Design log reviewed: N/A
- CHANGELOG reviewed: N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test infrastructure and a dev dependency only; no production behavior, API, or wire-format changes.
> 
> **Overview**
> Adds **test-only** heap allocation contracts using `stats_alloc` in a dedicated integration test process (`tests/allocation_contract.rs`), so measurements are not mixed with other tests.
> 
> The single test warms paths first, then asserts **zero** new allocations for documented non-allocating APIs (`codec::encode_into` with a fixed buffer, `local_player_handles_iter`), and **bounded** ceilings for `local_player_handles()` when 16 players spill past `HandleVec` inline capacity (8), plus warmed `SyncTestSession::advance_frame` after inputs for N=2, 4, and 16 (operation and byte ceilings calibrated from a red run, with repeatability checks).
> 
> Includes allocator **sanity controls** (known alloc/dealloc/realloc growth) so zero-allocation assertions cannot pass vacuously. No production code changes—prerequisite for issue #264 allocation optimization work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b779c78ac4251a64d3853f582b4c90f8a354fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->