### PR TITLE
Eliminate P2P local-input staging allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `SyncTestSession::advance_frame()` now reuses constructor-owned input staging, making warmed
-  one-to-four-player frames heap-allocation-free and reducing sixteen-player frames to the returned
-  `InputVec` spill.
+- `P2PSession` and `SyncTestSession` now reuse constructor-owned local-input staging. On the
+  measured warmed path, staging one to four local players adds no heap allocation, while staging
+  sixteen players retains only the returned `InputVec` spill. Network encoding and checksum history
+  keep their separate bounded allocations; application state callbacks are outside this measurement.
 
 ## [0.11.0] - 2026-07-18
 

--- a/src/network/protocol/input_bytes.rs
+++ b/src/network/protocol/input_bytes.rs
@@ -13,6 +13,38 @@ use crate::{
     Config, FortressError, Frame, InternalErrorKind, PlayerHandle, SerializationErrorKind,
 };
 
+/// Read-only input staging used by protocol serialization.
+///
+/// Implementations expose lookup by player handle; `InputBytes` owns the
+/// ascending handle walk so storage choice cannot change wire ordering.
+pub(crate) trait InputSource<T: Config> {
+    fn get(&self, handle: PlayerHandle) -> Option<&PlayerInput<T::Input>>;
+
+    fn serializable_len(&self, num_players: usize) -> usize;
+}
+
+impl<T: Config> InputSource<T> for BTreeMap<PlayerHandle, PlayerInput<T::Input>> {
+    fn get(&self, handle: PlayerHandle) -> Option<&PlayerInput<T::Input>> {
+        self.get(&handle)
+    }
+
+    fn serializable_len(&self, num_players: usize) -> usize {
+        self.keys()
+            .filter(|handle| handle.as_usize() < num_players)
+            .count()
+    }
+}
+
+impl<T: Config> InputSource<T> for [Option<PlayerInput<T::Input>>] {
+    fn get(&self, handle: PlayerHandle) -> Option<&PlayerInput<T::Input>> {
+        self.get(handle.as_usize()).and_then(Option::as_ref)
+    }
+
+    fn serializable_len(&self, num_players: usize) -> usize {
+        self.iter().take(num_players).flatten().count()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum InputBytesDecodeError {
     AllocationFailed {
@@ -146,7 +178,7 @@ impl InputBytes {
     /// whose serialized length differs from `Config::Input::default()`.
     pub fn try_from_inputs<T: Config>(
         num_players: usize,
-        inputs: &BTreeMap<PlayerHandle, PlayerInput<T::Input>>,
+        inputs: &(impl InputSource<T> + ?Sized),
     ) -> Result<Self, FortressError> {
         let input_size = codec::encoded_len(&T::Input::default()).map_err(|err| {
             report_violation!(
@@ -161,10 +193,7 @@ impl InputBytes {
             return Err(SerializationErrorKind::InputSerializedSizeZero.into());
         }
 
-        let serializable_inputs = inputs
-            .keys()
-            .filter(|handle| handle.as_usize() < num_players)
-            .count();
+        let serializable_inputs = inputs.serializable_len(num_players);
         let estimated_size = input_size.checked_mul(serializable_inputs).ok_or({
             FortressError::SerializationErrorStructured {
                 kind: SerializationErrorKind::InputSerializedFrameTooLarge {
@@ -180,7 +209,7 @@ impl InputBytes {
         let mut frame = Frame::NULL;
         // in ascending order
         for handle in 0..num_players {
-            if let Some(input) = inputs.get(&PlayerHandle::new(handle)) {
+            if let Some(input) = inputs.get(PlayerHandle::new(handle)) {
                 let input_len = codec::encoded_len(&input.input).map_err(|err| {
                     report_violation!(
                         ViolationSeverity::Error,
@@ -592,6 +621,23 @@ mod tests {
         let input_bytes = InputBytes::from_inputs::<TestConfig>(2, &inputs);
         // Only serializes inputs that exist - results in 4 bytes for player 0
         assert_eq!(input_bytes.bytes.len(), 4);
+    }
+
+    #[test]
+    fn map_and_slot_input_sources_encode_identically() {
+        let frame = Frame::new(50);
+        let player_zero = PlayerInput::new(frame, TestInput { inp: 42 });
+        let player_two = PlayerInput::new(frame, TestInput { inp: 99 });
+        let mut map = BTreeMap::new();
+        map.insert(PlayerHandle::new(2), player_two);
+        map.insert(PlayerHandle::new(0), player_zero);
+        let slots = vec![Some(player_zero), None, Some(player_two)];
+
+        let from_map = InputBytes::try_from_inputs::<TestConfig>(3, &map).unwrap();
+        let from_slots = InputBytes::try_from_inputs::<TestConfig>(3, slots.as_slice()).unwrap();
+
+        assert_eq!(from_slots.frame, from_map.frame);
+        assert_eq!(from_slots.bytes, from_map.bytes);
     }
 
     #[test]

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -17,7 +17,7 @@ pub use handshake_trace::{
     HandshakeReplyDisposition, HandshakeRequestDisposition, HandshakeRequestIdDisposition,
     HandshakeTraceAction, HandshakeTraceConfig, HandshakeTraceEvent, HandshakeTraceOverflow,
 };
-use input_bytes::{log_input_decode_error, InputBytes};
+use input_bytes::{log_input_decode_error, InputBytes, InputSource};
 pub use state::ProtocolState;
 
 use crate::error::{allocation_failed, SerializationErrorKind};
@@ -1745,7 +1745,7 @@ impl<T: Config> UdpProtocol<T> {
 
     pub(crate) fn send_input(
         &mut self,
-        inputs: &BTreeMap<PlayerHandle, PlayerInput<T::Input>>,
+        inputs: &(impl InputSource<T> + ?Sized),
         connect_status: &[ConnectionStatus],
     ) {
         if self.state != ProtocolState::Running {

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -329,8 +329,9 @@ where
 
     /// Contains all events to be forwarded to the user.
     event_queue: VecDeque<FortressEvent<T>>,
-    /// Contains all local inputs not yet sent into the system. This should have inputs for every local player before calling advance_frame
-    local_inputs: BTreeMap<PlayerHandle, PlayerInput<T::Input>>,
+    /// Contains all local inputs not yet sent into the system, indexed by player handle.
+    /// This should have inputs for every local player before calling `advance_frame`.
+    local_inputs: Vec<Option<PlayerInput<T::Input>>>,
 
     /// With desync detection, the session will compare checksums for all peers to detect discrepancies / desyncs between peers
     desync_detection: DesyncDetection,
@@ -2784,6 +2785,14 @@ impl<T: Config> P2PSession<T> {
             .try_reserve_exact(event_queue_size)
             .map_err(|_err| allocation_failed("p2p.event_queue", event_queue_size))?;
 
+        let mut local_inputs = Vec::new();
+        local_inputs
+            .try_reserve_exact(num_players)
+            .map_err(|_err| allocation_failed("p2p.local_inputs", num_players))?;
+        for _ in 0..num_players {
+            local_inputs.push(None);
+        }
+
         Ok(Self {
             state,
             num_players,
@@ -2798,7 +2807,7 @@ impl<T: Config> P2PSession<T> {
             disconnect_frame: Frame::NULL,
             player_reg: players,
             event_queue,
-            local_inputs: BTreeMap::new(),
+            local_inputs,
             desync_detection,
             local_checksum_history: BTreeMap::new(),
             last_sent_checksum_frame: Frame::NULL,
@@ -2866,7 +2875,17 @@ impl<T: Config> P2PSession<T> {
             .into());
         }
         let player_input = PlayerInput::<T::Input>::new(self.sync_layer.current_frame(), input);
-        self.local_inputs.insert(player_handle, player_input);
+        let local_inputs_len = self.local_inputs.len();
+        let slot = self.local_inputs.get_mut(player_handle.as_usize()).ok_or(
+            FortressError::InternalErrorStructured {
+                kind: InternalErrorKind::IndexOutOfBounds(crate::error::IndexOutOfBounds {
+                    name: "p2p.local_inputs",
+                    index: player_handle.as_usize(),
+                    length: local_inputs_len,
+                }),
+            },
+        )?;
+        *slot = Some(player_input);
         Ok(())
     }
 
@@ -2971,7 +2990,12 @@ impl<T: Config> P2PSession<T> {
 
         // check if input for all local players is queued (zero-allocation via iterator)
         for handle in self.player_reg.local_player_handles_iter() {
-            if !self.local_inputs.contains_key(&handle) {
+            if self
+                .local_inputs
+                .get(handle.as_usize())
+                .and_then(Option::as_ref)
+                .is_none()
+            {
                 return Err(InvalidRequestKind::MissingLocalInput.into());
             }
         }
@@ -3076,13 +3100,14 @@ impl<T: Config> P2PSession<T> {
         // register local inputs in the system and send them (zero-allocation via iterator)
         for handle in self.player_reg.local_player_handles_iter() {
             // we have checked that these all exist above, but return error for safety
-            let player_input =
-                self.local_inputs
-                    .get_mut(&handle)
-                    .ok_or_else(|| FortressError::MissingInput {
-                        player_handle: handle,
-                        frame: self.sync_layer.current_frame(),
-                    })?;
+            let player_input = self
+                .local_inputs
+                .get_mut(handle.as_usize())
+                .and_then(Option::as_mut)
+                .ok_or_else(|| FortressError::MissingInput {
+                    player_handle: handle,
+                    frame: self.sync_layer.current_frame(),
+                })?;
             // send the input into the sync layer
             let actual_frame = self.sync_layer.add_local_input(handle, *player_input);
             player_input.frame = actual_frame;
@@ -3100,9 +3125,14 @@ impl<T: Config> P2PSession<T> {
         }
 
         // if the local inputs have not been dropped by the sync layer, send to all remote clients
-        if !self.local_inputs.values().any(|&i| i.frame == Frame::NULL) {
+        if !self
+            .local_inputs
+            .iter()
+            .flatten()
+            .any(|input| input.frame == Frame::NULL)
+        {
             for endpoint in self.player_reg.remotes.values_mut() {
-                endpoint.send_input(&self.local_inputs, &self.local_connect_status);
+                endpoint.send_input(self.local_inputs.as_slice(), &self.local_connect_status);
                 endpoint.send_all_messages(&mut self.socket);
             }
         }
@@ -3150,7 +3180,9 @@ impl<T: Config> P2PSession<T> {
             // advance the frame count
             self.sync_layer.advance_frame();
             // clear the local inputs after advancing the frame to allow new inputs to be ingested
-            self.local_inputs.clear();
+            for input in &mut self.local_inputs {
+                *input = None;
+            }
             requests.push(FortressRequest::AdvanceFrame { inputs });
 
             // Record the forward (visual) advance and sample confirmation lag:
@@ -12486,6 +12518,23 @@ mod tests {
         }
     }
 
+    struct RecordingSocket {
+        sent: Arc<std::sync::Mutex<Vec<Message>>>,
+    }
+
+    impl NonBlockingSocket<SocketAddr> for RecordingSocket {
+        fn send_to(&mut self, msg: &Message, _addr: &SocketAddr) {
+            self.sent
+                .lock()
+                .expect("recording socket lock")
+                .push(msg.clone());
+        }
+
+        fn receive_all_messages(&mut self) -> Vec<(SocketAddr, Message)> {
+            Vec::new()
+        }
+    }
+
     struct QueuedReceiveSocket {
         messages: Arc<std::sync::Mutex<Vec<(SocketAddr, Message)>>>,
     }
@@ -13441,7 +13490,48 @@ mod tests {
         session
             .add_local_input(PlayerHandle::new(0), 20u8)
             .expect("Second input failed");
-        // Should succeed without error - second input overwrites first
+        let requests = session.advance_frame().expect("Advance failed");
+        let input = requests
+            .iter()
+            .find_map(|request| match request {
+                FortressRequest::AdvanceFrame { inputs } => inputs.first(),
+                FortressRequest::SaveGameState { .. } | FortressRequest::LoadGameState { .. } => {
+                    None
+                },
+            })
+            .expect("advance request must contain the local input");
+        assert_eq!(input.0, 20);
+    }
+
+    #[test]
+    fn add_local_input_uses_sparse_player_handle_slot() {
+        let mut session = SessionBuilder::<TestConfig>::new()
+            .with_num_players(3)
+            .unwrap()
+            .add_remote_player(0, test_addr(8080))
+            .unwrap()
+            .add_remote_player(1, test_addr(8080))
+            .unwrap()
+            .add_local_player(2)
+            .unwrap()
+            .start_p2p_session(DummySocket)
+            .unwrap();
+
+        session
+            .add_local_input(PlayerHandle::new(2), 42)
+            .expect("sparse local input must succeed");
+
+        assert_eq!(session.local_inputs.len(), 3);
+        assert!(session.local_inputs.first().is_some_and(Option::is_none));
+        assert!(session.local_inputs.get(1).is_some_and(Option::is_none));
+        assert_eq!(
+            session
+                .local_inputs
+                .get(2)
+                .and_then(Option::as_ref)
+                .map(|input| input.input),
+            Some(42)
+        );
     }
 
     // ==========================================
@@ -13512,6 +13602,47 @@ mod tests {
     }
 
     #[test]
+    fn advance_frame_dropped_local_input_suppresses_endpoint_send() {
+        let sent = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let socket = RecordingSocket {
+            sent: Arc::clone(&sent),
+        };
+        let mut session = SessionBuilder::<TestConfig>::new()
+            .with_num_players(2)
+            .unwrap()
+            .add_local_player(0)
+            .unwrap()
+            .add_remote_player(1, test_addr(8080))
+            .unwrap()
+            .start_p2p_session(socket)
+            .unwrap();
+        session.state = SessionState::Running;
+        for endpoint in session.player_reg.remotes.values_mut() {
+            endpoint.force_running_for_tests();
+        }
+        session.poll_remote_clients();
+        sent.lock().expect("recording socket lock").clear();
+        session
+            .add_local_input(PlayerHandle::new(0), 42)
+            .expect("local input must be staged");
+        session
+            .local_inputs
+            .first_mut()
+            .and_then(Option::as_mut)
+            .expect("local input slot must exist")
+            .frame = Frame::new(1);
+
+        session
+            .advance_frame()
+            .expect("dropped local input must fail closed without a send");
+
+        assert!(
+            sent.lock().expect("recording socket lock").is_empty(),
+            "Frame::NULL local input must suppress the whole endpoint send"
+        );
+    }
+
+    #[test]
     fn advance_frame_multiple_local_players_requires_all_inputs() {
         let mut session = create_two_local_players_session();
         // Add input for player 0 only
@@ -13526,19 +13657,55 @@ mod tests {
                 kind: InvalidRequestKind::MissingLocalInput
             })
         ));
+
+        session
+            .add_local_input(PlayerHandle::new(1), 7u8)
+            .expect("Input retry failed");
+        let requests = session.advance_frame().expect("Advance retry failed");
+        let inputs = requests
+            .iter()
+            .find_map(|request| match request {
+                FortressRequest::AdvanceFrame { inputs } => Some(inputs),
+                FortressRequest::SaveGameState { .. } | FortressRequest::LoadGameState { .. } => {
+                    None
+                },
+            })
+            .expect("advance retry must retain the first input");
+        assert_eq!(
+            inputs
+                .iter()
+                .map(|(input, _status)| *input)
+                .collect::<Vec<_>>(),
+            vec![42, 7]
+        );
     }
 
     #[test]
     fn advance_frame_multiple_local_players_succeeds_with_all_inputs() {
         let mut session = create_two_local_players_session();
         session
-            .add_local_input(PlayerHandle::new(0), 1u8)
-            .expect("Input 0 failed");
-        session
             .add_local_input(PlayerHandle::new(1), 2u8)
             .expect("Input 1 failed");
+        session
+            .add_local_input(PlayerHandle::new(0), 1u8)
+            .expect("Input 0 failed");
         let requests = session.advance_frame().expect("Advance failed");
-        assert!(!requests.is_empty());
+        let inputs = requests
+            .iter()
+            .find_map(|request| match request {
+                FortressRequest::AdvanceFrame { inputs } => Some(inputs),
+                FortressRequest::SaveGameState { .. } | FortressRequest::LoadGameState { .. } => {
+                    None
+                },
+            })
+            .expect("advance request must exist");
+        assert_eq!(
+            inputs
+                .iter()
+                .map(|(input, _status)| *input)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
     }
 
     // ==========================================

--- a/tests/allocation_contract.rs
+++ b/tests/allocation_contract.rs
@@ -12,7 +12,10 @@ use std::hint::black_box;
 use std::net::SocketAddr;
 
 use fortress_rollback::network::codec;
-use fortress_rollback::{Config, PlayerHandle, SessionBuilder, SyncTestSession};
+use fortress_rollback::{
+    Config, DesyncDetection, FortressRequest, Message, NonBlockingSocket, P2PSession, PlayerHandle,
+    SessionBuilder, SyncTestSession,
+};
 use stats_alloc::{Region, Stats, StatsAlloc, INSTRUMENTED_SYSTEM};
 
 #[global_allocator]
@@ -24,6 +27,16 @@ impl Config for AllocationConfig {
     type Input = u32;
     type State = u32;
     type Address = SocketAddr;
+}
+
+struct AllocationSocket;
+
+impl NonBlockingSocket<SocketAddr> for AllocationSocket {
+    fn send_to(&mut self, _msg: &Message, _addr: &SocketAddr) {}
+
+    fn receive_all_messages(&mut self) -> Vec<(SocketAddr, Message)> {
+        Vec::new()
+    }
 }
 
 fn measure<T>(operation: impl FnOnce() -> T) -> (T, Stats) {
@@ -103,6 +116,50 @@ fn warmed_synctest_frame_stats(num_players: usize) -> Stats {
                 .expect("add measured input");
         }
         black_box(session.advance_frame().expect("advance measured frame"))
+    });
+    black_box(requests);
+    stats
+}
+
+fn warmed_all_local_p2p_frame_stats(num_players: usize) -> Stats {
+    let mut builder = SessionBuilder::new()
+        .with_num_players(num_players)
+        .expect("configure allocation-contract P2P player count")
+        .with_desync_detection_mode(DesyncDetection::Off);
+    for player in 0..num_players {
+        builder = builder
+            .add_local_player(player)
+            .expect("add allocation-contract P2P local player");
+    }
+    let mut session: P2PSession<AllocationConfig> = builder
+        .start_p2p_session(AllocationSocket)
+        .expect("construct allocation-contract P2P session");
+
+    for player in 0..num_players {
+        session
+            .add_local_input(
+                PlayerHandle::new(player),
+                u32::try_from(player).expect("allocation-contract handle fits u32"),
+            )
+            .expect("add P2P warm-up input");
+    }
+    let warm_up_requests = session.advance_frame().expect("advance P2P warm-up frame");
+    for request in warm_up_requests {
+        if let FortressRequest::SaveGameState { cell, frame } = request {
+            cell.save(frame, Some(0), Some(0));
+        }
+    }
+
+    let (requests, stats) = measure(|| {
+        for player in 0..num_players {
+            session
+                .add_local_input(
+                    PlayerHandle::new(player),
+                    u32::try_from(player).expect("allocation-contract handle fits u32"),
+                )
+                .expect("add measured P2P input");
+        }
+        black_box(session.advance_frame().expect("advance measured P2P frame"))
     });
     black_box(requests);
     stats
@@ -203,6 +260,23 @@ fn warmed_hot_paths_obey_allocation_contracts() {
         }
         assert_allocation_ceiling(
             &format!("warmed {players}-player sync-test frame"),
+            first,
+            operation_ceiling,
+            byte_ceiling,
+        );
+    }
+
+    for (players, operation_ceiling, byte_ceiling) in [(2, 0, 0), (4, 0, 0), (16, 1, 128)] {
+        let first = warmed_all_local_p2p_frame_stats(players);
+        for repetition in 1..3 {
+            assert_eq!(
+                warmed_all_local_p2p_frame_stats(players),
+                first,
+                "warmed {players}-player all-local P2P frame repetition {repetition}"
+            );
+        }
+        assert_allocation_ceiling(
+            &format!("warmed {players}-player all-local P2P frame"),
             first,
             operation_ceiling,
             byte_ceiling,


### PR DESCRIPTION
## What

- replace per-frame `P2PSession` local-input `BTreeMap` staging with fallibly preallocated player-indexed slots
- retain slot storage across frames while preserving sparse handles, overwrite, retry, input-drop, and deterministic ordering semantics
- let protocol serialization consume map-backed or slot-backed inputs without changing canonical handle order or encoded bytes
- extend the deterministic allocation ledger to the isolated warmed all-local P2P staging path

## Why

Issue #264's allocation ledger identified the next candidate but required measurement before optimization. The zero-allocation target failed with a stable signature:

- N=2: one allocation / 192 bytes
- N=4: one allocation / 192 bytes
- N=16: four allocations / 800 bytes

The transient cost matched the removed sync-test staging map: N=16 contained 672 bytes of map nodes plus the returned `InputVec`'s 128-byte spill.

## Result

With desync detection disabled to isolate staging, the warm-up save request fulfilled, and application callbacks outside the measured region:

- N=2: zero allocations / zero bytes
- N=4: zero allocations / zero bytes
- N=16: one allocation / 128 bytes (the returned `InputVec` spill)

Network encoding and checksum history retain their separate bounded allocations; this PR does not claim whole networked frames are allocation-free.

## Semantics and safety

Regression coverage pins:

- sparse/nonzero local player handles
- reverse submission preserving ascending player order
- observable duplicate overwrite
- missing-input failure followed by retry with only the missing slot
- `Frame::NULL` local-input rejection suppressing the whole endpoint send
- map-backed and slot-backed input sources producing identical frame metadata and bytes
- fallible construction-time reservation with structured errors

No public signature, config default, or wire layout changes.

## Validation

- allocation target went red with the exact baseline above before production changes
- ten consecutive debug allocation runs
- release-mode allocation contract
- default Nextest: 2,886 passed, 71 skipped
- hot-join Nextest: 3,142 passed, 72 skipped
- `cargo clippy --workspace --all-targets --features tokio,json`
- warning-denied workspace docs
- changelog/version checks, 1,393 links, 286 release-automation tests, spelling, allocation-bound hook, and full agent preflight
- independent adversarial review: zero remaining findings

## Review readiness

- Build/tests: PASS
- Zero-panic: PASS
- Determinism: PASS
- Agent preflight: PASS
- Error handling: PASS
- Tests breadth: PASS
- Design log reviewed: N/A (private staging representation)
- CHANGELOG reviewed: YES

Progresses #264.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal staging and protocol abstraction only; no public API or wire layout changes. Risk is mainly behavioral parity (sparse handles, drop suppression, encoding order), which the expanded tests target.
> 
> **Overview**
> **P2P local-input staging** moves from a per-frame `BTreeMap` to constructor-reserved `Vec<Option<PlayerInput>>` slots indexed by player handle. Slots are cleared with `None` after each advance instead of `clear()`, so sparse handles, overwrite, and missing-input retry keep working without rebuilding map nodes each frame.
> 
> **Wire encoding** gains an internal `InputSource` trait so `InputBytes::try_from_inputs` and `send_input` accept either the old map or the new slot slice; ascending handle order and encoded bytes stay identical.
> 
> **Allocation contract** adds warmed all-local `P2PSession` frame measurements (desync off, warm-up save fulfilled): 2–4 players stay heap-free on staging; 16 players keep only the returned `InputVec` spill. Network encode and checksum history are outside that ledger.
> 
> Regression tests cover sparse local handles, dropped-input send suppression, map vs slot encoding parity, and overwrite/advance behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a01679fdb10aeaad5ad03f748ba8dc30ad25e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->