### PR TITLE
ci: handle empty mutation corpora

### DIFF
--- a/.github/workflows/ci-mutation.yml
+++ b/.github/workflows/ci-mutation.yml
@@ -144,7 +144,14 @@ jobs:
           fi
 
           cargo mutants --list --json "${filter_args[@]}" > mutation-list.json
-          expected_mutants="$(jq 'length' mutation-list.json)"
+          if [ ! -s mutation-list.json ]; then
+            printf '%s\n' '[]' > mutation-list.json
+          fi
+          expected_mutants="$(jq -e '
+            if type == "array" then length
+            else error("mutation list must be a JSON array")
+            end
+          ' mutation-list.json)"
           shard_count="$(( (expected_mutants + 49) / 50 ))"
           if [ "$shard_count" -lt 1 ]; then
             shard_count="1"
@@ -257,7 +264,14 @@ jobs:
           shard="${SHARD_INDEX}/${SHARD_COUNT}"
           cargo mutants --list --json --sharding round-robin \
             --shard "$shard" "${filter_args[@]}" > mutation-list.json
-          selected_mutants="$(jq 'length' mutation-list.json)"
+          if [ ! -s mutation-list.json ]; then
+            printf '%s\n' '[]' > mutation-list.json
+          fi
+          selected_mutants="$(jq -e '
+            if type == "array" then length
+            else error("mutation list must be a JSON array")
+            end
+          ' mutation-list.json)"
 
           set +e
           cargo mutants \

--- a/progress/session-171-zero-mutant-release-ci.md
+++ b/progress/session-171-zero-mutant-release-ci.md
@@ -1,0 +1,56 @@
+# Session 171: Zero-Mutant Release CI
+
+## Objective
+
+Close the post-merge audit, repair the only failing v0.13.0 release check, and preserve the
+release process's reconstructible-candidate trust boundary.
+
+## Incident evidence
+
+- PR #304 squash-merged as `0370e8a`; all 16 push workflow groups and the subsequent network and
+  simulation nightlies passed on that exact `main` head.
+- Complete paginated searches found zero open issues, zero dependency-update pull requests, and no
+  compatible dependency update omitted from Session 170.
+- Automated release preparation opened PR #305. Thirteen workflow groups passed; mutation run
+  32810731825 alone failed.
+- The release changes contain only Rust documentation edits. Cargo-mutants 27.1.0 therefore exited
+  successfully with `INFO No mutants to filter` and wrote zero bytes for `--list --json`.
+- The planner and shard both assumed successful list output was nonempty JSON. Empty shell values
+  then reached arithmetic and `jq --argjson`, cascading into shard and summary failures.
+
+## Implementation
+
+- Normalize a successful zero-byte mutant list to the canonical empty JSON array in both corpus
+  planning and shard execution.
+- Require the normalized value to be a JSON array before deriving its length. Malformed JSON,
+  scalars, objects, and producer failures remain fail-closed.
+- Exercise the actual shell fragments extracted from both workflow steps with a fake cargo
+  producer covering empty output, a valid two-item array, malformed JSON, non-array JSON, and an
+  exact producer exit status of 42.
+- Close generated release PR #305 before repair publication. The release-state gate requires a
+  release candidate to remain one byte-for-byte reconstructible preparation commit, so the CI fix
+  must land on `main` before v0.13.0 is regenerated.
+
+## Review
+
+- The first adversarial pass found no implementation, parsing, portability, or fail-open defect.
+  It requested behavioral coverage rather than a structural-only workflow assertion.
+- A second independent pass implemented the table-driven extraction test without adding a
+  one-off production helper. Exact successful output and every rejection path are pinned.
+
+## Local verification
+
+- Exact cargo-mutants 27.1.0 release-diff reproduction: zero-byte output normalizes to `[]` and
+  count `0`.
+- Focused mutation workflow and aggregation contracts: 15 passed.
+- `actionlint .github/workflows/ci-mutation.yml`: passed.
+- Repository shell portability check: passed.
+- `cargo fmt --check`: passed.
+- Strict workspace/all-target Clippy with `tokio,json`: passed.
+- `git diff --check`: passed.
+
+## Remaining gates
+
+- Publish the focused repair PR and require every exact-head workflow and reviewer pass.
+- Merge the repair to `main`, verify post-merge CI, and regenerate v0.13.0 through the supported
+  release-preparation workflow.

--- a/scripts/tests/test_ci_mutation_workflow.py
+++ b/scripts/tests/test_ci_mutation_workflow.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
+import textwrap
 from pathlib import Path
 
 try:
@@ -34,6 +37,29 @@ def named_step(text: str, name: str) -> str:
     )
     ends = [end for end in (next_step, next_job) if end != -1]
     return text[start : min(ends) if ends else len(text)]
+
+
+def mutation_list_fragment(step: str, count_variable: str) -> str:
+    """Extract the producer and normalization fragment from a workflow step."""
+    lines = step.splitlines()
+    start = next(
+        index
+        for index, line in enumerate(lines)
+        if "cargo mutants --list --json" in line
+    )
+    end = next(
+        index
+        for index, line in enumerate(lines[start:], start=start)
+        if line.strip() == "' mutation-list.json)\""
+    )
+    fragment = textwrap.dedent("\n".join(lines[start : end + 1]))
+    return (
+        "set -euo pipefail\n"
+        "filter_args=()\n"
+        'shard="0/1"\n'
+        f"{fragment}\n"
+        f'printf "count=%s\\n" "${{{count_variable}}}"\n'
+    )
 
 
 def test_workflow_pins_tool_and_runs_linux_only() -> None:
@@ -80,6 +106,59 @@ def test_runtime_flags_are_reproducible_and_list_only_json() -> None:
     assert 'pipeline_status=("${PIPESTATUS[@]}")' in step
     assert 'command_status="${pipeline_status[0]}"' in step
     assert 'tee_status="${pipeline_status[1]}"' in step
+
+
+def test_mutant_list_normalization_behavior(tmp_path: Path) -> None:
+    fake_cargo = tmp_path / "cargo"
+    fake_cargo.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+case "${FAKE_MUTANT_LIST_MODE}" in
+  zero) exit 0 ;;
+  valid) printf '%s\\n' '[{}, {}]' ;;
+  malformed) printf '%s\\n' '{' ;;
+  non_array) printf '%s\\n' '{}' ;;
+  producer_failure) exit 42 ;;
+  *) exit 64 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    fake_cargo.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+
+    cases = (
+        ("zero", 0, "count=0\n"),
+        ("valid", 0, "count=2\n"),
+        ("malformed", None, ""),
+        ("non_array", None, ""),
+        ("producer_failure", 42, ""),
+    )
+    steps = (
+        ("Plan exact mutation corpus", "expected_mutants"),
+        ("Run bounded mutation shard", "selected_mutants"),
+    )
+    for step_name, count_variable in steps:
+        fragment = mutation_list_fragment(named_step(workflow_text(), step_name), count_variable)
+        for mode, expected_status, expected_output in cases:
+            env["FAKE_MUTANT_LIST_MODE"] = mode
+            result = subprocess.run(
+                ["bash", "-c", fragment],
+                cwd=tmp_path,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+
+            context = f"{step_name}/{mode}: {result.stderr}"
+            if expected_status is None:
+                assert result.returncode != 0, context
+            else:
+                assert result.returncode == expected_status, context
+            assert result.stdout == expected_output, context
 
 
 def test_baseline_and_summary_are_fail_closed() -> None:


### PR DESCRIPTION
## Summary

- normalize cargo-mutants 27.1.0's successful zero-byte `--list --json` output to `[]` in both planning and shard execution;
- require every nonempty list result to be a JSON array before deriving its length;
- execute the actual workflow fragments against empty, valid, malformed, non-array, and failed-producer cases.

## RCA

Generated release PR #305 contains only Rust documentation edits. Cargo-mutants correctly reports `INFO No mutants to filter`, exits 0, and writes zero bytes. The workflow treated the resulting empty shell value as an integer/JSON value, so its shard and summary failed despite a legitimate empty corpus.

PR #305 was closed before this repair because release candidates must remain one byte-for-byte reconstructible generated commit. After this fix lands on `main`, v0.13.0 will be regenerated through `Release - Prepare PR`.

## Safety

Malformed JSON, non-array JSON, and producer failures remain fail-closed. This changes CI/tooling only; production Rust, public API, wire behavior, determinism, and dependencies are unchanged. No changelog entry is required.

## Validation

- exact cargo-mutants 27.1.0 release-diff reproduction: zero bytes -> `[]` -> count 0;
- 15 focused mutation workflow/aggregation contracts;
- 2,099 Python tests;
- 2,903 Nextest tests (71 skipped);
- strict workspace/all-target Clippy with `tokio,json`;
- formatting, actionlint, shell portability, Markdownlint, agent preflight, and `git diff --check`;
- two adversarial review rounds, zero remaining findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-only changes; no production Rust, API, or runtime behavior.
> 
> **Overview**
> Fixes mutation CI when **cargo-mutants 27.1.0** succeeds with no mutants (e.g. doc-only release diffs) and writes **zero bytes** for `--list --json`. The planner and shard steps now treat an empty file as **`[]`**, then use **`jq -e`** to require a JSON **array** before taking its length; malformed or non-array output still fails the job.
> 
> Adds a **table-driven Python test** that pulls the real shell from both workflow steps and runs it against a fake `cargo` (empty list, valid array, bad JSON, non-array, producer failure). A **session progress note** documents the v0.13.0 release mutation failure and the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1392dd040fd06b9586e00d4946d9a8c417d711c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->