### PR TITLE
Eliminate warmed sync-test input staging allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `SyncTestSession::advance_frame()` now reuses constructor-owned input staging, making warmed
+  one-to-four-player frames heap-allocation-free and reducing sixteen-player frames to the returned
+  `InputVec` spill.
+
 ## [0.11.0] - 2026-07-18
 
 ### Added

--- a/src/sessions/sync_test_session.rs
+++ b/src/sessions/sync_test_session.rs
@@ -37,7 +37,7 @@ where
     sync_layer: SyncLayer<T>,
     dummy_connect_status: Vec<ConnectionStatus>,
     checksum_history: BTreeMap<Frame, Option<u128>>,
-    local_inputs: BTreeMap<PlayerHandle, PlayerInput<T::Input>>,
+    local_inputs: Vec<Option<PlayerInput<T::Input>>>,
     /// Pending events to be consumed via [`events()`](Self::events).
     event_queue: VecDeque<FortressEvent<T>>,
     /// Optional observer for specification violations.
@@ -107,7 +107,7 @@ impl<T: Config> SyncTestSession<T> {
                     ),
                     dummy_connect_status: Vec::new(),
                     checksum_history: BTreeMap::new(),
-                    local_inputs: BTreeMap::new(),
+                    local_inputs: Vec::new(),
                     event_queue: VecDeque::new(),
                     violation_observer: None,
                 }
@@ -129,6 +129,14 @@ impl<T: Config> SyncTestSession<T> {
             .map_err(|_err| allocation_failed("synctest.dummy_connect_status", num_players))?;
         for _ in 0..num_players {
             dummy_connect_status.push(ConnectionStatus::default());
+        }
+
+        let mut local_inputs = Vec::new();
+        local_inputs
+            .try_reserve_exact(num_players)
+            .map_err(|_err| allocation_failed("synctest.local_inputs", num_players))?;
+        for _ in 0..num_players {
+            local_inputs.push(None);
         }
 
         let mut sync_layer =
@@ -153,7 +161,7 @@ impl<T: Config> SyncTestSession<T> {
             sync_layer,
             dummy_connect_status,
             checksum_history: BTreeMap::new(),
-            local_inputs: BTreeMap::new(),
+            local_inputs,
             event_queue: VecDeque::new(),
             violation_observer,
         })
@@ -180,7 +188,17 @@ impl<T: Config> SyncTestSession<T> {
             .into());
         }
         let player_input = PlayerInput::<T::Input>::new(self.sync_layer.current_frame(), input);
-        self.local_inputs.insert(player_handle, player_input);
+        let local_inputs_len = self.local_inputs.len();
+        let slot = self.local_inputs.get_mut(player_handle.as_usize()).ok_or(
+            FortressError::InternalErrorStructured {
+                kind: InternalErrorKind::IndexOutOfBounds(crate::error::IndexOutOfBounds {
+                    name: "synctest.local_inputs",
+                    index: player_handle.as_usize(),
+                    length: local_inputs_len,
+                }),
+            },
+        )?;
+        *slot = Some(player_input);
         Ok(())
     }
 
@@ -223,16 +241,25 @@ impl<T: Config> SyncTestSession<T> {
         }
 
         // we require inputs for all players
-        if self.num_players != self.local_inputs.len() {
+        if self.num_players != self.local_inputs.len()
+            || self.local_inputs.iter().any(Option::is_none)
+        {
             return Err(InvalidRequestKind::MissingLocalInput.into());
         }
         // pass all inputs into the sync layer
-        for (&handle, &input) in self.local_inputs.iter() {
+        for (player, input) in self.local_inputs.iter().enumerate() {
+            let input = match input {
+                Some(input) => *input,
+                None => return Err(InvalidRequestKind::MissingLocalInput.into()),
+            };
             // send the input into the sync layer
-            self.sync_layer.add_local_input(handle, input);
+            self.sync_layer
+                .add_local_input(PlayerHandle::new(player), input);
         }
-        // clear local inputs after using them
-        self.local_inputs.clear();
+        // Clear values while retaining the constructor-owned player slots.
+        for input in &mut self.local_inputs {
+            *input = None;
+        }
 
         // save the current frame in the synchronization layer
         // we can skip all the saving if the check_distance is 0
@@ -824,6 +851,21 @@ mod tests {
                 kind: InvalidRequestKind::MissingLocalInput
             })
         ));
+
+        // A failed advance must retain already staged inputs so callers can
+        // supply only the missing player and retry without changing semantics.
+        session
+            .add_local_input(PlayerHandle::new(1), 100)
+            .expect("should add the missing input");
+        let requests = session.advance_frame().expect("retry should advance");
+        let inputs = requests.iter().find_map(|request| match request {
+            FortressRequest::AdvanceFrame { inputs } => Some(inputs),
+            _ => None,
+        });
+        let inputs = inputs.expect("retry should return an advance request");
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(inputs[0].0, 42);
+        assert_eq!(inputs[1].0, 100);
     }
 
     #[test]
@@ -1220,11 +1262,13 @@ mod tests {
     fn requests_contain_advance_frame_with_inputs() {
         let mut session: SyncTestSession<TestConfig> = SyncTestSession::new(2, 8, 0, 0, None);
 
-        session
-            .add_local_input(PlayerHandle::new(0), 111)
-            .expect("should succeed");
+        // Add in reverse handle order; the emitted input vector must remain
+        // player-index ordered.
         session
             .add_local_input(PlayerHandle::new(1), 222)
+            .expect("should succeed");
+        session
+            .add_local_input(PlayerHandle::new(0), 111)
             .expect("should succeed");
 
         let requests = session.advance_frame().expect("should advance");

--- a/tests/allocation_contract.rs
+++ b/tests/allocation_contract.rs
@@ -189,10 +189,10 @@ fn warmed_hot_paths_obey_allocation_contracts() {
     assert_allocation_ceiling("sixteen-player HandleVec spill", collecting_stats, 1, 256);
     drop(handles);
 
-    // The ceilings are based on the red-run observations (1/192 B, 1/192 B,
-    // and 4/800 B). Byte ceilings leave bounded layout headroom while operation
-    // counts stay tight enough to expose new per-player allocation growth.
-    for (players, operation_ceiling, byte_ceiling) in [(2, 1, 256), (4, 1, 256), (16, 4, 1_024)] {
+    // Warmed frame input staging reuses constructor-owned storage at every
+    // scale. N=2 and N=4 therefore touch no allocator; N=16 retains one exact
+    // 128-byte spill for the returned 16-player InputVec above inline capacity.
+    for (players, operation_ceiling, byte_ceiling) in [(2, 0, 0), (4, 0, 0), (16, 1, 128)] {
         let first = warmed_synctest_frame_stats(players);
         for repetition in 1..3 {
             assert_eq!(


### PR DESCRIPTION
## What

- replace per-frame `BTreeMap` input staging in `SyncTestSession` with fallibly preallocated player-indexed slots
- retain slot storage across frames while preserving duplicate overwrite, missing-input retry, and deterministic player ordering
- tighten the deterministic allocation ledger to zero operations/bytes for warmed N=2 and N=4 frames, and one exact 128-byte returned-`InputVec` spill at N=16
- document the observable performance improvement in the changelog

## Why

PR #270 established a deterministic allocation ledger and measured one allocation / 192 bytes per warmed frame at N=2 and N=4, plus four operations / 800 bytes at N=16. Those allocations came from rebuilding the sync-test staging map every frame. Constructor-owned slots remove that repeated work without changing the public API or wire behavior.

Progresses #264.

## Impact

Warmed `SyncTestSession::advance_frame()` calls for one-to-four-player sessions are heap-allocation-free. Sixteen-player frames now allocate only for the returned `InputVec` above its inline capacity. Construction remains fallible for arbitrary configured player counts, and an impossible slot-length mismatch returns a structured internal error.

## Validation

- allocation contract: 10 consecutive debug runs and one release run
- focused semantic/allocation tests: 3/3
- sync-test unit suite: 49/49
- sync-test determinism regression: 1/1
- default Nextest matrix: 2,883/2,883
- `hot-join` Nextest matrix: 3,139/3,139
- `cargo clippy --workspace --all-targets --features tokio,json`
- warning-denied workspace documentation
- changelog formatting, Unreleased policy, and version synchronization
- agent preflight, including 286 release-automation tests and 1,393 links
- independent adversarial review: zero findings

## Review Readiness

- Build/tests: PASS
- Zero-panic: PASS
- Determinism: PASS
- Agent preflight: PASS
- Error handling: PASS
- Tests breadth: PASS
- Design log reviewed: N/A (private staging refactor)
- CHANGELOG reviewed: YES

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private sync-test staging only; semantics are covered by unit and allocation-contract tests with no public API or network wire changes.
> 
> **Overview**
> **`SyncTestSession`** no longer rebuilds per-frame input staging with a **`BTreeMap`**. Construction fallibly reserves **`Vec<Option<PlayerInput>>`** indexed by player handle; **`add_local_input`** overwrites slots, and **`advance_frame`** clears slots to **`None`** while keeping that storage for the next frame.
> 
> **Behavior preserved or tightened:** missing-input checks cover empty slots; player-index ordering in **`AdvanceFrame`** inputs is unchanged; a failed **`advance_frame`** keeps already-staged inputs so callers can add only missing players and retry.
> 
> **Allocation impact:** warmed **`advance_frame()`** for 1–4 players is heap-free; 16-player frames are limited to the returned **`InputVec`** spill above inline capacity (allocation contract and changelog updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75047918c901b6ab1d3efd941014a20544284f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->