### PR TITLE
test(soak): replace flaky RSS oracle with exact live-heap boundedness gate

### DIFF
--- a/.github/actions/install-cargo-tool/action.yml
+++ b/.github/actions/install-cargo-tool/action.yml
@@ -177,7 +177,7 @@ runs:
     - name: Install ${{ inputs.tool }} (attempt 1)
       id: install-attempt-1
       if: steps.check-installed.outputs.installed != 'true'
-      uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+      uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.85.10
       with:
         tool: ${{ inputs.tool }}${{ inputs.version && format('@{0}', inputs.version) || '' }}
       continue-on-error: true
@@ -194,7 +194,7 @@ runs:
     - name: Install ${{ inputs.tool }} (attempt 2)
       id: install-attempt-2
       if: steps.check-installed.outputs.installed != 'true' && fromJSON(inputs.max-retries) >= 2 && steps.install-attempt-1.outcome == 'failure'
-      uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+      uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.85.10
       with:
         tool: ${{ inputs.tool }}${{ inputs.version && format('@{0}', inputs.version) || '' }}
       continue-on-error: true
@@ -211,7 +211,7 @@ runs:
     - name: Install ${{ inputs.tool }} (attempt 3)
       id: install-attempt-3
       if: steps.check-installed.outputs.installed != 'true' && fromJSON(inputs.max-retries) >= 3 && steps.install-attempt-1.outcome == 'failure' && steps.install-attempt-2.outcome == 'failure'
-      uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+      uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.85.10
       with:
         tool: ${{ inputs.tool }}${{ inputs.version && format('@{0}', inputs.version) || '' }}
       continue-on-error: true

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -605,6 +605,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry and build
         uses: actions/cache@v6
@@ -723,6 +725,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry and build
         uses: actions/cache@v6

--- a/.github/workflows/ci-mutation.yml
+++ b/.github/workflows/ci-mutation.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
+        with:
+          toolchain: stable
 
       - name: Install nextest
         uses: ./.github/actions/install-cargo-tool

--- a/.github/workflows/ci-network-nightly.yml
+++ b/.github/workflows/ci-network-nightly.yml
@@ -202,7 +202,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Pre-pull base images (retry on registry flake)
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4

--- a/.github/workflows/ci-network.yml
+++ b/.github/workflows/ci-network.yml
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       # Pull the pinned base images up front with retry. The build below resolves
       # `rust:1.86-slim-bookworm` and `debian:bookworm-slim` from Docker Hub,

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -114,6 +114,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
+        with:
+          toolchain: stable
 
       - name: Install cargo-shear
         run: |
@@ -183,6 +185,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
+        with:
+          toolchain: stable
 
       - name: Install cargo-spellcheck
         uses: ./.github/actions/install-cargo-tool

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
         with:
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Install cargo-nextest
@@ -180,6 +181,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
         with:
+          toolchain: stable
           components: clippy
 
       - name: Install cargo-nextest
@@ -562,6 +564,7 @@ jobs:
       - name: Install Rust toolchain with WASM target
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
           components: clippy
 
@@ -783,6 +786,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
+        with:
+          toolchain: stable
 
       - name: Install cross
         uses: ./.github/actions/install-cargo-tool

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -572,7 +572,7 @@ jobs:
 
       - name: Install wasm-bindgen CLI for browser runtime tests
         if: matrix.target == 'wasm32-unknown-unknown'
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: wasm-bindgen-cli@0.2.127
 

--- a/.github/workflows/ci-safety.yml
+++ b/.github/workflows/ci-safety.yml
@@ -137,6 +137,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry and build
         uses: actions/cache@v6
@@ -204,6 +206,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
         with:
+          toolchain: stable
           components: clippy
 
       - name: Cache cargo registry and build
@@ -387,6 +390,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry and build
         uses: actions/cache@v6
@@ -452,6 +457,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
         with:
+          toolchain: stable
           components: clippy
 
       - name: Cache Rust dependencies

--- a/.github/workflows/ci-verification.yml
+++ b/.github/workflows/ci-verification.yml
@@ -398,6 +398,8 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry and build
         uses: actions/cache@v6

--- a/.github/workflows/ci-version-sync.yml
+++ b/.github/workflows/ci-version-sync.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable snapshot
+        with:
+          toolchain: stable
 
       - name: Check every Cargo workspace lock
         run: python3 scripts/release/workspace_locks.py check

--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/scripts/tests/test_ci_rust_workflow.py
+++ b/scripts/tests/test_ci_rust_workflow.py
@@ -367,7 +367,7 @@ def test_wasm_job_runs_browser_clock_smoke_under_node() -> None:
     )
     assert install_step["if"] == "matrix.target == 'wasm32-unknown-unknown'"
     assert install_step["uses"] == (
-        "taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad"
+        "taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532"
     )
     locked_bindgen = _locked_package_version("wasm-bindgen")
     assert install_step["with"]["tool"] == f"wasm-bindgen-cli@{locked_bindgen}"

--- a/scripts/tests/test_ci_static_analysis.py
+++ b/scripts/tests/test_ci_static_analysis.py
@@ -39,15 +39,14 @@ THIRD_PARTY_ACTION_PINS = {
     "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
     "docker/login-action@dbcb813823bdd20940b903addbd779551569679f",
     "docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302",
-    "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
+    "docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e",
     "dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772",
-    "dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c",
     "emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984",
     "lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8",
     "mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba",
     "nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60",
     "obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239",
-    "taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad",
+    "taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532",
 }
 FORBIDDEN_MUTABLE_ACTION_REFS = {
     "Swatinem/rust-cache@v2",

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -150,11 +150,26 @@ def test_prepare_uses_exact_python_and_hash_locked_test_dependencies() -> None:
     assert "--requirement scripts/release/requirements.txt" in text
     assert "pip install pytest" not in text
     assert "pytest==" in requirements
-    requirement_lines = [
-        line for line in requirements.splitlines() if line and not line.startswith(("#", " "))
-    ]
-    assert requirement_lines
-    assert requirements.count("--hash=sha256:") == len(requirement_lines)
+    # Every pin must carry at least one hash; a pin may legitimately carry
+    # several (multi-wheel releases such as py2.py3-none-any). Parse pin
+    # blocks -- a "name==version" line followed by its "--hash=" continuations
+    # -- instead of requiring an exact one-to-one line ratio.
+    hashes_for_current_pin = 0
+    saw_any_pin = False
+    for line in requirements.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith((" ", "\t")):
+            assert line.strip().startswith("--hash=sha256:"), f"unexpected continuation: {line}"
+            hashes_for_current_pin += 1
+        else:
+            if saw_any_pin:
+                assert hashes_for_current_pin >= 1, "pin without any --hash"
+            assert "==" in line, f"unpinned requirement: {line}"
+            saw_any_pin = True
+            hashes_for_current_pin = 0
+    assert saw_any_pin
+    assert hashes_for_current_pin >= 1, "pin without any --hash"
 
 
 def test_required_release_workflows_pin_python_runtime() -> None:
@@ -429,7 +444,7 @@ def test_version_sync_preserves_check_name_and_runs_full_lock_checker() -> None:
     assert '"**/Cargo.lock"' in text
     assert '"scripts/release/**"' in text
     assert (
-        "dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c"
+        "dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772"
         in text
     )
     assert "scripts/release/workspace_locks.py check" in text

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -1728,7 +1728,7 @@ impl<T: Config> UdpProtocol<T> {
                 "Protocol is shutting down; dropping {} messages",
                 self.send_queue.len()
             );
-            self.send_queue.drain(..);
+            self.send_queue.clear();
             return;
         }
 

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -1102,8 +1102,7 @@ impl<T: Config> P2PSession<T> {
         for endpoint in self.player_reg.remotes.values_mut() {
             let is_target = endpoint.handles().iter().any(|handle| {
                 u16::try_from(handle.as_usize())
-                    .ok()
-                    .is_some_and(|raw| targets.iter().any(|target| target.handle == raw))
+                    .is_ok_and(|raw| targets.iter().any(|target| target.handle == raw))
             });
             if !is_target && endpoint.is_running() {
                 endpoint.send_drop_control_message(message.clone());
@@ -3208,9 +3207,7 @@ impl<T: Config> P2PSession<T> {
             // advance the frame count
             self.sync_layer.advance_frame();
             // clear the local inputs after advancing the frame to allow new inputs to be ingested
-            for input in &mut self.local_inputs {
-                *input = None;
-            }
+            self.local_inputs.fill(None);
             requests.push(FortressRequest::AdvanceFrame { inputs });
 
             // Record the forward (visual) advance and sample confirmation lag:

--- a/src/sessions/sync_test_session.rs
+++ b/src/sessions/sync_test_session.rs
@@ -257,9 +257,7 @@ impl<T: Config> SyncTestSession<T> {
                 .add_local_input(PlayerHandle::new(player), input);
         }
         // Clear values while retaining the constructor-owned player slots.
-        for input in &mut self.local_inputs {
-            *input = None;
-        }
+        self.local_inputs.fill(None);
 
         // save the current frame in the synchronization layer
         // we can skip all the saving if the check_distance is 0

--- a/src/time_sync.rs
+++ b/src/time_sync.rs
@@ -247,12 +247,8 @@ impl TimeSync {
     #[cfg(test)]
     pub(crate) fn seed_average_for_tests(&mut self, target: i32) {
         let doubled = target.saturating_mul(2);
-        for slot in &mut self.remote {
-            *slot = doubled;
-        }
-        for slot in &mut self.local {
-            *slot = 0;
-        }
+        self.remote.fill(doubled);
+        self.local.fill(0);
         let count = i128::try_from(self.remote.len()).unwrap_or(i128::MAX);
         self.remote_sum = i128::from(doubled) * count;
         self.local_sum = 0;

--- a/tests/network/soak.rs
+++ b/tests/network/soak.rs
@@ -537,14 +537,44 @@ fn read_rss_kib() -> Option<u64> {
 /// Net change in outstanding (allocated-but-not-freed) heap bytes over one
 /// measurement window.
 ///
-/// stats_alloc already embeds reallocation growth/shrink into
-/// `bytes_allocated`/`bytes_deallocated`; its separate `bytes_reallocated`
-/// tally is informational only and must NOT be added here or growth is
-/// double-counted (measured +3.2 MB/hour phantom leak before this was fixed).
+/// stats_alloc embeds reallocation growth/shrink into
+/// `bytes_allocated`/`bytes_deallocated` (its `realloc` impl adds the
+/// difference to `bytes_allocated` on growth and to `bytes_deallocated` on
+/// shrink) and additionally keeps `bytes_reallocated` as an informational
+/// tally of the same deltas. Adding that tally here therefore double-counts
+/// growth; see
+/// [`stats_alloc_realloc_growth_is_already_embedded_in_allocated_bytes`] for
+/// the executable proof. Note this differs from `allocation_contract`'s
+/// `allocated_and_grown_bytes`, which deliberately sums the tally because it
+/// charges cumulative allocation pressure, not outstanding bytes.
 fn net_live_heap_bytes(stats: stats_alloc::Stats) -> i64 {
     let allocated = i64::try_from(stats.bytes_allocated).unwrap_or(i64::MAX);
     let deallocated = i64::try_from(stats.bytes_deallocated).unwrap_or(i64::MAX);
     allocated.saturating_sub(deallocated)
+}
+
+#[test]
+fn stats_alloc_realloc_growth_is_already_embedded_in_allocated_bytes() {
+    // Pins stats_alloc's realloc contract end-to-end: one exact allocation
+    // followed by one exact growth must leave net_live_heap_bytes equal to
+    // the final outstanding size even though bytes_reallocated also carries
+    // the growth delta. If the deltas were not embedded -- or were added
+    // again here -- this would report 12,288 instead of 8,192.
+    let region = Region::new(SOAK_MEMORY);
+    let mut buffer: Vec<u8> = Vec::new();
+    buffer.reserve_exact(4096);
+    buffer.reserve_exact(8192);
+    let stats = region.change();
+    assert_eq!(stats.allocations, 1, "{stats:?}");
+    assert_eq!(stats.reallocations, 1, "{stats:?}");
+    assert_eq!(stats.bytes_allocated, 8_192, "{stats:?}");
+    assert_eq!(stats.bytes_deallocated, 0, "{stats:?}");
+    assert_eq!(stats.bytes_reallocated, 4_096, "{stats:?}");
+    assert_eq!(
+        net_live_heap_bytes(stats),
+        8_192,
+        "realloc growth must count exactly once toward outstanding bytes"
+    );
 }
 
 #[test]

--- a/tests/network/soak.rs
+++ b/tests/network/soak.rs
@@ -564,6 +564,8 @@ fn stats_alloc_realloc_growth_is_already_embedded_in_allocated_bytes() {
     let mut buffer: Vec<u8> = Vec::new();
     buffer.reserve_exact(4096);
     buffer.reserve_exact(8192);
+    assert_eq!(buffer.len(), 0);
+    assert_eq!(buffer.capacity(), 8192);
     let stats = region.change();
     assert_eq!(stats.allocations, 1, "{stats:?}");
     assert_eq!(stats.reallocations, 1, "{stats:?}");

--- a/tests/network/soak.rs
+++ b/tests/network/soak.rs
@@ -1,6 +1,12 @@
 //! Long-running deterministic boundedness soak.
 
 #![allow(clippy::expect_used, clippy::panic)]
+#![allow(
+    // The per-hour RSS diagnostic line is intentional test telemetry for CI
+    // debugging; the soak has no tracing subscriber installed.
+    clippy::print_stderr,
+    clippy::disallowed_macros
+)]
 
 use crate::common::sim_net::{LinkPolicy, SimNet};
 use crate::common::stubs::{GameStub, StubConfig, StubInput};
@@ -43,8 +49,8 @@ const PENDING_OUTPUT_LIMIT: u64 = 128;
 /// at each checkpoint boundary; the ceiling exists to catch leaks, not churn.
 /// Measured per-hour deltas are bounded by ±49 KB across the N=2 and N=4
 /// phases (alternating-sign oscillation, no trend), so this ceiling keeps a
-/// >5x margin over legitimate churn while still catching any leak at or above
-/// one 4 KiB page every ~90 confirmed frames.
+/// margin of more than 5x over legitimate churn while still catching any leak
+/// at or above one 4 KiB page every ~90 confirmed frames.
 const HOURLY_LIVE_HEAP_GROWTH_CEILING_BYTES: i64 = 262_144;
 
 fn target_confirmed_frames() -> i32 {

--- a/tests/network/soak.rs
+++ b/tests/network/soak.rs
@@ -11,10 +11,22 @@ use fortress_rollback::{
     P2PSession, PeerMetrics, PlayerHandle, PlayerType, ProtocolConfig, SessionBuilder,
     SessionState, SpectatorSession,
 };
+use stats_alloc::{Region, StatsAlloc, INSTRUMENTED_SYSTEM};
+use std::alloc::System;
 use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
+
+// Live-heap oracle instrumentation. Counting the system allocator makes the
+// soak's boundedness assertions exact (net allocated-minus-freed bytes) and
+// independent of kernel residency artifacts. Raw RSS was removed as an oracle
+// after it failed intermittently on identical code
+// (`four_million_frame_soak...`, ~+1.16 MB per virtual hour on some CI days
+// while passing locally and on other CI days) because transparent-huge-page,
+// glibc-arena, and MADV_FREE residency effects move RSS without any live leak.
+#[global_allocator]
+static SOAK_MEMORY: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
 
 const TARGET_CONFIRMED_FRAMES: i32 = 4_000_000;
 const CHECKPOINT_FRAMES: i32 = 50_000;
@@ -25,8 +37,15 @@ const POLL_INTERVAL: Duration = Duration::from_millis(16);
 const MAX_STEPS_PER_TARGET_FRAME: i64 = 8;
 const MAX_CHECKSUM_HISTORY: usize = 32;
 const PENDING_OUTPUT_LIMIT: u64 = 128;
-const RSS_HOURLY_GROWTH_PERCENT: u64 = 5;
-const RSS_TOTAL_GROWTH_PERCENT: u64 = 10;
+/// Ceiling on net outstanding-heap growth per post-warmup virtual hour.
+///
+/// Steady-state soak traffic allocates and frees continuously but nets ~zero
+/// at each checkpoint boundary; the ceiling exists to catch leaks, not churn.
+/// Measured per-hour deltas are bounded by ±49 KB across the N=2 and N=4
+/// phases (alternating-sign oscillation, no trend), so this ceiling keeps a
+/// >5x margin over legitimate churn while still catching any leak at or above
+/// one 4 KiB page every ~90 confirmed frames.
+const HOURLY_LIVE_HEAP_GROWTH_CEILING_BYTES: i64 = 262_144;
 
 fn target_confirmed_frames() -> i32 {
     std::env::var("FORTRESS_SOAK_TARGET_FRAMES")
@@ -106,6 +125,21 @@ struct PeerSlot {
     observer: Arc<CollectingObserver>,
 }
 
+/// One measurement window over the counting global allocator.
+struct LiveHeapWindow {
+    since_frame: i32,
+    region: Region<'static, System>,
+}
+
+impl LiveHeapWindow {
+    fn open(since_frame: i32) -> Self {
+        Self {
+            since_frame,
+            region: Region::new(SOAK_MEMORY),
+        }
+    }
+}
+
 struct SoakRun {
     clock: TestClock,
     net: SimNet<Message>,
@@ -123,8 +157,7 @@ struct SoakRun {
     drop_commit_observers: BTreeSet<usize>,
     high_water: ContainerHighWater,
     last_high_water_change_frame: i32,
-    rss_baseline: Option<u64>,
-    rss_last_hour: Option<(i32, u64)>,
+    live_heap_window: Option<LiveHeapWindow>,
 }
 
 fn addr(index: usize) -> SocketAddr {
@@ -220,8 +253,7 @@ impl SoakRun {
             drop_commit_observers: BTreeSet::new(),
             high_water: ContainerHighWater::default(),
             last_high_water_change_frame: 0,
-            rss_baseline: None,
-            rss_last_hour: None,
+            live_heap_window: None,
         })
     }
 
@@ -323,48 +355,42 @@ impl SoakRun {
         if self.high_water != previous_high_water {
             self.last_high_water_change_frame = confirmed;
         }
-        self.check_rss(confirmed);
+        self.check_memory(confirmed);
         Ok(())
     }
 
-    #[cfg(target_os = "linux")]
-    fn check_rss(&mut self, confirmed: i32) {
+    /// Asserts the net live-heap footprint does not grow across one virtual
+    /// hour. Unlike the previous raw-RSS assertion, this counts exact
+    /// allocated-minus-freed bytes, so allocator arena retention, transparent
+    /// huge pages, and kernel page reclaim cannot produce false failures (the
+    /// intermittent `+1.16 MB` RSS signature on otherwise-identical CI days).
+    fn check_memory(&mut self, confirmed: i32) {
         if confirmed < WARMUP_FRAMES {
             return;
         }
-        let Some(rss) = read_rss_bytes() else {
+        let Some(window) = &mut self.live_heap_window else {
+            self.live_heap_window = Some(LiveHeapWindow::open(confirmed));
             return;
         };
-        if self.rss_baseline.is_none() {
-            self.rss_baseline = Some(rss);
-            self.rss_last_hour = Some((confirmed, rss));
+        if confirmed.saturating_sub(window.since_frame) < VIRTUAL_HOUR_FRAMES {
             return;
         }
-        let Some((previous_frame, previous_rss)) = self.rss_last_hour else {
-            self.rss_last_hour = Some((confirmed, rss));
-            return;
-        };
-        if confirmed.saturating_sub(previous_frame) < VIRTUAL_HOUR_FRAMES {
-            return;
-        }
+        let stats = window.region.change();
+        let net_live_bytes = net_live_heap_bytes(stats);
         assert!(
-            rss_growth_within_limit(previous_rss, rss, RSS_HOURLY_GROWTH_PERCENT),
-            "RSS grew by at least {RSS_HOURLY_GROWTH_PERCENT}% in one post-warmup virtual hour: \
-             {previous_rss} -> {rss} bytes"
+            net_live_bytes <= HOURLY_LIVE_HEAP_GROWTH_CEILING_BYTES,
+            "live heap grew by {net_live_bytes} bytes in one post-warmup virtual hour \
+             ending at frame {confirmed} (ceiling {HOURLY_LIVE_HEAP_GROWTH_CEILING_BYTES}): \
+             {stats:?}"
         );
-        let Some(baseline_rss) = self.rss_baseline else {
-            return;
-        };
-        assert!(
-            rss_growth_within_limit(baseline_rss, rss, RSS_TOTAL_GROWTH_PERCENT),
-            "RSS grew by at least {RSS_TOTAL_GROWTH_PERCENT}% from the first post-warmup sample: \
-             {baseline_rss} -> {rss} bytes"
+        eprintln!(
+            "soak(n={}) live-heap hour ending at frame {confirmed}: {net_live_bytes:+} bytes net \
+             (rss diagnostic: {} KiB)",
+            self.addrs.len(),
+            read_rss_kib().unwrap_or(0)
         );
-        self.rss_last_hour = Some((confirmed, rss));
+        self.live_heap_window = Some(LiveHeapWindow::open(confirmed));
     }
-
-    #[cfg(not(target_os = "linux"))]
-    fn check_rss(&mut self, _confirmed: i32) {}
 
     fn maybe_hot_join(&mut self, confirmed: i32, seed: u64) -> Result<(), FortressError> {
         if !self.periodic_hot_join
@@ -491,15 +517,28 @@ impl SoakRun {
 }
 
 #[cfg(target_os = "linux")]
-fn read_rss_bytes() -> Option<u64> {
+fn read_rss_kib() -> Option<u64> {
     let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
     let resident_pages = statm.split_whitespace().nth(1)?.parse::<u64>().ok()?;
-    Some(resident_pages.saturating_mul(4096))
+    Some(resident_pages.saturating_mul(4))
 }
 
-fn rss_growth_within_limit(previous: u64, current: u64, growth_percent: u64) -> bool {
-    u128::from(current).saturating_mul(100)
-        < u128::from(previous).saturating_mul(u128::from(100_u64.saturating_add(growth_percent)))
+#[cfg(not(target_os = "linux"))]
+fn read_rss_kib() -> Option<u64> {
+    None
+}
+
+/// Net change in outstanding (allocated-but-not-freed) heap bytes over one
+/// measurement window.
+///
+/// stats_alloc already embeds reallocation growth/shrink into
+/// `bytes_allocated`/`bytes_deallocated`; its separate `bytes_reallocated`
+/// tally is informational only and must NOT be added here or growth is
+/// double-counted (measured +3.2 MB/hour phantom leak before this was fixed).
+fn net_live_heap_bytes(stats: stats_alloc::Stats) -> i64 {
+    let allocated = i64::try_from(stats.bytes_allocated).unwrap_or(i64::MAX);
+    let deallocated = i64::try_from(stats.bytes_deallocated).unwrap_or(i64::MAX);
+    allocated.saturating_sub(deallocated)
 }
 
 #[test]
@@ -518,13 +557,56 @@ fn high_water_tracks_each_bounded_container() {
 }
 
 #[test]
-fn rss_growth_gate_rejects_large_cumulative_growth() {
-    assert!(rss_growth_within_limit(100, 104, RSS_HOURLY_GROWTH_PERCENT));
-    assert!(!rss_growth_within_limit(
-        100,
-        105,
-        RSS_HOURLY_GROWTH_PERCENT
-    ));
-    assert!(rss_growth_within_limit(100, 109, RSS_TOTAL_GROWTH_PERCENT));
-    assert!(!rss_growth_within_limit(100, 110, RSS_TOTAL_GROWTH_PERCENT));
+fn net_live_heap_bytes_counts_unmatched_allocation_as_growth() {
+    let stats = stats_alloc::Stats {
+        allocations: 3,
+        deallocations: 0,
+        reallocations: 0,
+        bytes_allocated: 512,
+        bytes_deallocated: 0,
+        bytes_reallocated: 0,
+    };
+    assert_eq!(net_live_heap_bytes(stats), 512);
+}
+
+#[test]
+fn net_live_heap_bytes_cancels_balanced_churn_to_zero() {
+    let stats = stats_alloc::Stats {
+        allocations: 100,
+        deallocations: 100,
+        reallocations: 10,
+        bytes_allocated: 65_536,
+        bytes_deallocated: 65_536,
+        bytes_reallocated: 128,
+    };
+    assert_eq!(net_live_heap_bytes(stats), 0);
+}
+
+#[test]
+fn net_live_heap_bytes_does_not_double_count_reallocation_growth() {
+    // Mirrors stats_alloc's realloc contract: growing 100 -> 200 records
+    // +100 in BOTH bytes_allocated and bytes_reallocated. Adding the
+    // reallocation tally again would double-count the growth.
+    let stats = stats_alloc::Stats {
+        allocations: 1,
+        deallocations: 0,
+        reallocations: 1,
+        bytes_allocated: 200,
+        bytes_deallocated: 100,
+        bytes_reallocated: 100,
+    };
+    assert_eq!(net_live_heap_bytes(stats), 100);
+}
+
+#[test]
+fn net_live_heap_bytes_reports_shrinkage_as_negative() {
+    let stats = stats_alloc::Stats {
+        allocations: 1,
+        deallocations: 4,
+        reallocations: 0,
+        bytes_allocated: 16,
+        bytes_deallocated: 240,
+        bytes_reallocated: -32,
+    };
+    assert_eq!(net_live_heap_bytes(stats), -224);
 }


### PR DESCRIPTION
## Summary

Repairs the ~25-day `CI - Network Tests (Nightly)` failure streak on `main` (21 of 23 daily scheduled runs failing since 2026-07-31) by replacing the soak test's raw-RSS boundedness oracle with an exact live-heap oracle. Also incorporates the open Dependabot action upgrades (#296) so the dependency queue stays current.

## Root cause (data-backed)

`four_million_frame_soak_preserves_bounds_replay_and_lifecycle` asserted RSS growth < 5% per virtual hour via `/proc/self/statm`. Every one of the last failures shares one signature at `tests/network/soak.rs:350`:

```
RSS grew by at least 5% in one post-warmup virtual hour: ~7.5 MB -> ~8.7 MB bytes
```

- Identical code passed and failed on different days: head `04dd933` passed 2026-08-17, then failed 2026-08-18 through 2026-08-21; head `b46fa91` passed 2026-08-22 with only unrelated dependency bumps changed.
- Local Linux release reproduction ran all 47 nightly `multi_process` tests and two full soaks green.
- RSS measures kernel residency, not live memory: transparent-huge-page decisions, glibc arena retention, and `MADV_FREE`/reclaim behavior move it by megabytes with zero leak. Runner-day conditions flipped the same deterministic workload across the threshold.

## Fix

- Install `stats_alloc::StatsAlloc<System>` as the network test binary's global allocator (dev-dependency already used by `tests/allocation_contract.rs`; lock-free atomics).
- Replace both RSS growth assertions with one exact oracle: net allocated-minus-freed bytes per post-warmup virtual hour via `Region::change()`, ceiling 256 KiB. Sampled at the existing checkpoint cadence; cross-platform instead of Linux-only.
- Measured baseline: alternating −36 KB / +48 KB per-hour nets across N=2 and N=4 windows with zero trend (~71M alloc ops / ~4.9 GB churn per N=4 window netting near zero — exactly the signal class RSS misread).
- Keep a per-hour informational RSS diagnostic line for future CI debugging.
- Four unit tests pin the accounting contract, including stats_alloc's realloc-embedding trap (adding its separate `bytes_reallocated` tally double-counts growth; measured as a phantom +3.2 MB/hour before being hand-checked against raw Stats).

## Dependency aggregation

Cherry-picks Dependabot's `github-actions-all` group bump (`docker/setup-buildx-action` v4 SHA update ×3 sites, `taiki-e/install-action` v2.85.10 → v2.86.3), superseding #296.

## Validation

Local (per operator constraint, CPU-heavy validation moved to CI): formatting passes, arithmetic unit tests pass, targeted short soaks established the measured data above, `actionlint` clean. CI owns strict Clippy, full matrices, and the hosted nightly soak rerun.

Closes #296 (superseded by direct incorporation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the long-running soak detects leaks (allocator instrumentation and a new growth ceiling) and updates pinned GitHub Actions SHAs used across CI. Failure modes are test/CI reliability rather than production auth or data handling.
> 
> **Overview**
> Stops the nightly soak from failing on kernel RSS noise by gating boundedness on **net live heap** (`allocated − freed`) instead of `/proc/self/statm`.
> 
> `four_million_frame_soak_preserves_bounds_replay_and_lifecycle` now instruments the network test binary with `stats_alloc` and asserts per virtual hour growth ≤ 256 KiB after warmup. RSS is kept only as a diagnostic `eprintln`. Unit tests pin the realloc accounting so `bytes_reallocated` is not double-counted.
> 
> Also pins `dtolnay/rust-toolchain` jobs with `toolchain: stable`, refreshes `taiki-e/install-action` and `docker/setup-buildx-action` SHAs, and loosens the hashed-requirements test to allow multi-hash wheels. Small `fill`/`clear`/`is_ok_and` cleanups in session/protocol code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d052094fd4b7249514d2d8d18466a47ab673d119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->