### PR TITLE
chore(deps): update Z3 verification stack

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -90,8 +90,13 @@ RUN TLA_TOOLS_VERSION="$(tr -d '[:space:]' < /tmp/tla-tools-version)" && \
 # Note: devcontainer.json containerEnv overrides this to the workspace copy
 ENV TLA_TOOLS_JAR=/opt/tla/tla2tools.jar
 
-# Install Z3 and yamllint via pip
-RUN pip3 install --no-cache-dir --break-system-packages z3-solver yamllint
+# Install the Z3 version matched by the Rust bindings and make its shared
+# library the default for both development builds and verification binaries.
+RUN pip3 install --no-cache-dir --break-system-packages z3-solver==5.1.0.0 yamllint && \
+    Z3_PACKAGE_DIR="$(python3 -c \
+      'from pathlib import Path; import z3; print(Path(z3.__file__).parent)')" && \
+    printf '%s\n' "${Z3_PACKAGE_DIR}/lib" > /etc/ld.so.conf.d/z3-solver.conf && \
+    ldconfig
 
 # Install actionlint (GitHub Actions linter)
 RUN curl --proto '=https' --tlsv1.2 -fsSL --retry 5 --retry-delay 2 --retry-all-errors --max-time 120 https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -248,7 +248,7 @@ sudo mv /tmp/actionlint /usr/local/bin/
 rm /tmp/download-actionlint.bash
 
 # Z3
-pip3 install z3-solver
+pip3 install 'z3-solver==5.1.0.0'
 ```
 
 ## Troubleshooting

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -517,8 +517,8 @@ jobs:
     name: Semver Check
     runs-on: ubuntu-latest
     # Backstop only: a warm sccache + target cache brings this well under a
-    # minute. The first (cold) run after a Cargo.lock change can take longer.
-    timeout-minutes: 20
+    # minute. Allow a cold Cargo.lock rebuild to finish and save its cache.
+    timeout-minutes: 40
     if: github.event_name == 'pull_request'
 
     steps:

--- a/.github/workflows/ci-verification.yml
+++ b/.github/workflows/ci-verification.yml
@@ -43,6 +43,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # z3 0.21's generated bindings target Z3 5.x. Keep the native solver and
+  # Rust bindings aligned instead of relying on each runner image's apt version.
+  Z3_VERSION: '5.1.0'
   # Single source of truth for Kani version used by both `cargo install` and
   # the actions/cache key. Bump here to upgrade Kani; the cache key invalidates
   # automatically. Without this pinning, `cargo install --locked kani-verifier`
@@ -135,11 +138,25 @@ jobs:
         with:
           cache-key: z3
 
-      - name: Install Z3 library
-        run: sudo apt-get update && sudo apt-get install -y libz3-dev
+      - name: Install pinned Z3 library
+        run: |
+          python3 -m pip install --disable-pip-version-check --no-cache-dir \
+            "z3-solver==${Z3_VERSION}.0"
+          python3 -c \
+            'import os, z3; assert z3.get_version_string() == os.environ["Z3_VERSION"]'
+          z3_package_dir="$(python3 -c \
+            'from pathlib import Path; import z3; print(Path(z3.__file__).parent)')"
+          z3_lib_dir="${z3_package_dir}/lib"
+          test -f "${z3_lib_dir}/libz3.so"
+          z3_runtime_path="${z3_lib_dir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+          {
+            printf 'Z3_LIBRARY_PATH_OVERRIDE=%s\n' "${z3_lib_dir}"
+            printf 'LD_LIBRARY_PATH=%s\n' "${z3_runtime_path}"
+            printf 'Z3_SYS_Z3_VERSION=%s\n' "${Z3_VERSION}"
+          } >> "${GITHUB_ENV}"
 
       - name: Run Z3 verification tests (nextest)
-        run: cargo nextest run --profile ci --test verification --features z3-verification -E 'test(z3)'
+        run: cargo nextest run --locked --profile ci --test verification --features z3-verification -E 'test(z3)'
         timeout-minutes: 10
 
   # Kani Formal Verification (Tier 1 - Fast proofs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** the development-only `z3-verification` feature now uses `z3` 0.21 and requires
+  Z3 4.13.3 or newer; Z3 5.1.0 is recommended so native enum definitions match the bindings. The
+  existing `z3-verification-bundled` feature now uses upstream's supported vendored build path for
+  contributors without a compatible system solver.
 - **Breaking:** failover spectator startup now rejects an empty host list with
   `InvalidRequestKind::NoSpectatorHosts` and repeated addresses with
   `InvalidRequestKind::DuplicateSpectatorHost { first_index, duplicate_index }` before endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pre-existing:** Cargo lockfile refreshes no longer cancel the semver gate before its cold
+  dependency build can finish and populate the shared cache.
 - **Pre-existing:** synchronization and disconnect timers now compare monotonic elapsed durations
   rather than constructing absolute `Instant` deadlines. Extremely large valid intervals no longer
   panic through `Instant` overflow, a regressing injected test clock saturates elapsed time at zero,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,9 +1325,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "z3"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c4de445f5c9e3013703a6b8a40c80b4a64c925f0a19e7d0a23a7a9b70e854d"
+checksum = "08975512fd325de2a15eede8ed293b2189c745e0770886fae2b30ae229c5b886"
 dependencies = [
  "log",
  "z3-sys",
@@ -1335,18 +1335,18 @@ dependencies = [
 
 [[package]]
 name = "z3-src"
-version = "416.0.2"
+version = "501.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2af0c6527de39877cf55cb87f233016573eeeb7cf77afdc1469e4b32faef832"
+checksum = "5b72734fb46b47cd6c5a9a1dab4ca1c3c060822d3f34cdcac5d6ae570408b47a"
 dependencies = [
  "cmake",
 ]
 
 [[package]]
 name = "z3-sys"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18b0a91a13522d21b3414847667de2b2056a721a3edcb5b6ee6858352d58db4"
+checksum = "96975839f50a909f6ec19671e5c06d7f0d6fc67287a120e1b010c5f8d91944d6"
 dependencies = [
  "pkg-config",
  "z3-src",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,11 +283,11 @@ paranoid = []
 # No-op compatibility marker. Actual Loom builds use RUSTFLAGS="--cfg loom";
 # retaining this name avoids breaking existing development feature lists.
 loom = []
-# Enable Z3 formal verification tests (requires system Z3: apt install libz3-dev)
+# Enable Z3 formal verification tests (requires Z3 >=4.13.3; Z3 5.x recommended)
 z3-verification = ["dep:z3"]
-# Enable Z3 with bundled build (slow - builds Z3 from source, ~30+ minutes)
+# Enable Z3 with a vendored build (slow - builds Z3 from source, ~30+ minutes)
 # Use this only if you don't have Z3 installed system-wide
-z3-verification-bundled = ["z3-verification", "z3?/bundled"]
+z3-verification-bundled = ["z3-verification", "z3?/vendored"]
 # Enable tokio async runtime integration for async socket adapters
 # Provides TokioUdpSocket for use with async networking code
 tokio = ["dep:tokio"]
@@ -309,8 +309,8 @@ tracing = "0.1"
 smallvec = { version = "1.13", features = ["serde"] }
 # SMT solver for formal verification
 # Only compiled when z3-verification feature is enabled
-# For bundled build (slow), use z3-verification-bundled feature instead
-z3 = { version = "0.20", optional = true }
+# For a vendored build (slow), use z3-verification-bundled instead
+z3 = { version = "0.21", optional = true }
 # Tokio async runtime for async socket adapters
 # Only compiled when tokio feature is enabled
 tokio = { version = "1.52", features = ["net", "io-util", "sync", "rt", "macros", "time"], optional = true }

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -72,6 +72,20 @@ use fortress_rollback::rle::{decode, encode};
 The functions and their wire-compatible bytes are unchanged; only the duplicate
 callable paths were removed.
 
+The development-only `z3-verification` feature now uses the `z3` 0.21 bindings,
+which require Z3 4.13.3 or newer and target Z3 5.x enum definitions. Contributors
+who run the formal-verification suite should install Z3 5.1.0 or use the existing
+`z3-verification-bundled` feature. The bundled feature name is unchanged, but it
+now selects upstream's supported `vendored` build path:
+
+```shell
+# Before: older system Z3 installations could link against z3 0.20.
+cargo test --features z3-verification -- --nocapture
+
+# After: use a matching vendored solver when Z3 5.1.0 is unavailable.
+cargo test --features z3-verification-bundled -- --nocapture
+```
+
 ## Upgrading from 0.11
 
 The Macroquad-based `ex_game_p2p`, `ex_game_spectator`, and `ex_game_synctest` binaries are removed.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2220,20 +2220,23 @@ verification surface compiles out of normal builds and is not intended for appli
 
 #### `z3-verification`
 
-Enables Z3 formal verification tests. Requires the Z3 SMT solver library to be installed on your system.
+Enables Z3 formal verification tests. The Rust bindings require Z3 4.13.3 or
+newer and use enum definitions compatible with Z3 5.x. Use Z3 5.1.0 when
+installing a system solver so the native library and Rust bindings agree.
 
 **System installation (recommended):**
 
 ```bash
-# Debian/Ubuntu
-sudo apt install libz3-dev
-
-# macOS
-brew install z3
+# Confirm that the installed solver is compatible.
+z3 --version
 
 # Then run verification tests
-cargo test --features z3-verification
+cargo test --features z3-verification -- --nocapture
 ```
+
+Distribution packages older than Z3 4.13.3 are unsupported. If the available
+system package is older than 5.x, use `z3-verification-bundled` to build the
+matching solver from source.
 
 **What it tests:**
 
@@ -2244,14 +2247,17 @@ cargo test --features z3-verification
 
 #### `z3-verification-bundled`
 
-Like `z3-verification`, but builds Z3 from source. This is useful for CI environments where system Z3 is not available.
+Like `z3-verification`, but builds the matching Z3 source instead of linking a
+system library. Use this option when the installed solver is missing, older
+than 4.13.3, or from a different enum-compatibility range.
 
-```toml
+```shell
 # In CI or when Z3 is not installed
 cargo test --features z3-verification-bundled
 ```
 
-**Warning:** Building Z3 from source takes 30+ minutes. Use `z3-verification` with system Z3 when possible.
+**Warning:** Building Z3 from source takes 30+ minutes. Prefer
+`z3-verification` with Z3 5.1.0 when a compatible system library is available.
 
 ### Feature Flag Combinations
 

--- a/progress/session-177-z3-021-verification-refresh.md
+++ b/progress/session-177-z3-021-verification-refresh.md
@@ -63,3 +63,12 @@ the assertion now reads the single workflow environment pin. The final diff pass
 documentation inconsistencies: an overstated 5.x minimum in the manifest comment and a shell
 command labeled as TOML. Both are corrected. The change does not touch production Rust, network or
 replay formats, deterministic state, allocation-sensitive paths, or public runtime APIs.
+
+## Hosted CI Follow-up
+
+The first PR run completed 15 workflows successfully, including Z3 verification, the devcontainer
+image, mutation testing, CodeQL, and the cross-platform Rust matrix. The semver job alone exhausted
+its 20-minute backstop twice while rebuilding after the lockfile change; GitHub reported
+`cancelled`, not a semver finding, and the cancellation prevented the cache-save post-step. The
+semver backstop is now 40 minutes, with a regression test preserving enough time for a cold
+lockfile rebuild to finish and populate its cache.

--- a/progress/session-177-z3-021-verification-refresh.md
+++ b/progress/session-177-z3-021-verification-refresh.md
@@ -1,0 +1,65 @@
+# Session 177: Z3 0.21 Verification Refresh
+
+## Objective
+
+Reconcile `GOAL.md`, `PLAN.md`, GitHub, and dependency state; take the highest-impact compatible
+upgrade; and keep the formal-verification environment reproducible across local development and
+hosted CI.
+
+## External State
+
+- Local `main`, remote `main`, and the GitHub default branch all resolve to
+  `b621ffbd6f42147511ec36e6195f96f91f0f9c0e`.
+- The exhaustive two-page GitHub census contains no open issues and no open or draft pull requests.
+- All 18 workflows associated with the current `main` commit completed successfully, including the
+  nightly simulation workflow.
+- `PLAN.md` has no in-progress or future milestones, so the dependency audit supplied the next
+  actionable unit of work.
+
+## Dependency Decision
+
+- All four Cargo workspaces selected zero compatible lockfile updates before this change. npm also
+  reported no outdated packages.
+- `z3` 0.21.0 supports the repository's Rust 1.86 MSRV and was therefore upgraded. Its transitive
+  solver crates moved to `z3-sys` 0.13.0 and `z3-src` 501.0.0.
+- `bincode-next` 3.1.1 remains excluded because it requires Rust 1.90. `serial_test` 4.0.1 remains
+  excluded because it requires Rust 1.93.1. The post-update compatible dependency dry run selected
+  zero additional updates.
+- The upstream `z3` 0.21 release requires a native solver at least as new as Z3 4.13.3 and ships
+  generated definitions for Z3 5.x. CI and the devcontainer now pin Z3 5.1.0 so compile-time
+  bindings and the loaded runtime library cannot drift with runner package repositories.
+
+## Implementation
+
+- Upgraded the optional Rust dependency from `z3` 0.20 to 0.21 and changed the existing
+  `z3-verification-bundled` compatibility feature to upstream's supported `vendored` path.
+- Replaced the verification runner's unpinned Ubuntu package with the pinned `z3-solver` 5.1.0.0
+  wheel. The job verifies the runtime version, discovers the wheel's native library, exports the
+  build/runtime paths, and runs Nextest with the committed lockfile.
+- Pinned the same solver in the devcontainer and registered its native library with the dynamic
+  linker. The Codex npm package and bootstrap hooks remain unchanged.
+- Added a static CI regression test covering the solver pin, runtime assertion, library overrides,
+  blocking failure behavior, locked test invocation, and devcontainer linker setup.
+- Documented the new solver floor and recommended version in the changelog, migration guide, user
+  guide, and synchronized wiki copies.
+
+## Green Evidence
+
+- The targeted static test failed before the workflow change and passed afterward. The complete
+  CI static-analysis module passes 31 tests; the focused devcontainer suites pass 70 tests.
+- The native Z3 5.1.0 proof run passes all 65 selected verification tests, including 54 Z3 proofs.
+- Stable formatting and strict workspace/all-target Clippy with `tokio,json` pass. The matching
+  Nextest suite passes 3,008 tests with 72 skipped; the review-readiness `cargo c` and `cargo t`
+  aliases pass, with `cargo t` completing 2,975 tests and 72 accepted skips.
+- All 210 documentation tests pass with 160 executions and 50 accepted ignores. Rustdoc with
+  warnings denied, Actionlint, doc-claim checks, wiki consistency, Markdown linting, link checking,
+  spell checking, version synchronization, workspace lock checks, Cargo audit, and Cargo deny pass.
+- The repository agent preflight passes all 286 general checks and 66 additional checks.
+
+## Adversarial Review
+
+The first review pass found a low-severity duplicated Z3 runtime-version literal in the workflow;
+the assertion now reads the single workflow environment pin. The final diff pass found two
+documentation inconsistencies: an overstated 5.x minimum in the manifest comment and a shell
+command labeled as TOML. Both are corrected. The change does not touch production Rust, network or
+replay formats, deterministic state, allocation-sensitive paths, or public runtime APIs.

--- a/scripts/tests/test_ci_rust_workflow.py
+++ b/scripts/tests/test_ci_rust_workflow.py
@@ -231,6 +231,14 @@ def test_semver_failure_summary_distinguishes_infra_from_api_breaks() -> None:
     assert "found a breaking public-API change" not in summary
 
 
+def test_semver_gate_allows_cold_lockfile_rebuild() -> None:
+    """Lockfile refreshes must have enough time to populate an empty cache."""
+    workflow = _load_ci_rust_workflow()
+    job = workflow["jobs"]["semver-checks"]
+
+    assert job["timeout-minutes"] == 40
+
+
 def test_public_api_census_uses_pinned_nightly_and_checked_snapshot() -> None:
     """Callable hidden paths must be rebuilt by the canonical nightly gate."""
     workflow = _load_ci_rust_workflow()

--- a/scripts/tests/test_ci_static_analysis.py
+++ b/scripts/tests/test_ci_static_analysis.py
@@ -21,6 +21,8 @@ WORKFLOW_DIRECTORY = REPO_ROOT / ".github" / "workflows"
 QUALITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-quality.yml"
 LINT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-lint.yml"
 CODEQL_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-codeql.yml"
+VERIFICATION_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-verification.yml"
+DEVCONTAINER_DOCKERFILE = REPO_ROOT / ".devcontainer" / "Dockerfile"
 DEPENDABOT_CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
 RUFF_CONFIG = REPO_ROOT / "ruff.toml"
 RUFF_ACTION = "astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89"
@@ -260,6 +262,33 @@ def test_static_workflow_paths_cover_all_relevant_sources() -> None:
         assert {"Cargo.toml", "tests/**", "fuzz/**", "loom-tests/**"}.issubset(
             quality[event]["paths"]
         )
+
+
+def test_z3_verification_uses_pinned_compatible_solver() -> None:
+    workflow = _load_workflow(VERIFICATION_WORKFLOW)
+    assert workflow["env"]["Z3_VERSION"] == "5.1.0"
+
+    steps = _steps(workflow, "z3-verification")
+    install = _step_by_name(steps, "Install pinned Z3 library")
+    install_command = install["run"]
+    assert '"z3-solver==${Z3_VERSION}.0"' in install_command
+    assert "apt-get install -y libz3-dev" not in install_command
+    assert "Z3_LIBRARY_PATH_OVERRIDE" in install_command
+    assert "LD_LIBRARY_PATH" in install_command
+    assert "Z3_SYS_Z3_VERSION" in install_command
+    assert 'z3.get_version_string() == os.environ["Z3_VERSION"]' in install_command
+    assert install.get("continue-on-error") is not True
+
+    verification = _step_by_name(
+        steps, "Run Z3 verification tests (nextest)"
+    )
+    assert "cargo nextest run --locked" in verification["run"]
+    assert verification.get("continue-on-error") is not True
+
+    dockerfile = DEVCONTAINER_DOCKERFILE.read_text(encoding="utf-8")
+    assert "z3-solver==5.1.0.0" in dockerfile
+    assert "/etc/ld.so.conf.d/z3-solver.conf" in dockerfile
+    assert "ldconfig" in dockerfile
 
 
 def test_codeql_covers_all_repository_languages_and_fails_on_findings() -> None:

--- a/wiki/Migration.md
+++ b/wiki/Migration.md
@@ -72,6 +72,20 @@ use fortress_rollback::rle::{decode, encode};
 The functions and their wire-compatible bytes are unchanged; only the duplicate
 callable paths were removed.
 
+The development-only `z3-verification` feature now uses the `z3` 0.21 bindings,
+which require Z3 4.13.3 or newer and target Z3 5.x enum definitions. Contributors
+who run the formal-verification suite should install Z3 5.1.0 or use the existing
+`z3-verification-bundled` feature. The bundled feature name is unchanged, but it
+now selects upstream's supported `vendored` build path:
+
+```shell
+# Before: older system Z3 installations could link against z3 0.20.
+cargo test --features z3-verification -- --nocapture
+
+# After: use a matching vendored solver when Z3 5.1.0 is unavailable.
+cargo test --features z3-verification-bundled -- --nocapture
+```
+
 ## Upgrading from 0.11
 
 The Macroquad-based `ex_game_p2p`, `ex_game_spectator`, and `ex_game_synctest` binaries are removed.

--- a/wiki/User-Guide.md
+++ b/wiki/User-Guide.md
@@ -2220,20 +2220,23 @@ verification surface compiles out of normal builds and is not intended for appli
 
 #### `z3-verification`
 
-Enables Z3 formal verification tests. Requires the Z3 SMT solver library to be installed on your system.
+Enables Z3 formal verification tests. The Rust bindings require Z3 4.13.3 or
+newer and use enum definitions compatible with Z3 5.x. Use Z3 5.1.0 when
+installing a system solver so the native library and Rust bindings agree.
 
 **System installation (recommended):**
 
 ```bash
-# Debian/Ubuntu
-sudo apt install libz3-dev
-
-# macOS
-brew install z3
+# Confirm that the installed solver is compatible.
+z3 --version
 
 # Then run verification tests
-cargo test --features z3-verification
+cargo test --features z3-verification -- --nocapture
 ```
+
+Distribution packages older than Z3 4.13.3 are unsupported. If the available
+system package is older than 5.x, use `z3-verification-bundled` to build the
+matching solver from source.
 
 **What it tests:**
 
@@ -2244,14 +2247,17 @@ cargo test --features z3-verification
 
 #### `z3-verification-bundled`
 
-Like `z3-verification`, but builds Z3 from source. This is useful for CI environments where system Z3 is not available.
+Like `z3-verification`, but builds the matching Z3 source instead of linking a
+system library. Use this option when the installed solver is missing, older
+than 4.13.3, or from a different enum-compatibility range.
 
-```toml
+```shell
 # In CI or when Z3 is not installed
 cargo test --features z3-verification-bundled
 ```
 
-**Warning:** Building Z3 from source takes 30+ minutes. Use `z3-verification` with system Z3 when possible.
+**Warning:** Building Z3 from source takes 30+ minutes. Prefer
+`z3-verification` with Z3 5.1.0 when a compatible system library is available.
 
 ### Feature Flag Combinations
 


### PR DESCRIPTION
## Summary

- update the optional `z3` dependency to 0.21.0 and migrate the bundled compatibility feature to upstream's `vendored` path
- pin Z3 5.1.0 for hosted verification and the devcontainer, including explicit build/runtime library selection
- add static regression coverage and document the solver compatibility floor, recommended version, and migration path

## Dependency audit

- all four Cargo workspaces select zero further compatible updates
- npm reports no outdated packages
- `bincode-next` 3.1.1 remains blocked by its Rust 1.90 requirement
- `serial_test` 4.0.1 remains blocked by its Rust 1.93.1 requirement

## Validation

- `cargo fmt --check`
- strict workspace/all-target Clippy with `tokio,json`
- feature-specific Nextest: 3,008 passed, 72 skipped
- `cargo c`
- `cargo t`: 2,975 passed, 72 skipped
- native Z3 5.1.0 verification: 65 passed, including 54 Z3 proofs
- vendored Z3 verification target compiles with `--locked`
- doc tests: 160 passed, 50 ignored
- rustdoc with warnings denied
- focused CI/devcontainer tests: 101 passed
- agent preflight: 286 + 66 checks passed
- Actionlint, wiki consistency, Markdown lint, link check, spell check, Cargo audit, and Cargo deny

## Risk

This only changes development-time formal verification and tooling. Production Rust, runtime public APIs, network/replay formats, deterministic state, and allocation-sensitive paths are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect optional formal-verification features, CI, and devcontainer tooling only—not production runtime APIs, networking, or replay formats.
> 
> **Overview**
> Upgrades the optional **`z3`** crate to **0.21** and documents a **breaking** change for the dev-only **`z3-verification`** feature: native Z3 must be **≥4.13.3**, with **5.1.0** recommended so Rust bindings match Z3 5.x enums. **`z3-verification-bundled`** now enables upstream’s **`vendored`** build instead of **`bundled`**.
> 
> **CI and devcontainer** stop using distro **`libz3-dev`** and instead install pinned **`z3-solver==5.1.0.0`**, assert the runtime version, export **`Z3_LIBRARY_PATH_OVERRIDE`**, **`LD_LIBRARY_PATH`**, and **`Z3_SYS_Z3_VERSION`**, and run Z3 Nextest with **`--locked`**. The devcontainer registers the wheel’s **`lib`** via **`ld.so.conf.d`** and **`ldconfig`**.
> 
> **Semver** job timeout increases from **20** to **40** minutes so a cold lockfile rebuild after the dependency bump can finish and save cache instead of cancelling. Static workflow tests lock in the Z3 pin and semver timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c86fc5afbae144d8542251cea2524472d02355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->