### PR TITLE
ci: repair post-merge green gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -144,7 +144,9 @@ updates:
 
   # Development-container features
   - package-ecosystem: "devcontainers"
-    directory: "/.devcontainer"
+    # The devcontainers updater discovers .devcontainer/devcontainer.json
+    # relative to the configured directory, so it must start at repository root.
+    directory: "/"
     schedule:
       interval: "weekly"
     assignees:

--- a/progress/session-162-post-merge-ci-green.md
+++ b/progress/session-162-post-merge-ci-green.md
@@ -1,0 +1,56 @@
+# Session 162: Post-Merge CI Green
+
+## Objective
+
+Audit the completed hardening work against live GitHub state, repair every post-merge failure, and
+return the repository to a fully green reviewed pull request and main branch.
+
+## Incident evidence
+
+- PR #288 merged at `aaaaee4` with a green exact-head matrix and all review threads resolved.
+- The subsequent `CI - Documentation` push run failed in
+  `test_absent_tag_accepts_previous_checkpoint_older_than_search_bound`: Git 2.54 could not
+  traverse a missing parent while pushing the fixture's rewritten synthetic `main`.
+- The first `devcontainers` Dependabot update failed before dependency discovery because
+  `directory: "/.devcontainer"` made the updater look for a nested devcontainer definition.
+- Live GitHub searches reported zero open issues and zero open pull requests before this repair.
+- All four Cargo workspaces reported zero compatible updates; npm reported none. The two newer
+  Rust major releases remain explicitly excluded by the Rust 1.86 MSRV contract.
+
+## Implementation
+
+- Run the `devcontainers` updater from repository root while retaining the devcontainer Docker
+  updater's `/.devcontainer` scope.
+- Strengthen the static-analysis regression to require exactly one root-scoped devcontainer
+  feature updater and one directory-scoped devcontainer Docker updater.
+- Recreate the prepared release tree on the long first-parent history without publishing rewritten
+  `main`. The resolver still fetches and verifies the real previous-release tag from the fixture
+  remote, preserving the release trust boundary under test.
+- Record the correction and its remaining hosted gates in `PLAN.md`.
+
+## Adversarial review
+
+- The Dependabot regression rejects a duplicate or incorrectly scoped `devcontainers` entry.
+- The release fixture still proves the previous annotated tag is older than the bounded candidate
+  search and remains a first-parent ancestor of the locally trusted dispatch SHA.
+- Removing the synthetic branch push cannot weaken production remote validation because
+  `release_checkpoint.resolve` never reads remote `main`; only release tag identity is remote.
+- No production Rust, public API, wire, deterministic simulation, or user-observable behavior is
+  touched. No changelog entry is required.
+
+## Local verification
+
+- Focused red-green Dependabot contract: failed on zero root-scoped entries, then passed.
+- Affected suites: 53 passed.
+- Formerly flaky release-checkpoint case: 10 consecutive passes with stable runtime.
+- Complete Python suite: 2,063 passed.
+- Strict workspace/all-target Clippy with `tokio,json`: passed.
+- Default Nextest matrix: 2,901 passed, 71 skipped.
+- `actionlint`: passed.
+- `python3 scripts/ci/agent-preflight.py --auto-fix`: passed all gates.
+- `git diff --check`: passed.
+
+## Publication
+
+- Pending commit, push, pull request, exact-head CI, reviewer convergence, merge, and post-merge
+  main verification.

--- a/progress/session-162-post-merge-ci-green.md
+++ b/progress/session-162-post-merge-ci-green.md
@@ -52,5 +52,8 @@ return the repository to a fully green reviewed pull request and main branch.
 
 ## Publication
 
-- Pending commit, push, pull request, exact-head CI, reviewer convergence, merge, and post-merge
-  main verification.
+- PR #291 is open, ready, and cleanly mergeable. Its implementation head `8f8511a` passed all
+  seven path-relevant workflow groups, including the previously failing Documentation lane and
+  CodeQL. Cursor's exact-head summary found no issue, Copilot returned only its terminal reviewer
+  quota response, and no review threads exist.
+- Any progress-only closeout head must repeat the same required hosted gates before handoff.

--- a/scripts/tests/test_ci_static_analysis.py
+++ b/scripts/tests/test_ci_static_analysis.py
@@ -465,16 +465,30 @@ def test_codeql_jq_predicate(
 
 def test_dependabot_tracks_devcontainer_images_and_features() -> None:
     config = _load_workflow(DEPENDABOT_CONFIG)
-    entries = [
+    docker_entries = [
         update
         for update in config["updates"]
-        if update.get("directory") == "/.devcontainer"
+        if update.get("package-ecosystem") == "docker"
+        and update.get("directory") == "/.devcontainer"
     ]
-    assert {entry["package-ecosystem"] for entry in entries} == {
-        "devcontainers",
-        "docker",
-    }
-    assert all(entry["schedule"]["interval"] == "weekly" for entry in entries)
+    feature_entries = [
+        update
+        for update in config["updates"]
+        if update.get("package-ecosystem") == "devcontainers"
+        and update.get("directory") == "/"
+    ]
+    all_feature_entries = [
+        update
+        for update in config["updates"]
+        if update.get("package-ecosystem") == "devcontainers"
+    ]
+    assert len(docker_entries) == 1
+    assert len(feature_entries) == 1
+    assert all_feature_entries == feature_entries
+    assert all(
+        entry["schedule"]["interval"] == "weekly"
+        for entry in [*docker_entries, *feature_entries]
+    )
 
 
 def test_ruff_subprocess_exceptions_are_scoped() -> None:

--- a/scripts/tests/test_release_checkpoint.py
+++ b/scripts/tests/test_release_checkpoint.py
@@ -247,16 +247,12 @@ def test_absent_tag_accepts_previous_checkpoint_older_than_search_bound(
             "-m",
             f"intervening main commit {index}",
         )
-    _git(trusted, "cherry-pick", prepared)
-    # Publish the deliberately rewritten history to an empty remote. Replacing
-    # the populated fixture remote makes pack generation depend on its
-    # advertised old refs and has produced missing-object failures across Git
-    # versions, even with --no-thin.
-    replacement_remote = tmp_path / "replacement-origin.git"
-    _git(tmp_path, "init", "--bare", str(replacement_remote))
-    _git(trusted, "remote", "set-url", "origin", str(replacement_remote))
-    _git(trusted, "push", "--set-upstream", "origin", "main")
-    _git(trusted, "push", "origin", "refs/tags/v1.2.2")
+    # Recreate the prepared tree on the long first-parent history without
+    # publishing rewritten main. The resolver trusts the checked-out dispatch
+    # SHA and consults the remote only for immutable release tags, so pushing
+    # this synthetic history tested Git packing rather than checkpoint logic.
+    _git(trusted, "checkout", "refs/test/prepared-release", "--", ".")
+    _git(trusted, "commit", "-m", "prepare release 1.2.3 after long history")
 
     checkpoint = _resolve(trusted, tmp_path)
 


### PR DESCRIPTION
## Summary

- run the devcontainer-feature Dependabot updater from repository root so it discovers `.devcontainer/devcontainer.json`
- make the updater-scope contract distinguish root-scoped devcontainer features from directory-scoped devcontainer Docker images
- remove an unrelated rewritten-branch push from the long-history release-checkpoint fixture, eliminating its Git 2.54 missing-parent failure without weakening remote release-tag validation
- record the post-merge audit in the Session 162 progress log

## Root causes

The newly added `devcontainers` updater used `directory: "/.devcontainer"`. That ecosystem resolves `.devcontainer/devcontainer.json` relative to its configured directory, so the hosted updater searched one directory too deep and failed before dependency discovery.

The documentation push lane's release-checkpoint fixture rewrote synthetic `main` and then pushed it solely to set up a local candidate-history test. Git 2.54 intermittently failed while packing that synthetic history. Production `release_checkpoint.resolve` trusts the checked-out dispatch SHA locally and consults the remote only for immutable release tags, so publishing synthetic `main` was outside the behavior under test.

## Validation

- focused Dependabot regression went red on the old directory and green after the fix
- affected Python modules: 53 passed
- formerly flaky checkpoint case: 10 consecutive passes with stable runtime
- complete Python suite: 2,063 passed
- strict workspace/all-target Clippy with `tokio,json`: passed
- default Nextest matrix: 2,901 passed, 71 skipped
- Ruff 0.16.2: passed
- actionlint: passed
- agent preflight: all gates passed
- git diff/check and pre-commit hooks: passed

## Review readiness

- Build/tests: PASS
- Zero-panic: PASS (no production Rust changes)
- Determinism: PASS (no simulation changes)
- Agent preflight: PASS
- Error handling: N/A (test/config-only)
- Tests breadth: PASS
- Design log reviewed: N/A
- CHANGELOG reviewed: N/A (no public or user-observable runtime change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Dependabot config, CI regression tests, and a release-checkpoint fixture change; no production Rust, APIs, or release resolver behavior.
> 
> **Overview**
> Repairs two post-merge CI failures with **config and test-only** changes.
> 
> **Dependabot:** The `devcontainers` ecosystem entry now uses `directory: "/"` (with a comment explaining discovery of `.devcontainer/devcontainer.json` relative to that path). Docker image updates stay scoped to `/.devcontainer`. The static-analysis test now requires exactly one root-scoped `devcontainers` updater and one `/.devcontainer` Docker updater, and rejects duplicate or mis-scoped feature entries.
> 
> **Documentation lane:** `test_absent_tag_accepts_previous_checkpoint_older_than_search_bound` no longer rewrites and pushes synthetic `main` to a bare remote (which triggered Git 2.54 missing-parent pack failures). It recreates the prepared release tree on the long first-parent history via checkout and commit while still resolving the previous release tag from the fixture remote—the same trust model as production (`trusted_sha` local, tags remote).
> 
> A Session 162 progress note documents the incident and verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f00a5da52173d8b4dd8e00643f6f3c2d12524289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->