### PR TITLE
chore(ci): refresh current action pins

### DIFF
--- a/.github/actions/setup-rust-cache/action.yml
+++ b/.github/actions/setup-rust-cache/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Configure sccache
       id: sccache
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@v0.0.11
       continue-on-error: true
 
     - name: Verify sccache is working

--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working
@@ -182,7 +182,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working
@@ -319,7 +319,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working

--- a/.github/workflows/ci-network-nightly.yml
+++ b/.github/workflows/ci-network-nightly.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working (Unix)

--- a/.github/workflows/ci-network.yml
+++ b/.github/workflows/ci-network.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working (Unix)

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working (Unix)

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working
@@ -164,7 +164,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working

--- a/.github/workflows/ci-simulation-nightly.yml
+++ b/.github/workflows/ci-simulation-nightly.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working

--- a/.github/workflows/ci-verification.yml
+++ b/.github/workflows/ci-verification.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Java 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working


### PR DESCRIPTION
## Summary

- update every executable `mozilla-actions/sccache-action` call site to v0.0.11, including the reusable composite action omitted by Dependabot PR #269
- preserve the publish workflow's immutable full-SHA policy with the v0.0.11 release commit
- pin `actions/setup-java` to the current v5.7.0 release, which supersedes PR #269's now-stale v5.6.0 proposal

This intentionally supersedes #269 after its `@dependabot recreate` request did not refresh the stale setup-java version or cover the reusable action.

## Red evidence

The pre-change repository scan found eleven executable sccache v0.0.10 references and one floating `actions/setup-java@v5` reference. Dependabot #269 covered the workflows it scanned but omitted `.github/actions/setup-rust-cache/action.yml`.

## Validation

- `actionlint`
- 142 targeted release/workflow policy tests
- 31/31 Agent Skill shell checks
- complete `scripts/ci/agent-preflight.py --all --verbose`
  - 286 release automation tests
  - 66 CI toolchain tests
  - 49 Agent Skills
  - 1,393 link checks
  - all remaining repository policy gates
- adversarial call-site, immutable-pin, supply-chain, and upstream-tag audit: no findings

## Risk

Low. This changes only third-party action refs and does not alter workflow triggers, permissions, inputs, application code, public API, or wire format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only third-party action version pins change; no application code, workflow behavior, or security-sensitive logic is altered.
> 
> **Overview**
> Bumps third-party GitHub Action references across CI and release workflows without changing triggers, permissions, or step logic.
> 
> **`mozilla-actions/sccache-action`** moves from **v0.0.10** to **v0.0.11** at every executable call site, including the reusable **`setup-rust-cache`** composite action (which Dependabot had missed). The publish workflow keeps its immutable full-SHA pin, updated to the v0.0.11 release commit.
> 
> **`actions/setup-java`** in **`ci-verification.yml`** is pinned from the floating **`@v5`** tag to **`@v5.7.0`** for the TLA+ Java 17 setup step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98836060e6459c9adc4c49e9058cce92f8bf7d1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->