### PR TITLE
Eliminate empty graceful-drop poll reservations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sixteen players retains only the returned `InputVec` spill. Network encoding and checksum history
   keep their separate bounded allocations; application state callbacks are outside this measurement.
 
+### Fixed
+
+- **Pre-existing:** ordinary networked `P2PSession` frame polling no longer reserves space for 256
+  graceful-drop control records per remote when every bounded endpoint mailbox is empty. In the
+  deterministic one-endpoint allocation contract, warmed N=2, N=4, and N=16 frame/send measurements
+  fall from 28.7–29.1 KiB to 45, 57, and 378 allocated bytes while active graceful-drop state machines
+  continue to advance on empty polls.
+
 ## [0.11.0] - 2026-07-18
 
 ### Added

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -3254,6 +3254,13 @@ impl<T: Config> UdpProtocol<T> {
         self.queue_message(message.into_body());
     }
 
+    /// Returns the number of coordinated graceful-drop messages currently
+    /// staged in the bounded endpoint mailbox.
+    #[must_use]
+    pub(crate) fn received_drop_message_count(&self) -> usize {
+        self.received_drop_messages.len()
+    }
+
     /// Drains every coordinated graceful-drop control message staged since the
     /// previous drain. The endpoint mailbox itself is bounded by
     /// [`MAX_RECEIVED_DROP_MESSAGES`].

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -2597,13 +2597,20 @@ impl<T: Config> P2PSession<T> {
     }
 
     fn poll_coordinated_drop(&mut self) {
-        let capacity = self
+        let Some(received_count) = self
             .player_reg
             .remotes
-            .len()
-            .saturating_mul(crate::network::MAX_RECEIVE_MESSAGES_PER_POLL);
+            .values()
+            .try_fold(0_usize, |count, endpoint| {
+                count.checked_add(endpoint.received_drop_message_count())
+            })
+        else {
+            self.coordinated_drop_fail_closed(DropAbortReason::ResourceLimit, true);
+            return;
+        };
+
         let mut received = Vec::new();
-        if received.try_reserve_exact(capacity).is_err() {
+        if received_count > 0 && received.try_reserve_exact(received_count).is_err() {
             self.coordinated_drop_fail_closed(DropAbortReason::ResourceLimit, true);
             return;
         }
@@ -12859,6 +12866,49 @@ mod tests {
             ),
             0,
             "the certificate generation uses the same documented u16 wrapping semantics"
+        );
+    }
+
+    #[test]
+    fn empty_drop_mailboxes_still_drive_queued_operation() {
+        let mut session = create_two_player_session();
+        let remote = PlayerHandle::new(1);
+        let remote_addr = test_addr(8080);
+        session.state = SessionState::Running;
+        session
+            .player_reg
+            .remotes
+            .get_mut(&remote_addr)
+            .expect("remote endpoint exists")
+            .force_running_for_tests();
+        assert_eq!(
+            session
+                .player_reg
+                .remotes
+                .values()
+                .map(UdpProtocol::received_drop_message_count)
+                .sum::<usize>(),
+            0,
+            "the regression requires empty bounded mailboxes"
+        );
+        assert!(session.coordinated_drop.queued.insert(remote));
+
+        session.poll_coordinated_drop();
+
+        assert!(
+            !session.coordinated_drop.queued.contains(&remote),
+            "the empty-mailbox poll must consume the queued operation"
+        );
+        assert!(
+            session.coordinated_drop.committed.contains_key(&remote),
+            "the single-survivor certificate must commit without inbound control messages"
+        );
+        assert!(
+            session
+                .local_connect_status
+                .get(remote.as_usize())
+                .is_some_and(|status| status.disconnected),
+            "the committed operation must freeze the remote slot"
         );
     }
 

--- a/tests/allocation_contract.rs
+++ b/tests/allocation_contract.rs
@@ -4,17 +4,24 @@
 //! The process-local global allocator therefore cannot observe allocations from
 //! another test, and every measured operation excludes construction and warm-up.
 
-#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used
+)]
 #![forbid(unsafe_code)]
 
 use std::alloc::System;
 use std::hint::black_box;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
 
 use fortress_rollback::network::codec;
 use fortress_rollback::{
-    Config, DesyncDetection, FortressRequest, Message, NonBlockingSocket, P2PSession, PlayerHandle,
-    SessionBuilder, SyncTestSession,
+    Config, DesyncDetection, FortressRequest, Message, MessageKind, NonBlockingSocket, P2PSession,
+    PlayerHandle, SessionBuilder, SessionState, SyncTestSession,
 };
 use stats_alloc::{Region, Stats, StatsAlloc, INSTRUMENTED_SYSTEM};
 
@@ -37,6 +44,70 @@ impl NonBlockingSocket<SocketAddr> for AllocationSocket {
     fn receive_all_messages(&mut self) -> Vec<(SocketAddr, Message)> {
         Vec::new()
     }
+}
+
+struct SwitchableSocket {
+    local_addr: SocketAddr,
+    peer_addr: SocketAddr,
+    sender: mpsc::Sender<(SocketAddr, Message)>,
+    receiver: Mutex<mpsc::Receiver<(SocketAddr, Message)>>,
+    drop_outbound: Arc<AtomicBool>,
+    sends: Arc<AtomicUsize>,
+}
+
+impl NonBlockingSocket<SocketAddr> for SwitchableSocket {
+    fn send_to(&mut self, msg: &Message, addr: &SocketAddr) {
+        if *addr != self.peer_addr {
+            return;
+        }
+        self.sends.fetch_add(1, Ordering::Relaxed);
+        if !self.drop_outbound.load(Ordering::Relaxed) {
+            let _result = self.sender.send((self.local_addr, msg.clone()));
+        }
+    }
+
+    fn receive_all_messages(&mut self) -> Vec<(SocketAddr, Message)> {
+        self.receiver
+            .lock()
+            .expect("allocation socket mutex poisoned")
+            .try_iter()
+            .collect()
+    }
+}
+
+fn switchable_socket_pair() -> (
+    SwitchableSocket,
+    SwitchableSocket,
+    Arc<AtomicBool>,
+    Arc<AtomicUsize>,
+) {
+    let addr_a = SocketAddr::from(([127, 0, 0, 1], 31_001));
+    let addr_b = SocketAddr::from(([127, 0, 0, 1], 31_002));
+    let (to_a, from_b) = mpsc::channel();
+    let (to_b, from_a) = mpsc::channel();
+    let drop_a = Arc::new(AtomicBool::new(false));
+    let sends_a = Arc::new(AtomicUsize::new(0));
+
+    (
+        SwitchableSocket {
+            local_addr: addr_a,
+            peer_addr: addr_b,
+            sender: to_b,
+            receiver: Mutex::new(from_b),
+            drop_outbound: Arc::clone(&drop_a),
+            sends: Arc::clone(&sends_a),
+        },
+        SwitchableSocket {
+            local_addr: addr_b,
+            peer_addr: addr_a,
+            sender: to_a,
+            receiver: Mutex::new(from_a),
+            drop_outbound: Arc::new(AtomicBool::new(false)),
+            sends: Arc::new(AtomicUsize::new(0)),
+        },
+        drop_a,
+        sends_a,
+    )
 }
 
 fn measure<T>(operation: impl FnOnce() -> T) -> (T, Stats) {
@@ -165,6 +236,166 @@ fn warmed_all_local_p2p_frame_stats(num_players: usize) -> Stats {
     stats
 }
 
+fn fulfill_save_requests(requests: fortress_rollback::RequestVec<AllocationConfig>) {
+    for request in requests {
+        match request {
+            FortressRequest::SaveGameState { cell, frame } => {
+                cell.save(frame, Some(0), Some(0));
+            },
+            FortressRequest::AdvanceFrame { .. } => {},
+            FortressRequest::LoadGameState { frame, .. } => {
+                panic!("allocation fixture unexpectedly requested rollback to {frame}");
+            },
+        }
+    }
+}
+
+fn warmed_networked_p2p_send_stats(num_players: usize) -> Stats {
+    let (socket_a, socket_b, drop_a, sends_a) = switchable_socket_pair();
+    let addr_a = socket_a.local_addr;
+    let addr_b = socket_b.local_addr;
+    let remote_handle = PlayerHandle::new(num_players.saturating_sub(1));
+
+    let mut builder_a = SessionBuilder::new()
+        .with_num_players(num_players)
+        .expect("configure networked allocation-contract player count")
+        .with_desync_detection_mode(DesyncDetection::Off);
+    let mut builder_b = SessionBuilder::new()
+        .with_num_players(num_players)
+        .expect("configure networked allocation-contract player count")
+        .with_desync_detection_mode(DesyncDetection::Off);
+    for player in 0..num_players {
+        if player + 1 == num_players {
+            builder_a = builder_a
+                .add_remote_player(player, addr_b)
+                .expect("add allocation-contract remote player to A");
+            builder_b = builder_b
+                .add_local_player(player)
+                .expect("add allocation-contract local player to B");
+        } else {
+            builder_a = builder_a
+                .add_local_player(player)
+                .expect("add allocation-contract local player to A");
+            builder_b = builder_b
+                .add_remote_player(player, addr_a)
+                .expect("add allocation-contract remote player to B");
+        }
+    }
+    let mut session_a: P2PSession<AllocationConfig> = builder_a
+        .start_p2p_session(socket_a)
+        .expect("construct networked allocation-contract session A");
+    let mut session_b: P2PSession<AllocationConfig> = builder_b
+        .start_p2p_session(socket_b)
+        .expect("construct networked allocation-contract session B");
+
+    for _ in 0..64 {
+        session_a.poll_remote_clients();
+        session_b.poll_remote_clients();
+        if session_a.current_state() == SessionState::Running
+            && session_b.current_state() == SessionState::Running
+        {
+            break;
+        }
+    }
+    assert_eq!(session_a.current_state(), SessionState::Running);
+    assert_eq!(session_b.current_state(), SessionState::Running);
+
+    for warm_up_frame in 0..2 {
+        for player in 0..num_players.saturating_sub(1) {
+            session_a
+                .add_local_input(PlayerHandle::new(player), 0)
+                .expect("add networked warm-up input to A");
+        }
+        session_b
+            .add_local_input(remote_handle, 0)
+            .expect("add networked warm-up input to B");
+        fulfill_save_requests(
+            session_a
+                .advance_frame()
+                .expect("advance networked warm-up frame on A"),
+        );
+        fulfill_save_requests(
+            session_b
+                .advance_frame()
+                .expect("advance networked warm-up frame on B"),
+        );
+        for _ in 0..4 {
+            session_a.poll_remote_clients();
+            session_b.poll_remote_clients();
+        }
+        assert_eq!(
+            session_a
+                .peer_metrics(remote_handle)
+                .expect("read A peer metrics")
+                .pending_output_len,
+            0,
+            "warm-up input {warm_up_frame} must be acknowledged before measuring"
+        );
+    }
+
+    drop_a.store(true, Ordering::Relaxed);
+    let sends_before = sends_a.load(Ordering::Relaxed);
+    let metrics_before = session_a
+        .peer_metrics(remote_handle)
+        .expect("read A peer metrics before measurement");
+    let (requests, stats) = measure(|| {
+        for player in 0..num_players.saturating_sub(1) {
+            session_a
+                .add_local_input(PlayerHandle::new(player), 0)
+                .expect("add measured networked input to A");
+        }
+        black_box(
+            session_a
+                .advance_frame()
+                .expect("advance measured networked frame on A"),
+        )
+    });
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| matches!(request, FortressRequest::AdvanceFrame { .. }))
+            .count(),
+        1,
+        "the measured frame must request exactly one application advance"
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| !matches!(request, FortressRequest::LoadGameState { .. })),
+        "the measured steady-state frame must not include rollback work"
+    );
+    black_box(requests);
+    assert_eq!(
+        sends_a.load(Ordering::Relaxed),
+        sends_before + 1,
+        "measured frame must exercise one endpoint send"
+    );
+    let metrics_after = session_a
+        .peer_metrics(remote_handle)
+        .expect("read A peer metrics after measurement");
+    assert_eq!(
+        metrics_after.messages_sent_by_kind.get(MessageKind::Input),
+        metrics_before.messages_sent_by_kind.get(MessageKind::Input) + 1,
+        "the measured endpoint message must be an Input packet"
+    );
+    assert_eq!(
+        metrics_after.input_bytes_pre_compression,
+        metrics_before.input_bytes_pre_compression
+            + u64::try_from(num_players.saturating_sub(1) * size_of::<u32>())
+                .expect("bounded input bytes fit u64"),
+        "the measured Input packet must include every local player's bytes"
+    );
+    assert!(
+        metrics_after.input_bytes_post_compression > metrics_before.input_bytes_post_compression,
+        "the measured Input packet must exercise delta/RLE compression"
+    );
+    assert_eq!(
+        metrics_after.pending_output_len, 1,
+        "the non-allocating sink must leave exactly one bounded frame awaiting acknowledgement"
+    );
+    stats
+}
+
 /// Allocation contracts are measured together so the instrumented allocator
 /// cannot observe concurrently running tests in this integration-test process.
 #[test]
@@ -277,6 +508,31 @@ fn warmed_hot_paths_obey_allocation_contracts() {
         }
         assert_allocation_ceiling(
             &format!("warmed {players}-player all-local P2P frame"),
+            first,
+            operation_ceiling,
+            byte_ceiling,
+        );
+    }
+
+    // This real synchronized one-endpoint path includes Fortress's internal
+    // receive/control poll plus input serialization, delta/RLE compression,
+    // status gossip, and request construction. The switchable socket counts
+    // submission but deliberately excludes adapter buffering and cloning. Its
+    // allocation contract is bounded rather than zero: one input buffer stays
+    // retained until acknowledgment, and compression/status temporaries are
+    // released after submission. The byte ceilings also prevent the empty
+    // graceful-drop poll from restoring its former 28 KiB reservation.
+    for (players, operation_ceiling, byte_ceiling) in [(2, 4, 128), (4, 4, 128), (16, 5, 512)] {
+        let first = warmed_networked_p2p_send_stats(players);
+        for repetition in 1..3 {
+            assert_eq!(
+                warmed_networked_p2p_send_stats(players),
+                first,
+                "warmed {players}-player networked P2P send repetition {repetition}"
+            );
+        }
+        assert_allocation_ceiling(
+            &format!("warmed {players}-player networked P2P send"),
             first,
             operation_ceiling,
             byte_ceiling,


### PR DESCRIPTION
## Summary

- add a synchronized one-endpoint P2P allocation contract at N=2, N=4, and N=16
- stop ordinary P2P polling from reserving 256 graceful-drop records per remote when bounded endpoint mailboxes are empty
- preserve queued and active coordinated-drop progress on empty polls, with a direct regression test
- document the measured improvement and close the broad benchmark/allocation research issue

## Root cause

`P2PSession::poll_coordinated_drop` reserved `remote_count * MAX_RECEIVE_MESSAGES_PER_POLL` entries on every poll. A warmed frame therefore allocated 28,672 temporary bytes even when every endpoint's bounded graceful-drop mailbox was empty.

The poll now checked-sums the exact staged message counts and reserves only that amount. Arithmetic overflow and allocation failure still fail closed with `ResourceLimit`; an empty count does not skip the lifecycle driver.

## Measured impact

| Players | Before | After | Contract |
| ---: | ---: | ---: | ---: |
| 2 | 5 ops / 28,717 B | 4 ops / 45 B | 4 ops / 128 B |
| 4 | 5 ops / 28,729 B | 4 ops / 57 B | 4 ops / 128 B |
| 16 | 6 ops / 29,050 B | 5 ops / 378 B | 5 ops / 512 B |

The fixture proves synchronization and acknowledged warm-up, exactly one `Input` submission, all local-player input bytes, delta/RLE compression, one pending bounded frame, one application advance, and no rollback request.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features tokio,json`
- default Nextest: 2,887 passed, 71 skipped
- hot-join Nextest: 3,143 passed, 72 skipped
- warning-denied workspace rustdoc
- doctests: 160 passed, 50 ignored
- allocation contract: 10 complete debug repetitions plus release
- repository agent preflight, changelog check, version-sync check, Markdown lint, and link check
- three-round adversarial review; findings were corrected in the fixture and empty-mailbox lifecycle regression

Closes #264.

## Follow-up disposition

#242 remains externally gated by upstream Signal Fish browser E2E work. Dependency research remains tracked separately by #273 (bincode replacement) and #274 (macroquad example-stack security/replacement); this PR changes no dependency or wire format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized polling/allocation change with regression and allocation-contract coverage; coordinated-drop fail-closed paths on overflow remain unchanged.
> 
> **Overview**
> **`poll_coordinated_drop`** no longer reserves `remote_count × 256` graceful-drop slots on every frame poll when endpoint mailboxes are empty. It sums each remote’s staged drop count via new **`UdpProtocol::received_drop_message_count`**, reserves only that exact capacity (skipping reservation when zero), and still fails closed on overflow or allocation failure.
> 
> A unit test confirms **empty mailboxes still advance** queued coordinated-drop work (single-survivor commit without inbound control messages). The **allocation contract** adds a warmed two-session networked send fixture at N=2/4/16 with byte ceilings (45–378 B vs ~29 KiB before), documenting the fix in **CHANGELOG**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086bb2e1f6360c6fc7a56b3bccb64a55e26bfa54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->