### PR TITLE
Make dropped-input Miri regression deterministic

### DIFF
--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -13652,12 +13652,24 @@ mod tests {
     }
 
     #[test]
-    fn advance_frame_dropped_local_input_suppresses_endpoint_send() {
+    fn advance_frame_dropped_local_input_suppresses_input_message() {
         let sent = Arc::new(std::sync::Mutex::new(Vec::new()));
         let socket = RecordingSocket {
             sent: Arc::clone(&sent),
         };
+        let clock_now = Arc::new(std::sync::Mutex::new(web_time::Instant::now()));
+        let protocol_clock = Arc::clone(&clock_now);
+        let protocol_config = ProtocolConfig {
+            clock: Some(Arc::new(move || {
+                *protocol_clock.lock().expect("protocol clock lock")
+            })),
+            protocol_rng_seed: Some(0),
+            ..ProtocolConfig::default()
+        };
+        let elapsed_report_interval =
+            protocol_config.quality_report_interval + web_time::Duration::from_millis(1);
         let mut session = SessionBuilder::<TestConfig>::new()
+            .with_protocol_config(protocol_config)
             .with_num_players(2)
             .unwrap()
             .add_local_player(0)
@@ -13681,14 +13693,22 @@ mod tests {
             .and_then(Option::as_mut)
             .expect("local input slot must exist")
             .frame = Frame::new(1);
+        *clock_now.lock().expect("protocol clock lock") += elapsed_report_interval;
 
         session
             .advance_frame()
             .expect("dropped local input must fail closed without a send");
 
+        let sent = sent.lock().expect("recording socket lock");
         assert!(
-            sent.lock().expect("recording socket lock").is_empty(),
-            "Frame::NULL local input must suppress the whole endpoint send"
+            sent.iter()
+                .any(|message| matches!(message.body, MessageBody::QualityReport(_))),
+            "the regression requires legitimate elapsed-timer traffic"
+        );
+        assert!(
+            sent.iter()
+                .all(|message| !matches!(message.body, MessageBody::Input(_))),
+            "Frame::NULL local input must suppress Input messages; observed {sent:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- fix the timing-dependent dropped-input regression that broke macOS Miri on `main`
- inject a deterministic protocol clock and deliberately cross the quality-report interval
- assert the real contract—no `Input` message—while proving legitimate timer traffic may coexist

Closes #278.

## Root cause

The regression added in #275 used the platform monotonic clock and recorded every packet sent by the endpoint. It then asserted that the entire socket remained empty across `P2PSession::advance_frame()`.

That assertion was broader than the behavior under test. `advance_frame()` first calls `poll_remote_clients()`; a running endpoint may legitimately emit interval-gated control traffic there. Slow macOS Miri execution crossed the default 200 ms quality-report interval, so the recorder contained a valid `QualityReport` even though the dropped `Frame::NULL` local input correctly emitted no `Input` packet.

This reached `main` because PR #275's exact-head macOS Miri job did run the test and passed. The wall-clock-sensitive oracle changed outcome with runner/interpreter timing rather than code behavior.

## Fix

The test now:

1. injects a controlled `ProtocolConfig::clock`;
2. advances it just beyond the configured quality-report interval;
3. proves a legitimate `QualityReport` is present; and
4. verifies that every recorded packet is non-`Input`.

This makes the former false failure deterministic and keeps the assertion mutation-sensitive to the production input-suppression guard.

No production code, public API, wire format, runtime behavior, or dependency changes are included.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features tokio,json -- -D warnings`
- default Nextest: 2,887 passed; 71 skipped
- hot-join Nextest: 3,143 passed; 72 skipped
- pinned `nightly-2026-02-10` Miri seed 0 targeted regression
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- Rust 1.86 all-target check
- agent preflight
- dependency dry-runs for all four Cargo workspaces: zero compatible updates

## Review Readiness

- Build/tests: PASS
- Zero-panic: PASS (test-only change)
- Determinism: PASS (wall clock replaced with injected time)
- Agent preflight: PASS
- Error handling: N/A (no production change)
- Tests breadth: PASS (ordinary + exact pinned Miri + full default/hot-join matrices)
- Design log reviewed: N/A
- CHANGELOG reviewed: N/A (test-oracle repair only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test oracle and naming only; no runtime or public API changes.
> 
> **Overview**
> Repairs the **dropped local input** P2P session test so it no longer flakes on slow macOS Miri runs.
> 
> The test now wires a **deterministic `ProtocolConfig::clock`**, bumps time past the quality-report interval, and checks the real contract: **`Input` messages stay suppressed** when local input is dropped to `Frame::NULL`, while a legitimate **`QualityReport`** may still be sent during `advance_frame()` polling. The old assertion that the recording socket was completely empty was too strict and failed when interval-gated control traffic crossed the default 200 ms window.
> 
> **Test-only** change; no production, API, or wire-format updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dbafec579173522a78d81c1f310852649459e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->